### PR TITLE
fix(topic): backfill empty illustration days

### DIFF
--- a/src/__tests__/download/handlers/IllustrationTargetHandler.test.ts
+++ b/src/__tests__/download/handlers/IllustrationTargetHandler.test.ts
@@ -207,6 +207,63 @@ describe('IllustrationTargetHandler', () => {
       );
     });
 
+    it('checks preceding days until a topic illustration is downloaded', async () => {
+      const selectWorks = jest.fn().mockResolvedValue({
+        works: [createMockIllust(1)],
+        selection: {
+          candidates: [], selected: [], resolvedTagCount: 1, rawCount: 1,
+          dedupedCount: 1, acceptedCount: 1, aiExcludedCount: 0,
+        },
+      });
+      mockPipeline.run
+        .mockResolvedValueOnce({ downloaded: 0, skipped: 0, alreadyDownloaded: 0, filteredOut: 0 })
+        .mockResolvedValueOnce({ downloaded: 1, skipped: 0, alreadyDownloaded: 0, filteredOut: 0 });
+      const outbox = { notifyNoMatch: jest.fn() } as any;
+      const topicHandler = new IllustrationTargetHandler(
+        mockClient, mockDatabase, mockRankingService, mockIllustrationDownloader,
+        mockPipeline, outbox, () => ({ selectWorks } as any)
+      );
+
+      await topicHandler.handle({
+        id: 'daily-image', type: 'illustration', mode: 'topic', topic: 'ボテ腹',
+        date: 'YESTERDAY', limit: 1, noMatchPolicy: { lookbackDays: 3, notify: true },
+      });
+
+      expect(selectWorks).toHaveBeenCalledTimes(2);
+      expect(selectWorks.mock.calls[0][2]).toBe('2023-06-14');
+      expect(selectWorks.mock.calls[1][2]).toBe('2023-06-13');
+      expect(outbox.notifyNoMatch).not.toHaveBeenCalled();
+    });
+
+    it('reports no_candidate after exhausting illustration lookback', async () => {
+      const selectWorks = jest.fn().mockResolvedValue({
+        works: [],
+        selection: {
+          candidates: [], selected: [], resolvedTagCount: 1, rawCount: 0,
+          dedupedCount: 0, acceptedCount: 0, aiExcludedCount: 0,
+        },
+      });
+      mockPipeline.run.mockResolvedValue({
+        downloaded: 0, skipped: 0, alreadyDownloaded: 0, filteredOut: 0,
+      });
+      const outbox = { notifyNoMatch: jest.fn().mockResolvedValue(undefined) } as any;
+      const topicHandler = new IllustrationTargetHandler(
+        mockClient, mockDatabase, mockRankingService, mockIllustrationDownloader,
+        mockPipeline, outbox, () => ({ selectWorks } as any)
+      );
+
+      await expect(topicHandler.handle({
+        id: 'daily-image', type: 'illustration', mode: 'topic', topic: 'ボテ腹',
+        date: 'YESTERDAY', limit: 1, storageMode: 'cache', delivery: { target: 'telepost' },
+        noMatchPolicy: { lookbackDays: 1, notify: true },
+      })).rejects.toThrow('No matching illustrations found after checking 2 day(s)');
+
+      expect(outbox.notifyNoMatch).toHaveBeenCalledTimes(1);
+      expect(mockDatabase.logExecution).toHaveBeenCalledWith(
+        'ボテ腹', 'illustration', 'success', expect.stringContaining('checking 2 day(s)')
+      );
+    });
+
     it('should handle errors and log them', async () => {
       const target: TargetConfig = {
         type: 'illustration',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -35,9 +35,9 @@ export interface CandidateCollectionConfig {
 /** Behaviour when a target cannot produce the requested number of works. */
 export interface NoMatchPolicyConfig {
   /**
-   * For topic novels with a language filter, inspect this many additional
-   * preceding publication days, one day at a time (default 0, max 7).
-   * Topic and language constraints are never relaxed implicitly.
+   * For topic targets, inspect this many additional preceding publication
+   * days, one day at a time (default 0, max 7). Topic, AI and language
+   * constraints are never relaxed implicitly.
    */
   lookbackDays?: number;
   /** Send a best-effort notice through the target's delivery endpoint. */
@@ -600,7 +600,6 @@ export interface StandaloneConfig {
     timeout?: number;
   };
 }
-
 
 
 

--- a/src/download/handlers/IllustrationTargetHandler.ts
+++ b/src/download/handlers/IllustrationTargetHandler.ts
@@ -40,6 +40,10 @@ export class IllustrationTargetHandler {
     logger.info(`Processing illustration ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag}`);
 
     try {
+      if (mode === 'topic') {
+        await this.handleTopicWithLookback(target, displayTag);
+        return;
+      }
       const illusts = await this.fetchIllustrations(target, mode);
       const result = await this.pipeline.run(
         illusts,
@@ -49,6 +53,9 @@ export class IllustrationTargetHandler {
       );
       this.handleDownloadResult(result, target, mode, illusts.length);
     } catch (error) {
+      if (error instanceof Error && error.message.startsWith('No matching illustrations found after checking')) {
+        throw error;
+      }
       await this.handleError(error, displayTag, mode, target);
     }
   }
@@ -66,11 +73,7 @@ export class IllustrationTargetHandler {
 
   private async fetchTopicIllustrations(target: TargetConfig): Promise<PixivIllust[]> {
     const topic = (target.topic ?? '').trim();
-    const day = target.date === 'TODAY'
-      ? getTodayDate()
-      : target.date && target.date !== 'YESTERDAY'
-        ? target.date
-        : getYesterdayDate();
+    const day = this.resolveTopicDay(target);
     const limit = target.limit || 1;
     // TopicPipeline ranks before DownloadPlanner removes works recorded in the
     // download database. Keep a small, bounded ranked pool so a second run for
@@ -93,6 +96,57 @@ export class IllustrationTargetHandler {
     );
     logger.info(`Topic "${topic}" illustration: tags=${selection.resolvedTagCount} raw=${selection.rawCount} deduped=${selection.dedupedCount} aiExcluded=${selection.aiExcludedCount} accepted=${selection.acceptedCount} candidates=${works.length} target=${limit}`);
     return works;
+  }
+
+  private async handleTopicWithLookback(target: TargetConfig, displayTag: string): Promise<void> {
+    const requested = target.limit || 1;
+    const additionalDays = Math.max(0, Math.min(target.noMatchPolicy?.lookbackDays ?? 0, 7));
+    const baseDay = this.resolveTopicDay(target);
+    const checkedDays: string[] = [];
+
+    for (let offset = 0; offset <= additionalDays; offset++) {
+      const day = this.shiftDay(baseDay, -offset);
+      const attemptTarget = offset === 0 ? target : { ...target, date: day };
+      checkedDays.push(day);
+      if (offset > 0) {
+        logger.warn(`No matching illustration found yet; checking fallback day ${day}`, {
+          topic: target.topic,
+          requestedDay: baseDay,
+          fallbackOffset: offset,
+        });
+      }
+      const illusts = await this.fetchTopicIllustrations(attemptTarget);
+      const result = await this.pipeline.run(
+        illusts,
+        attemptTarget,
+        'illustration',
+        (illust, tag) => this.downloadAndDeliver(illust, tag, attemptTarget)
+      );
+      if (result.downloaded > 0) {
+        this.handleDownloadResult(result, target, 'topic', illusts.length);
+        return;
+      }
+    }
+
+    const message = `No matching illustrations found after checking ${checkedDays.length} day(s): ${checkedDays.join(', ')}`;
+    this.database.logExecution(displayTag, 'illustration', 'success', message);
+    logger.warn(`Illustration topic ${displayTag} produced no matching result`, { checkedDays });
+    await this.notifyNoMatch(target, displayTag, checkedDays);
+    throw new Error(message);
+  }
+
+  private resolveTopicDay(target: TargetConfig): string {
+    return target.date === 'TODAY'
+      ? getTodayDate()
+      : target.date && target.date !== 'YESTERDAY'
+        ? target.date
+        : getYesterdayDate();
+  }
+
+  private shiftDay(day: string, offset: number): string {
+    const date = new Date(`${day}T00:00:00.000Z`);
+    date.setUTCDate(date.getUTCDate() + offset);
+    return date.toISOString().slice(0, 10);
   }
 
   private async fetchRankingIllustrations(target: TargetConfig): Promise<PixivIllust[]> {
@@ -288,6 +342,22 @@ export class IllustrationTargetHandler {
       await this.deliveryOutbox.notifyNoMatch(target, text, key);
     } catch (notifyError) {
       logger.warn('Failed to send download-failure notification', { label, errorMessage, notifyError });
+    }
+  }
+
+  private async notifyNoMatch(target: TargetConfig, label: string, checkedDays: string[]): Promise<void> {
+    if (target.noMatchPolicy?.notify !== true || !this.deliveryOutbox) return;
+    const text = [
+      '⚠️ PixivFlow 本次没有可投稿内容',
+      `目标：${target.id || label}（${label} · 插画）`,
+      `检查日期：${checkedDays.join('、')}`,
+      '处理结果：未创建空投稿；下次定时任务会继续正常执行。',
+    ].join('\n');
+    const key = `pixivflow:no-match:${target.id || label}:illustration:${checkedDays[0]}:${checkedDays.at(-1)}`;
+    try {
+      await this.deliveryOutbox.notifyNoMatch(target, text, key);
+    } catch (error) {
+      logger.warn('Failed to send no-match notification', { label, error });
     }
   }
 


### PR DESCRIPTION
## 根因
当天主题候选全部被 AI/元数据过滤时，插画目标直接返回 0，调度账本却将其记为 submitted/success。

## 修复
- 主题插画支持 `noMatchPolicy.lookbackDays`
- 找到可用作品后立即停止回看
- 全部日期为空时通知并让 Slot 记录为 no_candidate/partial

## 验证
- `npm run build`
- `npm test`：46 suites / 603 tests 全部通过