### PR TITLE
chore(release): drop stale release-infra comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ permissions:
 
 jobs:
   release:
-    # release-infra v1 includes the finalize Git-identity fix and npm secret
-    # interface; npm itself uses GitHub OIDC Trusted Publishing.
     uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1
     with:
       version: ${{ inputs.version || '' }}


### PR DESCRIPTION
## chore(release): drop stale release-infra comment

The caller already uses `redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1`; this removes the leftover comment naming the pre-rename `release-infra` repository. No workflow behavior change.
