### PR TITLE
feat(reliability): durable occurrence outbox/ledger, typed outcomes, global 429 gate, doctor/reconcile, occurrence-scoped idempotency key

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,15 @@ pixivflow scheduler             # 按 cron 配置长期挂机自动收集
 
 `headers` 和 `url` 里可用 `${环境变量名}` 引用环境变量（Token 别写死进配置）。
 
-投递是「发件箱」式的，进程重启也不丢：失败的文件和待投清单保存在数据库同级的
-`delivery-outbox/`，下次运行先补投，按「5 分钟起步、最长 6 小时」指数退避重试，
-成功后才清理。「今天没有可投稿内容」这类通知也走同一个 outbox，审核端暂时挂掉也能继续重试。
+投递是**事务发件箱（SQLite outbox）**式的，at-least-once 执行、effectively-once
+可见效果：每个外部副作用（一次内容投递、一条通知）在 `outbox` 表落一行，带幂等键和
+行级租约，独立 worker 立即泵送、指数退避重试（默认 5 分钟起步、最长 6 小时），超过
+`maxAttempts` 进 dead 状态并在投递账记 `failed`。进程崩溃 / 机器挂起后重启，残留的
+`processing` 租约过期即被新进程接管，重试同一个幂等意图——下游按
+`idempotent_replay`（同键，ACK 丢失重试）或 `duplicate_existing`（历史重复）收敛，
+频道里仍然只有一条消息。旧版文件型 `delivery-outbox/*.json` 清单在启动时自动一次性
+迁移进 SQLite，迁移幂等。「今天没有可投稿内容」这类通知与内容投递走同一张表、独立泵送，
+审核端暂时挂掉不会互相阻塞。
 
 运维通知可直接把 `notificationUrl` 指向 [Apprise API](docs/APPRISE.md)，由 Apprise 统一发送
 Email、Telegram、Discord、ntfy 等渠道；PixivFlow 不实现这些通知协议。
@@ -174,6 +180,8 @@ Email、Telegram、Discord、ntfy 等渠道；PixivFlow 不实现这些通知协
 | `pixivflow config` | 配置管理（查看 / 编辑 / 备份 / 恢复） |
 | `pixivflow status` | 下载统计与最近记录 |
 | `pixivflow health` | 健康检查：配置、目录可写性、连通性 |
+| `pixivflow doctor` | 可靠性体检：卡住的 slot/outbox 租约、pending 投递、dead 行；`--repair` 收敛 |
+| `pixivflow reconcile` | 把下游已确认的历史重复登记进投递账本（默认 dry-run，`--repair` 落库） |
 | `pixivflow tags discover <词>` | 发现相关 Tag（Pixiv 联想 + 作品标签共现），只列候选不改配置 |
 | `pixivflow tags apply <清单> --target <id> --select <tag1,tag2>` | 人工确认后把所选 Tag 原子写入配置并触发热重载 |
 | `pixivflow topic resolve <主题>` | 查看自动推导出的相关 Tag 空间（`--type illustration\|novel`、`--refresh`） |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,8 +170,10 @@ executeCommand():command.validate?(args) → command.execute(context, args)
 - **时区属于 schedule**：用 `schedule.timezone`（回退 `scheduler.timezone` / UTC）解析，从不用服务器本地时区。
 - **Target 成员冻结**：occurrence 首次创建时把当时的 `targetIds` 快照进 `schedule_slots.target_ids` 并物化 item（`UNIQUE(slot_id,target_id)`）。之后配置热重载增删 target **不影响**这次 occurrence，只影响未来 occurrence。
 - **作品锁（最关键不变量）**：target 首次选定作品后，先把 `work_id` 持久化（`lockWork`），再产生下载/投递等外部副作用；自动重试 / 进程重启 / outbox 重放都沿用同一作品。候选 fallback（重复→下一个、过滤→下一个、无效→下一个）**只发生在加锁之前**；加锁之后下载/投递失败继续该作品，不偷偷换候选。已锁作品若永久不可用（删除/禁止），普通重试判 `failed`，由显式 replacement（TelePost「重抓」）决定是否换。
-- **终态**：`submitted`（成功）、`no_candidate`（有界候选集里没有合法作品，正常业务终态，不无限重试）、`failed`（可重试失败）。slot 聚合状态由一处计算（全成功→`success`；成功+no_candidate/失败→`partial`；无一成功且不可恢复→`failed`）。
+- **Cell FSM**：`pending → selected → artifact_ready → delivery_pending → submitted`，另有终态 `no_candidate`（有界候选集里没有合法作品，正常业务终态）、`duplicate`（对账证实该作品已被**另一次意图**投递的历史漂移）、`failed`（仅不可重试失败）。可重试失败与 `delivery_pending` 都不是终态：重启/重复触发会沿同一 `work_id` 继续，永不下调已确认的 `submitted`。slot 聚合状态由一处计算（全成功→`success`；成功+no_candidate/duplicate/失败→`partial`；无一成功且不可恢复→`failed`）。
+- **投递账本 + Outbox**：`deliveries` 表回答“此作品是否已**确认**送达此 target”（去重域 = delivery_target + work_type + pixiv_id；只有 delivered/duplicate 算数，pending 不阻塞选择）；`outbox` 表是每种外部副作用（内容投递、通知）一行的事务性发件箱，worker 以租约认领、指数退避重试、超 maxAttempts 进 dead 状态并记 `deliveries.status=failed`。ACK 丢失后的重试由下游用 `idempotent_replay` 确认收敛为一条远端记录。
 - **Outbox 边界**：outbox 只保证“已产生的投递”最终送达，重放**永不**重新进入候选选择。
+- **运行租约**：重复 HTTP 触发对同一 slot 只会有一个 owner（`claimSlotLease` 比较-设置）；冲突触发观察/恢复而非并行执行，崩溃后租约过期才可被接管。
 - **Scheduled vs Ad-hoc**：`run-once` / 「重抓」是 ad-hoc 执行，跑下载计划但**不**打开 occurrence，绝不能把某次定时 occurrence 标记为完成或被 resume。
 
 **架构不变量（Architecture Invariants）**：
@@ -184,10 +186,11 @@ executeCommand():command.validate?(args) → command.execute(context, args)
 6. 自动重试不改变已锁定作品。
 7. 候选 fallback 只发生在作品加锁之前。
 8. outbox 重放永不重新进入候选选择。
-9. 成功的 item 永不自动重跑。
-10. external 模式永不做历史 catch-up。
-11. 手动 ad-hoc 执行 ≠ scheduled occurrence。
-12. Core 不依赖 TelePost / Fly / Cloudflare；`if (fly)…`、`morning/evening` 枚举、bot 编号都不属于 Core。
+9. 成功的 item 永不自动重跑；已确认的 `submitted` 永不被迟到结果降级。
+10. HTTP 状态码不是业务结果——只有解析后的 `DeliveryAck`（accepted/idempotent_replay/duplicate_existing/retryable/permanent）驱动账本。
+11. external 模式永不做历史 catch-up。
+12. 手动 ad-hoc 执行 ≠ scheduled occurrence。
+13. Core 不依赖 TelePost / Fly / Cloudflare；`if (fly)…`、`morning/evening` 枚举、bot 编号都不属于 Core。
 
 ## 存储层
 
@@ -204,7 +207,9 @@ executeCommand():command.validate?(args) → command.execute(context, args)
 | `config_history` | `name`、`config_json`、`is_active` | 配置快照,支持保存/应用/删除 |
 | `task_history` | `task_id` UNIQUE、`status`、`progress_*` | WebUI 下载任务状态持久化 |
 | `schedule_slots` | `id` PK（`<scheduleId>@<occurrenceStamp>`）、`schedule_id`、`occurrence_at`、`timezone`、`target_ids`（成员快照 JSON）、`status`、`trigger_source` | 一次 durable schedule occurrence |
-| `schedule_slot_items` | `slot_id`+`target_id` UNIQUE、`work_id`、`status`、`attempt_count`、`last_error` | occurrence 内每个 target 的执行/作品锁状态 |
+| `schedule_slot_items` | `slot_id`+`target_id` UNIQUE、`work_id`、`status`、`work_type`、`attempt_count`、`last_error` | occurrence 内每个 target 的执行/作品锁/FSM 状态 |
+| `deliveries` | `idempotency_key` UNIQUE、`delivery_target`+`work_type`+`pixiv_id`、`status`、`remote_id`、`reuse_reason` | 投递账本：确认送达事实，选择期/对账双重去重 |
+| `outbox` | `kind`、`idempotency_key` UNIQUE、`status`、`attempts`、`next_attempt_at`、`lease_owner/until` | 事务发件箱：内容投递与通知的崩溃安全重试 |
 
 常用索引覆盖 `downloads(pixiv_id, type)`、`downloads(tag)`、`downloads(downloaded_at)`、`execution_log(tag, type)`、`scheduler_executions(execution_number/status)`、`task_history(task_id/status/start_time)` 等。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6856,17 +6856,6 @@
         }
       }
     },
-    "node_modules/pixiv-token-getter/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/pixiv-token-getter/node_modules/ansi-regex": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
@@ -6938,55 +6927,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pixiv-token-getter/node_modules/data-uri-to-buffer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
-      "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/degenerator": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
-      "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
     "node_modules/pixiv-token-getter/node_modules/devtools-protocol": {
       "version": "0.0.1666840",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
@@ -6998,133 +6938,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
-    },
-    "node_modules/pixiv-token-getter/node_modules/get-uri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
-      "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "basic-ftp": "^5.3.1",
-        "data-uri-to-buffer": "8.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/http-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/https-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/pixiv-token-getter/node_modules/pac-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "get-uri": "8.0.1",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "pac-resolver": "9.0.1",
-        "quickjs-wasi": "^2.2.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/pac-resolver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
-      "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "degenerator": "7.0.1",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/proxy-agent": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
-      "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "9.1.0",
-        "proxy-from-env": "^2.0.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
     },
     "node_modules/pixiv-token-getter/node_modules/puppeteer": {
       "version": "25.9.0",
@@ -7162,22 +6975,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/pixiv-token-getter/node_modules/socks-proxy-agent": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
-      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/pixiv-token-getter/node_modules/string-width": {
@@ -7411,25 +7208,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent-negotiate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "kerberos": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "kerberos": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7596,14 +7374,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/quickjs-wasi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
-      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -8440,7 +8210,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/src/__tests__/commands/DoctorReconcile.test.ts
+++ b/src/__tests__/commands/DoctorReconcile.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Doctor + reconcile CLI tests: crash-recovery convergence actions and the
+ * manual historical-duplicate ledger path.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Database } from '../../storage/Database';
+import { DoctorCommand } from '../../commands/DoctorCommand';
+import { ReconcileCommand } from '../../commands/ReconcileCommand';
+import { logger } from '../../logger';
+
+function ctx(dbPath: string) {
+  return {
+    config: { storage: { databasePath: dbPath } } as any,
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+    configPath: '',
+  };
+}
+
+let consoleSpy: jest.SpyInstance;
+beforeEach(() => {
+  consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+afterEach(() => consoleSpy.mockRestore());
+
+describe('doctor command', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pf-doctor-'));
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('reports a stale processing outbox row read-only and releases it only with --repair', async () => {
+    const dbPath = join(dir, 't.db');
+    const db = new Database(dbPath);
+    db.migrate();
+    const row = db.outbox.enqueue({
+      kind: 'notification', deliveryTarget: 't', idempotencyKey: 'k1',
+      payload: { text: 'x' },
+    });
+    // A crashed worker left the row claimed with an expired lease.
+    db.outbox.claimDue('dead', 1, 5);
+    db.close();
+
+    const command = new DoctorCommand();
+    const dry = await command.execute(ctx(dbPath), { options: {}, positional: [] });
+    expect(dry.success).toBe(true);
+    const codes = (dry.data as any).findings.map((f: any) => f.code);
+    expect(codes).toContain('outbox-stale-processing');
+
+    const db2 = new Database(dbPath);
+    expect(db2.outbox.get(row.id)?.status).toBe('processing'); // untouched without --repair
+    db2.close();
+
+    const repaired = await command.execute(ctx(dbPath), { options: { repair: true }, positional: [] });
+    expect(repaired.success).toBe(true);
+    expect((repaired.data as any).repaired.some((x: string) => x.includes('stale processing'))).toBe(true);
+    const db3 = new Database(dbPath);
+    expect(db3.outbox.get(row.id)?.status).not.toBe('processing');
+    db3.close();
+  });
+
+  it('flags dead outbox rows as critical', async () => {
+    const dbPath = join(dir, 't2.db');
+    const db = new Database(dbPath);
+    db.migrate();
+    const row = db.outbox.enqueue({
+      kind: 'notification', deliveryTarget: 't', idempotencyKey: 'kdead',
+      payload: { text: 'x' }, maxAttempts: 1,
+    });
+    db.outbox.markRetry(row.id, Date.now() - 1, 'boom');
+    // markRetry with attempts exhausted marks dead
+    db.close();
+
+    const res = await new DoctorCommand().execute(ctx(dbPath), { options: {}, positional: [] });
+    const crit = (res.data as any).findings.filter((f: any) => f.level === 'critical');
+    expect(crit.map((f: any) => f.code)).toContain('outbox-dead');
+  });
+});
+
+describe('reconcile command', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pf-reconcile-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('dry-run changes nothing; --repair records the historical duplicate and is idempotent', async () => {
+    const dbPath = join(dir, 't.db');
+    const db = new Database(dbPath);
+    db.migrate();
+    expect(db.deliveries.isDelivered('bot1', 'illustration', '777')).toBe(false);
+    db.close();
+
+    const command = new ReconcileCommand();
+    const args = { options: { target: 'bot1', type: 'illustration', 'pixiv-id': '777', 'remote-id': '42' }, positional: [] };
+
+    const dry = await command.execute(ctx(dbPath), args);
+    expect(dry.success).toBe(true);
+    expect((dry.data as any).dryRun).toBe(true);
+    const db1 = new Database(dbPath);
+    expect(db1.deliveries.isDelivered('bot1', 'illustration', '777')).toBe(false);
+    db1.close();
+
+    const applied = await command.execute(ctx(dbPath), {
+      options: { ...args.options, repair: true }, positional: [],
+    });
+    expect(applied.success).toBe(true);
+    const db2 = new Database(dbPath);
+    expect(db2.deliveries.isDelivered('bot1', 'illustration', '777')).toBe(true);
+    db2.close();
+
+    // Second repair is a noop (already reconciled).
+    const again = await command.execute(ctx(dbPath), {
+      options: { ...args.options, repair: true }, positional: [],
+    });
+    expect((again.data as any).noop).toBe(true);
+  });
+
+  it('rejects invalid work type and missing required options', async () => {
+    const dbPath = join(dir, 't2.db');
+    const command = new ReconcileCommand();
+    const badType = await command.execute(ctx(dbPath), {
+      options: { target: 'bot1', type: 'video', 'pixiv-id': '1' }, positional: [],
+    });
+    expect(badType.success).toBe(false);
+    const missing = await command.execute(ctx(dbPath), { options: { target: 'bot1' }, positional: [] });
+    expect(missing.success).toBe(false);
+  });
+});

--- a/src/__tests__/commands/SchedulerRunOnceCommand.test.ts
+++ b/src/__tests__/commands/SchedulerRunOnceCommand.test.ts
@@ -39,6 +39,8 @@ describe('SchedulerRunOnceCommand', () => {
       runJob,
       close,
       cancelActive: jest.fn(),
+      startOutboxWorker: jest.fn(),
+      drainOutbox: jest.fn().mockResolvedValue({ processed: 0, done: 0, retried: 0, dead: 0 }),
     } as any);
     command = new SchedulerRunOnceCommand();
   });

--- a/src/__tests__/commands/scheduler-runtime.test.ts
+++ b/src/__tests__/commands/scheduler-runtime.test.ts
@@ -7,6 +7,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { notifyScheduleFailure, runWithTimeout } from '../../commands/scheduler-runtime';
+import { Database } from '../../storage/Database';
+import { DeliveryDispatcher } from '../../delivery/DeliveryDispatcher';
+import { OutboxWorker } from '../../delivery/OutboxWorker';
 
 describe('runWithTimeout watchdog', () => {
   it('resolves when the task finishes before the deadline', async () => {
@@ -44,6 +47,8 @@ describe('runWithTimeout watchdog', () => {
 
 it('notifies only the delivery targets assigned to the failed schedule', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'pixivflow-scheduler-notify-'));
+  const db = new Database(join(directory, 'pixivflow.db'));
+  db.migrate();
   const originalFetch = global.fetch;
   const fetchMock = jest.fn().mockResolvedValue(
     new Response(JSON.stringify({ ok: true }), { status: 201 })
@@ -67,7 +72,7 @@ it('notifies only the delivery targets assigned to the failed schedule', async (
 
     await notifyScheduleFailure(
       config,
-      join(directory, 'pixivflow.db'),
+      db,
       { id: 'morning', name: 'Morning', enabled: true, cron: '0 10 * * *', targetIds: ['t1'] },
       {
         scheduleId: 'morning',
@@ -79,6 +84,11 @@ it('notifies only the delivery targets assigned to the failed schedule', async (
       }
     );
 
+    // Notifications are durable outbox rows; pump them once to observe the POST.
+    const worker = new OutboxWorker(db, new DeliveryDispatcher(config.delivery));
+    const res = await worker.drainOnce();
+    expect(res.done).toBe(1);
+
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe('https://example.test/bot1/notify');
     expect(JSON.parse(String(fetchMock.mock.calls[0][1].body))).toEqual(expect.objectContaining({
@@ -87,6 +97,7 @@ it('notifies only the delivery targets assigned to the failed schedule', async (
     }));
   } finally {
     global.fetch = originalFetch;
+    db.close();
     await rm(directory, { recursive: true, force: true });
   }
 });

--- a/src/__tests__/delivery/LegacyOutboxMigration.test.ts
+++ b/src/__tests__/delivery/LegacyOutboxMigration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Legacy file-based outbox -> SQLite outbox migration (idempotent, crash-safe).
+ */
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "../../storage/Database";
+import { migrateLegacyOutbox, legacyOutboxDir } from "../../delivery/LegacyOutboxMigration";
+
+describe("migrateLegacyOutbox", () => {
+  let dir: string;
+  let db: Database;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "pf-legacy-"));
+    db = new Database(join(dir, "pixivflow.db"));
+    db.migrate();
+  });
+  afterEach(async () => {
+    db.close();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("imports a pending delivery manifest as a due outbox row", async () => {
+    const outDir = legacyOutboxDir(db.getDatabasePath());
+    await mkdir(outDir, { recursive: true });
+    await writeFile(join(outDir, "m1.json"), JSON.stringify({
+      version: 1, id: "abc", kind: "delivery", status: "pending", deliveryTarget: "bot1",
+      artifact: { pixivId: "123", type: "illustration", files: ["/tmp/a.jpg"], title: "T", tags: ["x"] },
+      request: { fields: { caption: "hi" } },
+    }));
+
+    const res1 = migrateLegacyOutbox(db);
+    expect(res1.imported).toBe(1);
+
+    const counts = db.outbox.counts();
+    expect(counts.pending + counts.processing + counts.retryWait).toBe(1);
+    // manifest archived after commit
+    const due = db.outbox.claimDue("test", 60_000, 10);
+    expect(due).toHaveLength(1);
+    expect(due[0].kind).toBe("delivery");
+
+    // Idempotent: archived manifests are not re-imported.
+    const res2 = migrateLegacyOutbox(db);
+    expect(res2.scanned).toBe(0);
+    expect(res2.imported).toBe(0);
+  });
+
+  it("backfills already-delivered manifests into the delivery ledger", async () => {
+    const outDir = legacyOutboxDir(db.getDatabasePath());
+    await mkdir(outDir, { recursive: true });
+    await writeFile(join(outDir, "d1.json"), JSON.stringify({
+      version: 1, id: "done", kind: "delivery", status: "delivered", deliveryTarget: "bot2",
+      artifact: { pixivId: "999", type: "novel", files: ["/x.txt"] },
+    }));
+
+    const res = migrateLegacyOutbox(db);
+    expect(res.delivered).toBe(1);
+    expect(db.deliveries.isDelivered("bot2", "novel", "999")).toBe(true);
+  });
+});

--- a/src/__tests__/delivery/OutboxFailureInjection.test.ts
+++ b/src/__tests__/delivery/OutboxFailureInjection.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Failure-injection tests for the delivery outbox + slot FSM.
+ *
+ * These exercise the "exactly one remote side effect" guarantee under the
+ * failures that actually occur on a 512 MiB auto-suspend machine:
+ *  - ACK loss (timeout AFTER the provider created the record)
+ *  - duplicate triggers / retries carrying the same idempotency key
+ *  - a crash mid-delivery (a stale 'processing' lease left on disk)
+ *  - permanent provider rejection -> bounded retries -> dead letter
+ *  - notification side effects failing independently of content delivery
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Database } from '../../storage/Database';
+import { OutboxWorker } from '../../delivery/OutboxWorker';
+import { DeliveryAck } from '../../delivery/DeliveryAck';
+
+function withDb<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-outbox-fi-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  return fn(db).finally(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+}
+
+/** Programmable delivery provider: each call pops the next scripted result. */
+class FakeDispatcher {
+  deliverCalls = 0;
+  notifyCalls = 0;
+  deliveredKeys: string[] = [];
+  constructor(
+    private deliverScript: Array<() => Promise<{ ack: DeliveryAck }>> = [],
+    private notifyScript: Array<() => Promise<void>> = [],
+  ) {}
+  async deliver(_name: string, request: { context: Record<string, unknown> }): Promise<{ ack: DeliveryAck }> {
+    this.deliverCalls++;
+    const step = this.deliverScript.shift();
+    if (!step) throw new Error('unexpected deliver call');
+    const result = await step();
+    if (result.ack.kind === 'accepted' || result.ack.kind === 'idempotent_replay') {
+      // Simulate the PROVIDER deduping on our key: it creates the record once.
+      const key = String(request.context?.idempotencyKey ?? '');
+      if (!this.deliveredKeys.includes(key)) this.deliveredKeys.push(key);
+    }
+    return result;
+  }
+  async notify(): Promise<void> {
+    this.notifyCalls++;
+    const step = this.notifyScript.shift();
+    if (!step) throw new Error('unexpected notify call');
+    await step();
+  }
+}
+
+const ctx = { idempotencyKey: 'k-1' } as any;
+
+describe('OutboxWorker failure injection', () => {
+  it('ACK loss converges to one remote record via idempotent_replay', async () => {
+    await withDb(async (db) => {
+      const dispatcher = new FakeDispatcher([
+        // Attempt 1: request reached the provider and it posted, but the ACK was
+        // lost (timeout). No local confirmation yet.
+        async () => {
+          throw new Error('network timeout awaiting ack');
+        },
+        // Attempt 2: provider recognises our key and replays the SAME record.
+        async () => ({ ack: { kind: 'idempotent_replay', remoteId: 'm-42' } as DeliveryAck }),
+      ]);
+      const worker = new OutboxWorker(db, dispatcher as any, {
+        retryBaseMs: 0, // no real waiting in tests
+      });
+      const { row: delivery } = db.deliveries.insertIntent({
+        id: 'd-1', deliveryTarget: 'bot1', workType: 'illustration',
+        pixivId: '100', idempotencyKey: 'k-1',
+      });
+      db.outbox.enqueue({
+        kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-1',
+        deliveryId: delivery.id,
+        payload: { files: [], context: ctx },
+        maxAttempts: 5,
+      });
+
+      const first = await worker.drainOnce();
+      // Attempt 1 is retryable; backoff is 0 but next_attempt is still in the
+      // future-free window because retryBaseMs=0 -> due immediately next round.
+      const second = await worker.drainOnce();
+
+      expect(dispatcher.deliveredKeys).toEqual(['k-1']); // exactly one remote record
+      const ledger = db.deliveries.getById('d-1')!;
+      expect(ledger.status).toBe('delivered');
+      expect(ledger.remoteId).toBe('m-42');
+      const row = db.outbox.getByKey('delivery', 'k-1')!;
+      expect(row.status).toBe('done');
+      expect(first.processed + second.processed).toBe(2);
+    });
+  });
+
+  it('duplicate triggers with the same key enqueue and deliver exactly once', async () => {
+    await withDb(async (db) => {
+      const dispatcher = new FakeDispatcher([
+        async () => ({ ack: { kind: 'accepted', remoteId: 'm-7' } as DeliveryAck }),
+      ]);
+      const worker = new OutboxWorker(db, dispatcher as any);
+      const { row: delivery } = db.deliveries.insertIntent({
+        id: 'd-2', deliveryTarget: 'bot1', workType: 'illustration',
+        pixivId: '101', idempotencyKey: 'k-dup',
+      });
+      for (let i = 0; i < 3; i++) {
+        db.outbox.enqueue({
+          kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-dup',
+          deliveryId: delivery.id, payload: { files: [], context: { idempotencyKey: 'k-dup' } },
+        });
+      }
+      const res = await worker.drainOnce();
+      expect(res.done).toBe(1);
+      expect(dispatcher.deliverCalls).toBe(1);
+    });
+  });
+
+  it('a stale processing lease left by a crashed worker is resumed with the same intent', async () => {
+    await withDb(async (db) => {
+      const dispatcher = new FakeDispatcher([
+        async () => ({ ack: { kind: 'accepted', remoteId: 'm-9' } as DeliveryAck }),
+      ]);
+      const worker = new OutboxWorker(db, dispatcher as any);
+      const { row: delivery } = db.deliveries.insertIntent({
+        id: 'd-3', deliveryTarget: 'bot1', workType: 'illustration',
+        pixivId: '102', idempotencyKey: 'k-crash',
+      });
+      const row = db.outbox.enqueue({
+        kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-crash',
+        deliveryId: delivery.id, payload: { files: [], context: { idempotencyKey: 'k-crash' } },
+      });
+      // Simulate a process killed between claim and markDone.
+      db.outbox.claimDue('dead-worker-pid', 1, 10);
+      expect(db.outbox.get(row.id)!.status).toBe('processing');
+
+      // Nothing due while the lease is live.
+      expect(await worker.drainOnce()).toMatchObject({ processed: 0 });
+
+      // After lease expiry the restarted worker claims the SAME row.
+      await new Promise((r) => setTimeout(r, 5));
+      const res = await worker.drainOnce();
+      expect(res.done).toBe(1);
+      expect(dispatcher.deliverCalls).toBe(1);
+      expect(db.outbox.get(row.id)!.status).toBe('done');
+    });
+  });
+
+  it('permanent rejection retries up to maxAttempts then dead-letters and records failure', async () => {
+    await withDb(async (db) => {
+      const dispatcher = new FakeDispatcher(
+        Array.from({ length: 3 }, () => async () => ({
+          ack: { kind: 'permanent_failure', error: '400 bad payload' } as DeliveryAck,
+        })),
+      );
+      const dead: string[] = [];
+      const worker = new OutboxWorker(db, dispatcher as any, {
+        retryBaseMs: 0, onDead: (r, err) => dead.push(r.id + ':' + err),
+      });
+      const { row: delivery } = db.deliveries.insertIntent({
+        id: 'd-4', deliveryTarget: 'bot1', workType: 'illustration',
+        pixivId: '103', idempotencyKey: 'k-dead',
+      });
+      db.outbox.enqueue({
+        kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-dead',
+        deliveryId: delivery.id, payload: { files: [], context: { idempotencyKey: 'k-dead' } },
+        maxAttempts: 3,
+      });
+      // Each drain round processes the row once; retryBaseMs=0 keeps it due.
+      let deadCount = 0;
+      for (let i = 0; i < 3 && deadCount === 0; i++) {
+        deadCount = (await worker.drainOnce()).dead;
+      }
+      expect(deadCount).toBe(1);
+      expect(db.outbox.getByKey('delivery', 'k-dead')!.status).toBe('dead');
+      expect(db.deliveries.getById('d-4')!.status).toBe('failed');
+      expect(dead).toHaveLength(1);
+    });
+  });
+
+  it('notifications are pumped independently: a failing content delivery does not block them', async () => {
+    await withDb(async (db) => {
+      const dispatcher = new FakeDispatcher(
+        [async () => { throw new Error('delivery down'); }],
+        [async () => { /* notification succeeds */ }],
+      );
+      const worker = new OutboxWorker(db, dispatcher as any, {
+        retryBaseMs: 0, batchSize: 8,
+      });
+      db.outbox.enqueue({
+        kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-content',
+        payload: { files: [], context: { idempotencyKey: 'k-content' } },
+        maxAttempts: 1,
+      });
+      db.outbox.enqueue({
+        kind: 'notification', deliveryTarget: 'bot1', idempotencyKey: 'k-note',
+        payload: { text: 'queued for review' },
+      });
+      // Drain until the notification is done (delivery dead-letters after 1 try).
+      let noteDone = false;
+      for (let i = 0; i < 5 && !noteDone; i++) {
+        await worker.drainOnce();
+        noteDone = db.outbox.getByKey('notification', 'k-note')?.status === 'done';
+      }
+      expect(noteDone).toBe(true);
+      expect(dispatcher.notifyCalls).toBe(1);
+      expect(db.outbox.getByKey('delivery', 'k-content')!.status).toBe('dead');
+    });
+  });
+
+  it('duplicate_existing marks the ledger duplicate without deleting cached files', async () => {
+    await withDb(async (db) => {
+      const dir = mkdtempSync(join(tmpdir(), 'pf-cache-'));
+      const file = join(dir, 'f.jpg');
+      writeFileSync(file, 'x');
+      const dispatcher = new FakeDispatcher([
+        async () => ({
+          ack: { kind: 'duplicate_existing', remoteId: 'm-1', matchedKey: 'older-key' } as DeliveryAck,
+        }),
+      ]);
+      const terminal: string[] = [];
+      const worker = new OutboxWorker(db, dispatcher as any, {
+        onDeliveryTerminal: (_id, ack) => terminal.push(ack.kind),
+      });
+      const { row: delivery } = db.deliveries.insertIntent({
+        id: 'd-5', deliveryTarget: 'bot1', workType: 'illustration',
+        pixivId: '104', idempotencyKey: 'k-hist',
+      });
+      db.outbox.enqueue({
+        kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-hist',
+        deliveryId: delivery.id,
+        payload: { files: [file], cleanupFiles: [], context: { idempotencyKey: 'k-hist' } },
+      });
+      await worker.drainOnce();
+      expect(db.deliveries.getById('d-5')!.status).toBe('duplicate');
+      expect(terminal).toEqual(['duplicate_existing']);
+      // Historical duplicate created no new post; the cache file is retained
+      // (nothing confirmed delivered by THIS intent).
+      const { existsSync } = await import('node:fs');
+      expect(existsSync(file)).toBe(true);
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+});

--- a/src/__tests__/delivery/e2e-idempotency-contract.test.ts
+++ b/src/__tests__/delivery/e2e-idempotency-contract.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { HttpMultipartDelivery } from '../../delivery/HttpMultipartDelivery';
+
+function parseFields(buffer: Buffer): Record<string, string> {
+  const text = buffer.toString('latin1');
+  const fields: Record<string, string> = {};
+  // Only field parts (no filename=); body up to the next boundary marker.
+  const re = /name="(?!\S+"; filename=")([^"]+)"\r\n\r\n([\s\S]*?)\r\n--/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    fields[m[1]] = Buffer.from(m[2], 'latin1').toString('utf8');
+  }
+  return fields;
+}
+
+describe('E2E idempotency contract over real HTTP', () => {
+  it('ACK loss retry carries the SAME key; server creates one record and answers idempotent_replay', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'e2e-'));
+    const file = join(dir, 'a.jpg');
+    writeFileSync(file, 'img');
+    const seenKeys: string[] = [];
+    const posts = new Map<string, number>();
+    let serverError: unknown = null;
+
+    const server: Server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        try {
+          const fields = parseFields(Buffer.concat(chunks));
+          const key = fields.idempotency_key;
+          expect(key).toBeTruthy();
+          seenKeys.push(key);
+          let payload: unknown;
+          const existing = posts.get(key);
+          if (existing) {
+            payload = {
+              ok: true,
+              data: {
+                status: 'published', reused: true,
+                reuse_reason: 'idempotent_replay',
+                matched_idempotency_key: key, message_id: existing,
+              },
+            };
+          } else {
+            posts.set(key, 555);
+            payload = { ok: true, data: { status: 'published', reused: false, message_id: 555 } };
+          }
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify(payload));
+        } catch (e) {
+          serverError = e;
+          if (!res.headersSent) res.writeHead(500);
+          res.end('err');
+        }
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const provider = new HttpMultipartDelivery({
+        type: 'httpMultipart',
+        url: `http://127.0.0.1:${port}/submissions`,
+        fileField: 'files',
+        fields: { tags: 'Pixiv', idempotency_key: '{{idempotencyKey}}' },
+      });
+      const ctx = {
+        title: 'W', pixivId: '999', type: 'illustration' as const,
+        idempotencyKey: 'pixivflow:t:illustration:999:slot1:ta',
+      };
+      const r1 = await provider.deliver({ files: [file], context: ctx });
+      // ACK lost: the caller retries the SAME intent with the SAME key.
+      const r2 = await provider.deliver({ files: [file], context: ctx });
+
+      expect(seenKeys).toEqual([ctx.idempotencyKey, ctx.idempotencyKey]);
+      expect(r1.ack?.kind).toBe('accepted');
+      expect(r2.ack?.kind).toBe('idempotent_replay');
+      expect(posts.size).toBe(1);
+      expect(serverError).toBeNull();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20000);
+});

--- a/src/__tests__/delivery/http-multipart.test.ts
+++ b/src/__tests__/delivery/http-multipart.test.ts
@@ -67,14 +67,15 @@ describe('HttpMultipartDelivery', () => {
       },
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       status: 201,
+      ack: { kind: 'idempotent_replay', remoteId: '42', remoteStatus: 'pending_review' },
       body: {
         ok: true,
         data: { id: 1, status: 'pending_review', review_id: 42, reused: true },
       },
     });
-    expect(log).toHaveBeenCalledWith('HTTP multipart delivery succeeded', expect.objectContaining({
+    expect(log).toHaveBeenCalledWith('HTTP multipart delivery response', expect.objectContaining({
       deliveryStatus: 'pending_review',
       reviewId: 42,
       reused: true,
@@ -109,7 +110,7 @@ describe('HttpMultipartDelivery', () => {
       maxAttempts: 1,
     });
 
-    await provider.notify({ text: 'no matching work', idempotencyKey: 'empty:2023-06-14' });
+    await provider.notifyOnce({ text: 'no matching work', idempotencyKey: 'empty:2023-06-14' });
 
     const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://example.test/notifications');
@@ -124,23 +125,19 @@ describe('HttpMultipartDelivery', () => {
   });
 
   it('does not log notification URL credentials or query secrets', async () => {
-    const fetchMock = jest.fn()
-      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
-      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    // One attempt (retries live in the durable outbox, not the HTTP adapter).
+    const fetchMock = jest.fn().mockResolvedValue(new Response('ok', { status: 200 }));
     global.fetch = fetchMock as typeof fetch;
-    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
     const info = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
     const provider = new HttpMultipartDelivery({
       type: 'httpMultipart',
       url: 'https://example.test/submissions',
       notificationUrl: 'https://notify:webhook-secret@example.test/notify/key?:text=body&token=query-secret',
-      maxAttempts: 2,
-      retryDelayMs: 0,
     });
 
-    await provider.notify({ text: 'no matching work', idempotencyKey: 'empty:2023-06-14' });
+    await provider.notifyOnce({ text: 'no matching work', idempotencyKey: 'empty:2023-06-14' });
 
-    const loggedUrls = [...warn.mock.calls, ...info.mock.calls]
+    const loggedUrls = info.mock.calls
       .flatMap((call) => call.slice(1))
       .map((entry) => (entry as { url?: string }).url)
       .filter((url): url is string => Boolean(url));
@@ -324,8 +321,9 @@ describe('HttpMultipartDelivery', () => {
         files: [filePath],
         context: { title: 'Work', pixivId: '1', type: 'novel' },
       })
-    ).resolves.toMatchObject({ status: 204 });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    ).resolves.toMatchObject({ status: 503, ack: { kind: 'retryable_failure' } });
+    // Exactly one HTTP attempt; the durable outbox owns the retry budget.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/__tests__/delivery/http-multipart.test.ts
+++ b/src/__tests__/delivery/http-multipart.test.ts
@@ -579,4 +579,43 @@ describe('DeliveryOutbox', () => {
     expect(dispatcher.deliver).not.toHaveBeenCalled();
     await expect(fs.access(filePath)).resolves.toBeUndefined();
   });
+  it('sends the occurrence-scoped idempotency_key field so ACK-loss retries converge as idempotent_replay', async () => {
+    const filePath = join(directory, 'cover.jpg');
+    await fs.writeFile(filePath, 'image');
+
+    const fetchMock = jest.fn().mockImplementation(async (_url: string, init: any) => {
+      // Body is a streaming hand-built multipart Readable; drain and inspect raw.
+      const chunks: Buffer[] = [];
+      for await (const chunk of init.body as AsyncIterable<Buffer>) chunks.push(Buffer.from(chunk));
+      const raw = Buffer.concat(chunks).toString('utf8');
+      expect(raw).toContain('name="idempotency_key"');
+      expect(raw).toContain(
+        'pixivflow:bot1:illustration:999:sched-a@202609081000:t-a'
+      );
+      return new Response(JSON.stringify({
+        ok: true,
+        data: { status: 'published', reused: false, message_id: 7 },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = new HttpMultipartDelivery({
+      type: 'httpMultipart',
+      url: 'https://example.test/submissions',
+      fileField: 'files',
+      fields: { tags: 'Pixiv', idempotency_key: '{{idempotencyKey}}' },
+      success: { statuses: [200, 201], jsonPath: 'ok', equals: true },
+    });
+
+    const result = await provider.deliver({
+      files: [filePath],
+      context: {
+        title: 'W', pixivId: '999', type: 'illustration',
+        idempotencyKey: 'pixivflow:bot1:illustration:999:sched-a@202609081000:t-a',
+      } as any,
+    });
+    expect(result.ack?.kind).toBe('accepted');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/src/__tests__/download/handlers/IllustrationTargetHandler.test.ts
+++ b/src/__tests__/download/handlers/IllustrationTargetHandler.test.ts
@@ -256,9 +256,9 @@ describe('IllustrationTargetHandler', () => {
         id: 'daily-image', type: 'illustration', mode: 'topic', topic: 'ボテ腹',
         date: 'YESTERDAY', limit: 1, storageMode: 'cache', delivery: { target: 'telepost' },
         noMatchPolicy: { lookbackDays: 1, notify: true },
-      })).rejects.toThrow('No matching illustrations found after checking 2 day(s)');
+      })).resolves.toMatchObject({ kind: 'no_candidate' });
 
-      expect(outbox.notifyNoMatch).toHaveBeenCalledTimes(1);
+      // Notifications are now centralized (NotificationPolicy), not sent per-handler.
       expect(mockDatabase.logExecution).toHaveBeenCalledWith(
         'ボテ腹', 'illustration', 'success', expect.stringContaining('checking 2 day(s)')
       );
@@ -273,7 +273,7 @@ describe('IllustrationTargetHandler', () => {
       const error = new Error('Test error');
       mockClient.searchIllustrations.mockRejectedValue(error);
 
-      await expect(handler.handle(target)).rejects.toThrow('Test error');
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: false, error: 'Test error' });
 
       expect(mockDatabase.logExecution).toHaveBeenCalledWith(
         'test-tag',
@@ -293,7 +293,7 @@ describe('IllustrationTargetHandler', () => {
       const error = new NetworkError('Rate limited', 'https://api.pixiv.net', cause);
       mockClient.searchIllustrations.mockRejectedValue(error);
 
-      await expect(handler.handle(target)).rejects.toThrow();
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: true });
 
       expect(mockDatabase.logExecution).toHaveBeenCalledWith(
         'test-tag',
@@ -675,7 +675,7 @@ describe('IllustrationTargetHandler', () => {
       );
     });
 
-    it('should throw error when zero downloads and items were skipped', async () => {
+    it('returns a retryable failed outcome when zero downloads and items were skipped', async () => {
       const target: TargetConfig = {
         type: 'illustration',
         tag: 'test-tag',
@@ -691,7 +691,7 @@ describe('IllustrationTargetHandler', () => {
         filteredOut: 0,
       });
 
-      await expect(handler.handle(target)).rejects.toThrow();
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: true });
     });
 
     it('should warn when downloaded count is less than 50% of limit', async () => {

--- a/src/__tests__/download/handlers/NovelTargetHandler.test.ts
+++ b/src/__tests__/download/handlers/NovelTargetHandler.test.ts
@@ -159,7 +159,7 @@ describe('NovelTargetHandler', () => {
       const error = new Error('Test error');
       mockClient.searchNovels.mockRejectedValue(error);
 
-      await expect(handler.handle(target)).rejects.toThrow('Test error');
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: false, error: 'Test error' });
 
       expect(mockDatabase.logExecution).toHaveBeenCalledWith(
         'test-tag',
@@ -179,7 +179,7 @@ describe('NovelTargetHandler', () => {
       const error = new NetworkError('Rate limited', 'https://api.pixiv.net', cause);
       mockClient.searchNovels.mockRejectedValue(error);
 
-      await expect(handler.handle(target)).rejects.toThrow();
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed' });
 
       expect(mockDatabase.logExecution).toHaveBeenCalledWith(
         'test-tag',
@@ -284,9 +284,10 @@ describe('NovelTargetHandler', () => {
         novelId: NaN as any,
       };
 
-      // The handler checks Number.isFinite(novelId) in handleSingleNovel
-      // NaN is not finite, so it should throw
-      await expect(handler.handle(target)).rejects.toThrow();
+      // Invalid id is a permanent failure outcome (not a throw).
+      await expect(handler.handle(target)).resolves.toMatchObject({
+        kind: 'failed', retryable: false, error: expect.stringContaining('Invalid novelId'),
+      });
     });
 
     it('should handle errors during single novel download', async () => {
@@ -390,9 +391,10 @@ describe('NovelTargetHandler', () => {
         seriesId: NaN as any,
       };
 
-      // The handler checks Number.isFinite(seriesId) in handleSeries
-      // NaN is not finite, so it should throw
-      await expect(handler.handle(target)).rejects.toThrow();
+      // Invalid series id is a permanent failure outcome (not a throw).
+      await expect(handler.handle(target)).resolves.toMatchObject({
+        kind: 'failed', retryable: false, error: expect.stringContaining('Invalid seriesId'),
+      });
     });
 
     it('should handle errors when fetching series', async () => {
@@ -702,7 +704,7 @@ describe('NovelTargetHandler', () => {
       );
     });
 
-    it('should throw error when zero downloads and items were skipped', async () => {
+    it('returns retryable failed outcome when zero downloads and items were skipped', async () => {
       const target: TargetConfig = {
         type: 'novel',
         tag: 'test-tag',
@@ -718,7 +720,7 @@ describe('NovelTargetHandler', () => {
         filteredOut: 0,
       });
 
-      await expect(handler.handle(target)).rejects.toThrow();
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: true });
     });
 
     it('should warn when downloaded count is less than 50% of limit', async () => {
@@ -820,16 +822,15 @@ describe('NovelTargetHandler', () => {
         { downloaded: 0, skipped: 1, alreadyDownloaded: 0, filteredOut: 0 },
         { downloaded: 0, skipped: 1, alreadyDownloaded: 0, filteredOut: 0 },
       ]);
-      await topicHandler.handle({
+      const outcome = await topicHandler.handle({
         id: 'daily-cn', type: 'novel', mode: 'topic', topic: 'ボテ腹',
         date: 'YESTERDAY', limit: 1, languageFilter: 'chinese',
         noMatchPolicy: { lookbackDays: 1, notify: true },
         storageMode: 'cache', delivery: { target: 'telepost' },
       });
-
-      expect(outbox.notifyNoMatch).toHaveBeenCalledTimes(1);
-      expect(outbox.notifyNoMatch.mock.calls[0][1]).toContain('没有可投稿内容');
-      expect(mockDatabase.logExecution).toHaveBeenCalledTimes(1);
+      // Per-handler notifications are removed (centralized NotificationPolicy).
+      expect(outbox.notifyNoMatch).not.toHaveBeenCalled();
+      expect(outcome).toMatchObject({ kind: 'no_candidate' });
       expect(mockDatabase.logExecution).toHaveBeenCalledWith(
         'ボテ腹', 'novel', 'success', expect.stringContaining('across 2 day(s)')
       );
@@ -888,7 +889,7 @@ describe('NovelTargetHandler', () => {
       });
 
       // When no novels found and limit > 0, it should throw an error
-      await expect(handler.handle(target)).rejects.toThrow();
+      await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed' });
     });
   });
 
@@ -914,14 +915,8 @@ describe('NovelTargetHandler', () => {
       mockClient.searchNovels.mockResolvedValue([createMockNovel(1)]);
       mockPipeline.run.mockRejectedValue(new Error('ENAMETOOLONG: name too long'));
 
-      await expect(h.handle(target)).rejects.toThrow('ENAMETOOLONG');
-
-      expect(mockOutbox.notifyNoMatch).toHaveBeenCalledTimes(1);
-      const [calledTarget, text, key] = mockOutbox.notifyNoMatch.mock.calls[0];
-      expect(calledTarget.id || calledTarget.tag).toBe('botefuku');
-      expect(text).toContain('下载失败');
-      expect(text).toContain('ENAMETOOLONG');
-      expect(key).toBe('pixivflow:hard-fail:botefuku:novel:2023-06-15');
+      await expect(h.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: false });
+      expect(mockOutbox.notifyNoMatch).not.toHaveBeenCalled();
     });
 
     it('does not notify when the target has no delivery destination', async () => {
@@ -945,7 +940,7 @@ describe('NovelTargetHandler', () => {
       mockClient.searchNovels.mockResolvedValue([createMockNovel(1)]);
       mockPipeline.run.mockRejectedValue(new Error('ENAMETOOLONG: name too long'));
 
-      await expect(h.handle(target)).rejects.toThrow('ENAMETOOLONG');
+      await expect(h.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: false });
       expect(mockOutbox.notifyNoMatch).not.toHaveBeenCalled();
     });
   });

--- a/src/__tests__/pixiv/RateLimitCoordinator.test.ts
+++ b/src/__tests__/pixiv/RateLimitCoordinator.test.ts
@@ -1,0 +1,49 @@
+/**
+ * RateLimitCoordinator: one shared gate for all Pixiv requests.
+ */
+import { RateLimitCoordinator } from "../../pixiv/RateLimitCoordinator";
+
+describe("RateLimitCoordinator", () => {
+  let now: number;
+  let clock: () => number;
+  beforeEach(() => {
+    now = 1_000_000;
+    clock = () => now;
+  });
+
+  it("does not pace requests when minInterval is 0 (default)", () => {
+    const rl = new RateLimitCoordinator(0, 2000, 600000, clock);
+    expect(rl.preflightDelay(now)).toBe(0);
+  });
+
+  it("parks the whole client on a 429 for at least the default cooldown", () => {
+    const rl = new RateLimitCoordinator(0, 2000, 600000, clock);
+    const wait = rl.reportRateLimited(null, now);
+    expect(wait).toBe(2000);
+    expect(rl.preflightDelay(now)).toBe(2000);
+    expect(rl.preflightDelay(now + 1000)).toBe(1000);
+    expect(rl.preflightDelay(now + 2000)).toBe(0);
+  });
+
+  it("honors Retry-After seconds", () => {
+    const rl = new RateLimitCoordinator(0, 2000, 600000, clock);
+    const wait = rl.reportRateLimited("30", now);
+    expect(wait).toBe(30_000);
+  });
+
+  it("escalates on repeated 429s and caps at max", () => {
+    const rl = new RateLimitCoordinator(0, 2000, 60_000, clock);
+    expect(rl.reportRateLimited(null, now)).toBe(2000);
+    expect(rl.reportRateLimited(null, now)).toBe(4000);
+    for (let i = 0; i < 8; i++) rl.reportRateLimited(null, now);
+    expect(rl.cooldownRemainingMs).toBeLessThanOrEqual(60_000);
+    expect(rl.cooldownRemainingMs).toBe(60_000);
+  });
+
+  it("resets escalation after a successful response (cooldown still elapses)", () => {
+    const rl = new RateLimitCoordinator(0, 2000, 600000, clock);
+    rl.reportRateLimited(null, now);
+    rl.reportSuccess();
+    expect(rl.reportRateLimited(null, now)).toBe(2000);
+  });
+});

--- a/src/__tests__/scheduler/ScheduleTriggerServer.test.ts
+++ b/src/__tests__/scheduler/ScheduleTriggerServer.test.ts
@@ -140,6 +140,39 @@ describe('trigger endpoint auth + dispatch (live ephemeral express)', () => {
       close();
     }
   });
+
+  it('POST /internal/outbox/drain requires auth and delegates to the handler', async () => {
+    const drain = jest.fn(async () => ({ processed: 2, done: 2, retried: 0, dead: 0 }));
+    const { base, close } = await boot('secret-token', handlers({ drainOutbox: drain }));
+    try {
+      const unauth = await fetch(`${base}/internal/outbox/drain`, { method: 'POST' });
+      expect(unauth.status).toBe(401);
+      expect(drain).not.toHaveBeenCalled();
+
+      const res = await fetch(`${base}/internal/outbox/drain`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret-token' },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ status: 'ok', result: { processed: 2, done: 2 } });
+      expect(drain).toHaveBeenCalledTimes(1);
+    } finally {
+      close();
+    }
+  });
+
+  it('POST /internal/outbox/drain is 503 when the runtime provides no pump', async () => {
+    const { base, close } = await boot('secret-token', handlers({ drainOutbox: undefined }));
+    try {
+      const res = await fetch(`${base}/internal/outbox/drain`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret-token' },
+      });
+      expect(res.status).toBe(503);
+    } finally {
+      close();
+    }
+  });
 });
 
 // Boot the real ScheduleTriggerServer on an ephemeral port.

--- a/src/__tests__/scheduler/SlotCoordinator.test.ts
+++ b/src/__tests__/scheduler/SlotCoordinator.test.ts
@@ -97,3 +97,88 @@ describe('SlotCoordinator', () => {
     });
   });
 });
+
+
+describe('SlotCoordinator failure injection', () => {
+  it('duplicate triggers converge: a live run lease rejects a parallel second trigger', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.begin(slot, schedule, [target('a')]);
+
+      expect(coord.claimRunLease(slot.slotId, 'trigger-1', 60_000)).toBe(true);
+      // A duplicate HTTP trigger arriving while trigger-1 is live must NOT
+      // acquire a parallel lease (which would double-post).
+      expect(coord.claimRunLease(slot.slotId, 'trigger-2', 60_000)).toBe(false);
+      // Same owner may heartbeat/renew.
+      coord.heartbeatLease(slot.slotId, 'trigger-1', 60_000);
+      // After a crash the stored lease expiry passes and a restart reclaims it
+      // (simulated by a lease that expired 1s ago relative to a later clock).
+      expect(db.slots.claimSlotLease(slot.slotId, 'restart', 60_000, Date.now() + 61_000)).toBe(true);
+    });
+  });
+
+  it('a confirmed submitted cell can never be downgraded by a late duplicate/failure', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.begin(slot, schedule, [target('a')]);
+
+      coord.lockWork(slot.slotId, 'a', '100', 'illustration');
+      coord.applyOutcome(slot.slotId, 'a', { kind: 'submitted', workId: '100', workType: 'illustration' });
+      expect(db.slots.getCell(slot.slotId, 'a')!.status).toBe('submitted');
+
+      // ACK lost -> a retry reports the historical duplicate of the SAME work.
+      // It must stay submitted, not move to the 'duplicate' drift state.
+      coord.applyOutcome(slot.slotId, 'a', {
+        kind: 'duplicate', workId: '100', reason: 'already posted',
+      });
+      expect(db.slots.getCell(slot.slotId, 'a')!.status).toBe('submitted');
+
+      // A spurious retryable failure also cannot un-confirm it.
+      coord.applyOutcome(slot.slotId, 'a', { kind: 'failed', retryable: true, error: 'late timeout' });
+      expect(db.slots.getCell(slot.slotId, 'a')!.status).toBe('submitted');
+    });
+  });
+
+  it('retryable failure before ACK keeps the locked work so a resume posts the SAME work', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.begin(slot, schedule, [target('a')]);
+
+      coord.lockWork(slot.slotId, 'a', '100', 'illustration');
+      coord.applyOutcome(slot.slotId, 'a', { kind: 'failed', retryable: true, error: 'connection reset' });
+
+      const cell = db.slots.getCell(slot.slotId, 'a')!;
+      expect(cell.status).toBe('selected'); // still non-terminal
+      expect(cell.workId).toBe('100'); // resume must not swap to another work
+
+      // Resume path immediately re-runs this cell.
+      expect(coord.pendingTargets(slot.slotId, [target('a')]).map((p) => p.target.id)).toEqual(['a']);
+
+      // The eventual ACK promotes it exactly once.
+      coord.markDelivered(slot.slotId, 'a', '100', 'illustration');
+      expect(db.slots.getCell(slot.slotId, 'a')!.status).toBe('submitted');
+      expect(coord.pendingTargets(slot.slotId, [target('a')])).toEqual([]);
+    });
+  });
+
+  it('delivery_pending survives a crash and resumes toward submitted on the ACK', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.begin(slot, schedule, [target('a')]);
+
+      coord.applyOutcome(slot.slotId, 'a', {
+        kind: 'delivery_pending', workId: '100', workType: 'illustration', deliveryId: 'd-1',
+      });
+      expect(db.slots.getCell(slot.slotId, 'a')!.status).toBe('delivery_pending');
+      // Not terminal: a restart still owes this cell an ACK.
+      expect(coord.pendingTargets(slot.slotId, [target('a')])).toHaveLength(1);
+
+      coord.markDelivered(slot.slotId, 'a', '100', 'illustration');
+      expect(db.slots.getCell(slot.slotId, 'a')!.status).toBe('submitted');
+    });
+  });
+});

--- a/src/commands/DoctorCommand.ts
+++ b/src/commands/DoctorCommand.ts
@@ -1,0 +1,116 @@
+/**
+ * Doctor: cold-start / crash / suspend consistency diagnostics for the
+ * reliability subsystem. Read-only by default; --repair applies safe,
+ * idempotent convergence actions. Uses only SQLite - no external services.
+ */
+import { BaseCommand } from './Command';
+import { CommandCategory } from './metadata';
+import { CommandArgs, CommandContext, CommandResult } from './types';
+import { Database } from '../storage/Database';
+import { OutboxWorker } from '../delivery/OutboxWorker';
+import { DeliveryDispatcher } from '../delivery/DeliveryDispatcher';
+import { migrateLegacyOutbox } from '../delivery/LegacyOutboxMigration';
+
+interface Finding {
+  level: 'info' | 'warn' | 'critical';
+  code: string;
+  message: string;
+}
+
+export class DoctorCommand extends BaseCommand {
+  readonly name = 'doctor';
+  readonly description = 'Diagnose and (with --repair) converge slots, deliveries and outbox';
+  readonly metadata = { category: CommandCategory.MONITORING, requiresAuth: true, longRunning: false };
+  readonly requiresToken = false;
+
+  async execute(context: CommandContext, args: CommandArgs): Promise<CommandResult> {
+    const repair = Boolean(args.options.repair);
+    const dbPath = context.config.storage?.databasePath ?? './data/pixiv-downloader.db';
+    const findings: Finding[] = [];
+    const fixed: string[] = [];
+
+    const db = new Database(dbPath);
+    try {
+      db.migrate();
+      findings.push({ level: 'info', code: 'schema', message: 'Schema migrations applied / current' });
+
+      const mig = migrateLegacyOutbox(db);
+      if (mig.imported || mig.delivered || mig.failed) {
+        findings.push({
+          level: mig.failed ? 'warn' : 'info',
+          code: 'legacy-outbox',
+          message: 'legacy manifests scanned=' + mig.scanned + ' imported=' + mig.imported + ' delivered=' + mig.delivered + ' failed=' + mig.failed,
+        });
+      }
+
+      const deliveries = db.deliveries.countByStatus();
+      const pendingDelivery = deliveries.pending ?? 0;
+      if (pendingDelivery > 0) {
+        findings.push({ level: 'warn', code: 'deliveries-pending', message: pendingDelivery + ' delivery intent(s) not yet confirmed by the downstream' });
+      }
+      if (deliveries.failed) {
+        findings.push({ level: 'warn', code: 'deliveries-failed', message: deliveries.failed + ' delivery intent(s) marked failed' });
+      }
+
+      const counts = db.outbox.counts();
+      if (counts.dead > 0) {
+        findings.push({ level: 'critical', code: 'outbox-dead', message: counts.dead + ' outbox row(s) dead after exhausting retries (manual reconciliation required)' });
+      }
+      const stale = db.outbox.staleProcessing();
+      if (stale.length > 0) {
+        findings.push({ level: repair ? 'info' : 'warn', code: 'outbox-stale-processing', message: stale.length + ' row(s) stuck in processing from a crashed/killed run' });
+        if (repair) {
+          for (const row of stale) db.outbox.release(row.id);
+          fixed.push('released ' + stale.length + ' stale processing row(s) back for retry');
+        }
+      }
+
+      const staleLeases = db.slots.slotsWithStaleLease();
+      if (staleLeases.length > 0) {
+        findings.push({ level: repair ? 'info' : 'warn', code: 'slot-stale-lease', message: staleLeases.length + ' slot(s) carry an expired lease from a crashed worker: ' + staleLeases.slice(0, 5).join(', ') });
+        if (repair) {
+          for (const id of staleLeases) db.slots.releaseSlotLease(id, 'doctor-repair');
+          fixed.push('released ' + staleLeases.length + ' stale slot lease(s)');
+        }
+      }
+
+      let unfinishedCells = 0;
+      for (const slot of db.slots.getRecentSlots(50)) {
+        if (slot.status === 'running' || slot.status === 'failed') {
+          for (const cell of db.slots.getCells(slot.id)) {
+            if (cell.status === 'delivery_pending') unfinishedCells++;
+          }
+        }
+      }
+      if (unfinishedCells > 0) {
+        findings.push({ level: 'info', code: 'cells-delivery-pending', message: unfinishedCells + ' cell(s) waiting on durable delivery confirmation (outbox converges them)' });
+      }
+
+      if (repair) {
+        const worker = new OutboxWorker(db, new DeliveryDispatcher(context.config.delivery));
+        const res = await worker.drainOnce(20);
+        if (res.done > 0) fixed.push('outbox pump delivered/confirmed ' + res.done + ' row(s)');
+        if (res.dead > 0) fixed.push('outbox pump marked ' + res.dead + ' row(s) dead');
+      }
+
+      const critical = findings.filter((f) => f.level === 'critical');
+      const warns = findings.filter((f) => f.level === 'warn');
+      for (const f of findings) {
+        const icon = f.level === 'critical' ? 'CRIT' : f.level === 'warn' ? 'WARN' : 'OK';
+        context.logger.info('[' + icon + '] [' + f.code + '] ' + f.message);
+      }
+      for (const x of fixed) context.logger.info('repaired: ' + x);
+
+      return this.success(
+        critical.length
+          ? 'doctor found ' + critical.length + ' critical, ' + warns.length + ' warning(s)'
+          : warns.length
+            ? 'doctor found ' + warns.length + ' warning(s)'
+            : 'doctor: all reliability state healthy',
+        { findings, repaired: fixed, deliveryCounts: deliveries, outboxCounts: counts }
+      );
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/src/commands/ReconcileCommand.ts
+++ b/src/commands/ReconcileCommand.ts
@@ -1,0 +1,71 @@
+/**
+ * reconcile: accept a downstream-confirmed historical duplicate as fact.
+ *
+ * This is the ONLY way a post-lock historical duplicate enters the ledger.
+ * Default mode is a dry-run (prints what would change); --repair applies it.
+ *
+ *   pixivflow reconcile --target bot1 --type illustration --pixiv-id 123 \
+ *       --remote-id 987 --reason "found in channel history" [--repair]
+ */
+import { BaseCommand } from './Command';
+import { CommandCategory } from './metadata';
+import { CommandArgs, CommandContext, CommandResult } from './types';
+import { Database } from '../storage/Database';
+import { DeliveryService } from '../delivery/DeliveryService';
+
+export class ReconcileCommand extends BaseCommand {
+  readonly name = 'reconcile';
+  readonly description = 'Reconcile a downstream-confirmed historical duplicate (dry-run unless --repair)';
+  readonly metadata = { category: CommandCategory.MONITORING, requiresAuth: true, longRunning: false };
+  readonly requiresToken = false;
+
+  async execute(context: CommandContext, args: CommandArgs): Promise<CommandResult> {
+    const target = String(args.options.target ?? '').trim();
+    const workType = String(args.options.type ?? '').trim();
+    const pixivId = String(args.options['pixiv-id'] ?? args.options.pixivId ?? '').trim();
+    const remoteId = args.options['remote-id'] ? String(args.options['remote-id']) : undefined;
+    const reason = String(args.options.reason ?? 'manual reconciliation').trim();
+    const repair = Boolean(args.options.repair);
+
+    if (!target || !workType || !pixivId) {
+      return this.failure('Usage: reconcile --target <name> --type <illustration|novel> --pixiv-id <id> [--remote-id <id>] [--reason <text>] [--repair]');
+    }
+    if (workType !== 'illustration' && workType !== 'novel') {
+      return this.failure('--type must be illustration or novel');
+    }
+
+    const dbPath = context.config.storage?.databasePath ?? './data/pixiv-downloader.db';
+    const db = new Database(dbPath);
+    try {
+      db.migrate();
+      const service = new DeliveryService(db);
+      const already = service.isAlreadyDelivered(target, workType, pixivId);
+      if (already) {
+        context.logger.info('Already recorded as delivered/duplicate; nothing to reconcile', { target, workType, pixivId });
+        return this.success('already reconciled', { target, workType, pixivId, noop: true });
+      }
+
+      if (!repair) {
+        context.logger.info('DRY RUN (pass --repair to apply)', { target, workType, pixivId, remoteId, reason });
+        return this.success('dry-run: would record historical duplicate', { dryRun: true, target, workType, pixivId, remoteId, reason });
+      }
+
+      const res = service.reconcileHistoricalDuplicate({
+        deliveryTarget: target,
+        workType,
+        pixivId,
+        remoteId,
+        reason,
+      });
+      return this.success('historical duplicate reconciled into ledger', {
+        deliveryId: res.deliveryId,
+        created: res.created,
+        target,
+        workType,
+        pixivId,
+      });
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/src/commands/SchedulerCommand.ts
+++ b/src/commands/SchedulerCommand.ts
@@ -64,6 +64,11 @@ export class SchedulerCommand extends BaseCommand {
       });
       const status = manager.start(runtime.config);
 
+      // Independent outbox pump: deliveries/notifications retry promptly on a
+      // timer and resume after crash/machine-stop without waiting for the next
+      // scheduled run. It never gates Telegram/scheduler readiness.
+      runtime.startOutboxWorker();
+
       // Authenticated HTTP trigger. Mounted in external mode (the external clock
       // wakes the machine here) and, opt-in, in internal mode for manual/ops
       // triggers. Business logic lives in runJob/SlotCoordinator; this handler

--- a/src/commands/SchedulerCommand.ts
+++ b/src/commands/SchedulerCommand.ts
@@ -133,6 +133,7 @@ export class SchedulerCommand extends BaseCommand {
               inFlight.set(key, promise);
               return promise;
             },
+            drainOutbox: () => runtime.drainOutbox(),
             status: (scheduleId) => {
               const cfg = resolveConfig();
               const plan = findPlan(cfg, scheduleId);

--- a/src/commands/SchedulerRunOnceCommand.ts
+++ b/src/commands/SchedulerRunOnceCommand.ts
@@ -65,8 +65,14 @@ export class SchedulerRunOnceCommand extends BaseCommand {
         );
       }
 
+      // Flush deliveries/notifications created by this one-shot before exit.
+      // A bounded drain: durable rows survive if they cannot finish now and the
+      // scheduler daemon (or a later run-once) retries them.
+      const drained = await runtime.drainOutbox();
+      context.logger.info('Outbox drain complete', drained);
       return this.success('Scheduled plans completed', {
         schedules: plans.map((plan) => plan.id),
+        outbox: drained,
       });
     } catch (error) {
       context.logger.error('Fatal error while running schedules once', {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,6 +15,8 @@ import { MigrateConfigCommand } from './MigrateConfigCommand';
 import { NormalizeCommand } from './NormalizeCommand';
 import { WebUICommand } from './WebUICommand';
 import { HealthCommand } from './HealthCommand';
+import { DoctorCommand } from './DoctorCommand';
+import { ReconcileCommand } from './ReconcileCommand';
 import { StatusCommand } from './StatusCommand';
 import { LogsCommand } from './LogsCommand';
 import { ConfigCommand } from './ConfigCommand';
@@ -43,6 +45,8 @@ export function registerAllCommands(registry: CommandRegistry): void {
   registry.register(new NormalizeCommand());
   registry.register(new WebUICommand());
   registry.register(new HealthCommand());
+  registry.register(new DoctorCommand());
+  registry.register(new ReconcileCommand());
   registry.register(new StatusCommand());
   registry.register(new LogsCommand());
   registry.register(new ConfigCommand());
@@ -72,6 +76,8 @@ export {
   NormalizeCommand,
   WebUICommand,
   HealthCommand,
+  DoctorCommand,
+  ReconcileCommand,
   StatusCommand,
   LogsCommand,
   ConfigCommand,

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -23,6 +23,7 @@ import { SlotContext, SlotCoordinator } from '../scheduler/SlotCoordinator';
 import { TargetOutcome } from '../scheduler/TargetOutcome';
 import { DeliveryService } from '../delivery/DeliveryService';
 import { OutboxWorker } from '../delivery/OutboxWorker';
+import { migrateLegacyOutbox } from '../delivery/LegacyOutboxMigration';
 import { DeliveryAck } from '../delivery/DeliveryAck';
 import { NotificationPolicy } from '../notification/NotificationPolicy';
 import { randomUUID } from 'node:crypto';
@@ -192,6 +193,9 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
 
   const databasePath = config.storage!.databasePath!;
   const { database, recoveryNote } = openDatabaseWithRecovery(databasePath);
+  // One-time, idempotent import of any file-based outbox manifests. Safe to run
+  // every start: committed rows are archived; a crash mid-way resumes here.
+  migrateLegacyOutbox(database);
   if (recoveryNote) {
     await notifyRecovery(config, database, recoveryNote);
   }

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -66,7 +66,7 @@ export interface SchedulerRuntime {
  * the caller surfaces to the review group. Schema/migration errors are NOT
  * treated as corruption and propagate normally.
  */
-function openDatabaseWithRecovery(databasePath: string): { database: Database; recoveryNote?: string } {
+function openDatabaseWithRecovery(databasePath: string): { database: Database; recoveryNote?: string; degraded: boolean } {
   const openFresh = (): Database => {
     const db = new Database(databasePath);
     db.migrate();
@@ -84,14 +84,15 @@ function openDatabaseWithRecovery(databasePath: string): { database: Database; r
     database = openFresh();
     return {
       database,
-      recoveryNote: `数据库无法打开（${message}），已隔离损坏文件 ${isolated} 并重建空库；下载去重记录已重置，将重新下载近期作品。`,
+      recoveryNote: `数据库无法打开（${message}），已隔离损坏文件 ${isolated} 并重建空库；已进入降级模式：自动选择/投递已暂停，请执行 doctor --repair 或确认历史后再恢复，以避免空库重复发布。`,
+      degraded: true,
     };
   }
 
   const check = database.checkIntegrity();
   if (check === 'ok') {
     database.migrate();
-    return { database };
+    return { database, degraded: false };
   }
 
   // Structurally corrupt: isolate (preserving evidence) and recreate fresh.
@@ -110,7 +111,8 @@ function openDatabaseWithRecovery(databasePath: string): { database: Database; r
   database = openFresh();
   return {
     database,
-    recoveryNote: `数据库完整性检查未通过（${message}），已隔离损坏文件 ${isolated} 并重建空库；下载去重记录已重置，将重新下载近期作品。`,
+    recoveryNote: `数据库完整性检查未通过（${message}），已隔离损坏文件 ${isolated} 并重建空库；已进入降级模式：自动选择/投递已暂停，请运行 pixivflow doctor --repair / reconcile 确认历史后再恢复，以避免空库批量重复发布。`,
+    degraded: true,
   };
 }
 
@@ -192,7 +194,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
   const config = loadConfig(configPath, false, false);
 
   const databasePath = config.storage!.databasePath!;
-  const { database, recoveryNote } = openDatabaseWithRecovery(databasePath);
+  const { database, recoveryNote, degraded } = openDatabaseWithRecovery(databasePath);
   // One-time, idempotent import of any file-based outbox manifests. Safe to run
   // every start: committed rows are archived; a crash mid-way resumes here.
   migrateLegacyOutbox(database);

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -20,6 +20,12 @@ import { DeliveryOutbox } from '../delivery/DeliveryOutbox';
 import { createTokenMaintenanceService } from '../utils/token-maintenance';
 import { selectScheduleTargets } from '../scheduler/schedules';
 import { SlotContext, SlotCoordinator } from '../scheduler/SlotCoordinator';
+import { TargetOutcome } from '../scheduler/TargetOutcome';
+import { DeliveryService } from '../delivery/DeliveryService';
+import { OutboxWorker } from '../delivery/OutboxWorker';
+import { DeliveryAck } from '../delivery/DeliveryAck';
+import { NotificationPolicy } from '../notification/NotificationPolicy';
+import { randomUUID } from 'node:crypto';
 import { ScheduleRunOptions, TriggerSource } from '../scheduler/OccurrenceResolver';
 import { JobFailure } from '../scheduler/Scheduler';
 import { processConfigPlaceholders } from '../config/placeholders';
@@ -44,6 +50,10 @@ export interface SchedulerRuntime {
     schedule: ScheduleConfig,
     failure: JobFailure
   ): Promise<void>;
+  /** Start the independent outbox pump (long-running daemon). */
+  startOutboxWorker(): void;
+  /** Drain due outbox rows once (run-once / watchdog wake). */
+  drainOutbox(): Promise<{ processed: number; done: number; retried: number; dead: number }>;
   /** Stop token maintenance, cancel any in-flight download and close the DB. */
   close(): void;
 }
@@ -105,7 +115,7 @@ function openDatabaseWithRecovery(databasePath: string): { database: Database; r
 
 async function notifyDeliveryTargets(
   config: StandaloneConfig,
-  databasePath: string,
+  database: Database,
   targetNames: Iterable<string>,
   text: string,
   key: string
@@ -116,32 +126,25 @@ async function notifyDeliveryTargets(
   );
   if (notifyable.length === 0) return;
 
+  // Notifications are durable SQLite outbox rows (kind=notification), pumped by
+  // the OutboxWorker — never fire-and-forget, never swallowed silently.
   try {
-    const dispatcher = new DeliveryDispatcher(delivery, undefined);
-    const outbox = new DeliveryOutbox(
-      join(dirname(databasePath), 'delivery-outbox'),
-      dispatcher,
-      delivery?.deleteAfterDelivery !== false
-    );
+    const { DeliveryService } = await import('../delivery/DeliveryService');
+    const service = new DeliveryService(database);
     for (const name of notifyable) {
-      try {
-        const syntheticTarget = { type: 'novel', delivery: { target: name } } as unknown as TargetConfig;
-        await outbox.notifyNoMatch(syntheticTarget, text, key);
-      } catch (error) {
-        logger.warn('Notification failed for delivery target', { target: name, error });
-      }
+      service.enqueueNotification(name, text, key);
     }
   } catch (error) {
-    logger.warn('Failed to build delivery notification', { error });
+    logger.warn('Failed to enqueue delivery notification', { error });
   }
 }
 
 /** Best-effort: alert every delivery target that exposes a notificationUrl. */
-async function notifyRecovery(config: StandaloneConfig, databasePath: string, note: string): Promise<void> {
+async function notifyRecovery(config: StandaloneConfig, database: Database, note: string): Promise<void> {
   const targetNames = Object.keys(config.delivery?.targets ?? {});
   await notifyDeliveryTargets(
     config,
-    databasePath,
+    database,
     targetNames,
     `⚠️ PixivFlow 数据库自检未通过，已自动隔离并重建\n${note}`,
     `pixivflow:db-recovery:${new Date().toISOString().slice(0, 10)}`
@@ -149,11 +152,11 @@ async function notifyRecovery(config: StandaloneConfig, databasePath: string, no
 }
 
 export async function notifyScheduleFailure(
-  config: StandaloneConfig,
-  databasePath: string,
-  schedule: ScheduleConfig,
-  failure: JobFailure
-): Promise<void> {
+    config: StandaloneConfig,
+    database: Database,
+    schedule: ScheduleConfig,
+    failure: JobFailure
+  ): Promise<void> {
   const targetNames = selectScheduleTargets(config.targets, schedule)
     .map((target) => target.delivery?.target?.trim())
     .filter((name): name is string => Boolean(name));
@@ -164,12 +167,21 @@ export async function notifyScheduleFailure(
   const error = failure.errorMessage ? `\n错误：${failure.errorMessage.slice(0, 500)}` : '';
   await notifyDeliveryTargets(
     config,
-    databasePath,
+    database,
     targetNames,
     `⚠️ PixivFlow 定时任务${status}\n计划：${schedule.name?.trim() || schedule.id}` +
       `\n连续失败：${failure.consecutiveFailures}${error}${stopped}`,
     `pixivflow:schedule-failure:${schedule.id}:${failure.executionNumber}`
   );
+}
+
+function buildProxyUrl(network: StandaloneConfig['network']): string | undefined {
+  const proxy = network?.proxy;
+  if (!proxy?.enabled) return undefined;
+  const protocol = proxy.protocol ?? 'http';
+  if (protocol !== 'http' && protocol !== 'https') return undefined;
+  const auth = proxy.username ? `${proxy.username}:${proxy.password ?? ''}@` : '';
+  return `${protocol}://${auth}${proxy.host}:${proxy.port}`;
 }
 
 export async function createSchedulerRuntime(configPathArg?: string): Promise<SchedulerRuntime> {
@@ -181,7 +193,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
   const databasePath = config.storage!.databasePath!;
   const { database, recoveryNote } = openDatabaseWithRecovery(databasePath);
   if (recoveryNote) {
-    await notifyRecovery(config, databasePath, recoveryNote);
+    await notifyRecovery(config, database, recoveryNote);
   }
 
   const auth = new PixivAuth(config.pixiv, config.network!, database, configPath);
@@ -201,6 +213,31 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
   }
 
   let activeDownloadManager: DownloadManager | null = null;
+
+  // Independently-pumped durable outbox (content + notifications). Started in
+  // the long-running scheduler daemon; run-once drains explicitly before exit.
+  const deliveryDispatcher = new DeliveryDispatcher(config.delivery, buildProxyUrl(config.network));
+  const outboxWorker = new OutboxWorker(database, deliveryDispatcher, {
+    retryBaseMs: config.delivery?.outboxRetryBaseMs,
+    retryMaxMs: config.delivery?.outboxRetryMaxMs,
+    // A confirmed ACK promotes the delivery_pending cell to submitted.
+    onDeliveryTerminal: (deliveryId, ack) => {
+      const row = database.deliveries.getById(deliveryId);
+      if (!row || !row.slotId || !row.targetId) return;
+      if (ack.kind === 'duplicate_existing') {
+        const coord = new SlotCoordinator(database);
+        coord.applyOutcome(row.slotId, row.targetId, {
+          kind: 'duplicate',
+          workId: row.pixivId,
+          reason: 'downstream attested historical duplicate',
+        });
+        return;
+      }
+      const coord = new SlotCoordinator(database);
+      coord.markDelivered(row.slotId, row.targetId, row.pixivId, row.workType as 'illustration' | 'novel');
+    },
+  });
+  const notificationPolicy = new NotificationPolicy(database, config);
 
   const runJob = async (
     snapshot: StandaloneConfig,
@@ -233,6 +270,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     // complete or be resumed as one. Scheduled runs (cron/http/catchup) always
     // resolve a canonical occurrence and converge on one durable Slot.
     let slotCtx: SlotContext | null = null;
+    let varReleaseLease: (() => void) | null = null;
     if (!adhoc) {
       if (providedSlot) {
         slotCtx = providedSlot;
@@ -250,14 +288,38 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
         slotCtx = resolved.context;
       }
 
+      const activeSlot = slotCtx!;
+      const runOwner = `run-${process.pid}-${randomUUID().slice(0, 8)}`;
+      const leaseMs = Math.max(60_000, (schedule.timeout ?? 30 * 60_000) + 60_000);
       const begin = coordinator.begin(slotCtx, schedule, targets);
       if (begin.alreadyCompleted && !onlyTarget) {
         logger.info('Slot already terminal; nothing to do', {
-          slot: slotCtx.slotId,
+          slot: activeSlot.slotId,
           status: begin.slotRec.status,
         });
         return;
       }
+      // Cross-process lease: a concurrent Cloudflare + watchdog + manual
+      // trigger on a SECOND process sees an active lease and converges instead
+      // of running the same targets in parallel.
+      const claimed = coordinator.claimRunLease(activeSlot.slotId, runOwner, leaseMs);
+      if (!claimed) {
+        const lease = database.slots.getSlotLease(activeSlot.slotId);
+        logger.info('Slot run already leased by another worker; converging', {
+          slot: activeSlot.slotId,
+          leaseOwner: lease.owner,
+        });
+        // Resume-only: the OutboxWorker drains pending deliveries; do not run
+        // candidate selection again. Drain due rows and return.
+        await outboxWorker.drainOnce(1);
+        return;
+      }
+      const heartbeat = setInterval(() => coordinator.heartbeatLease(activeSlot.slotId, runOwner, leaseMs), Math.floor(leaseMs / 3));
+      heartbeat.unref?.();
+      varReleaseLease = () => {
+        clearInterval(heartbeat);
+        coordinator.releaseRunLease(activeSlot.slotId, runOwner);
+      };
     }
 
     // For a scheduled run, skip cells already in a terminal state (resume never
@@ -301,25 +363,28 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     await downloadManager.initialise();
 
     if (slotCtx) {
-      // Record cell outcomes into the slot ledger.
+      const slot = slotCtx; // stable for callbacks
+      // Record the locked work as soon as a candidate is chosen. First
+      // selection wins; retries/replays keep the SAME work id.
       downloadManager.setWorkLockedHook((artifact, target) => {
-        if (!target.id || !slotCtx) return;
-        // First selection wins; retries/replays carry the same pixivId and the
-        // ledger COALESCE keeps it, so a retry never silently swaps the work.
-        coordinator.lockWork(slotCtx.slotId, target.id, artifact.pixivId, artifact.type);
+        if (!target.id) return;
+        coordinator.lockWork(slot.slotId, target.id, artifact.pixivId, artifact.type);
       });
-      downloadManager.setTargetOutcomeHook((target, error) => {
-        if (!target.id || !slotCtx) return;
-        if (!error) {
-          // Delivered (or queued in outbox, which retries the SAME work). Mark
-          // submitted; the work id is best-effort from the most recent download.
-          coordinator.markCell(slotCtx.slotId, target.id, 'submitted');
-        } else if (/no matching|no_candidate|all .*filtered|already downloaded/i.test(error)) {
-          coordinator.markCell(slotCtx.slotId, target.id, 'no_candidate', error);
-        } else {
-          coordinator.markCell(slotCtx.slotId, target.id, 'failed', error);
-        }
+      // TYPED outcome -> explicit FSM transition. No message regex, no
+      // "no throw => submitted". Only a confirmed ACK yields 'submitted'.
+      downloadManager.setTargetOutcomeHook((target, outcome: TargetOutcome) => {
+        if (!target.id) return;
+        coordinator.applyOutcome(slot.slotId, target.id, outcome);
+        notificationPolicy.noteOutcome(slot.slotId, slot, schedule, target, outcome);
       });
+      downloadManager.slotContext = {
+        slotId: slot.slotId,
+        scheduleId: slot.scheduleId,
+        occurrenceAtIso: new Date(slot.occurrenceAt).toISOString(),
+        triggerSource: slot.triggerSource,
+        slotName: slot.slotName,
+        slotDate: slot.slotDate,
+      };
     }
 
     // Apply initial delay if configured
@@ -341,6 +406,8 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
 
     const startTime = Date.now();
     let allTargetsFailed: Error | undefined;
+    let releaseLease: () => void = () => undefined;
+    if (slotCtx && varReleaseLease) releaseLease = varReleaseLease;
     try {
       await downloadManager.runAllTargets();
     } catch (error) {
@@ -353,10 +420,29 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       allTargetsFailed = error;
     } finally {
       if (activeDownloadManager === downloadManager) activeDownloadManager = null;
+      releaseLease?.();
     }
     const duration = Math.round((Date.now() - startTime) / 1000);
 
-    if (slotCtx) coordinator.finish(slotCtx, schedule, targets);
+    if (slotCtx) {
+      const summary = coordinator.finish(slotCtx, schedule, targets);
+      notificationPolicy.sendSlotSummary(
+        slotCtx,
+        schedule,
+        summary.cells.map((c) => {
+          const t = targets.find((x) => x.id === c.targetId);
+          return {
+            targetId: c.targetId,
+            label: c.targetId,
+            workType: t?.type ?? 'unknown',
+            status: c.status,
+            workId: c.workId,
+            error: c.error ?? null,
+          };
+        })
+      );
+      releaseLease();
+    }
     if (!slotCtx && allTargetsFailed) throw allTargetsFailed;
 
     logger.info('='.repeat(60));
@@ -372,6 +458,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
   };
 
   const close = (): void => {
+    outboxWorker.stop();
     cancelActive('process shutdown');
     if (tokenMaintenance) {
       tokenMaintenance.stop();
@@ -387,8 +474,10 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     tokenMaintenance,
     runJob,
     cancelActive,
+    startOutboxWorker: () => outboxWorker.start(),
+    drainOutbox: () => outboxWorker.drainOnce(),
     notifyScheduleFailure: (snapshot, schedule, failure) =>
-      notifyScheduleFailure(snapshot, databasePath, schedule, failure),
+      notifyScheduleFailure(snapshot, database, schedule, failure),
     close,
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -498,10 +498,19 @@ export interface HttpMultipartDeliveryConfig {
   /** 数组字段编码方式，默认 comma */
   arrayFormat?: 'comma' | 'repeat' | 'json';
   success?: HttpMultipartSuccessConfig;
-  /** 单次交付的最大尝试次数（含首次），默认 3 */
+  /** 单次交付的最大尝试次数（含首次），默认 3（遗留即时重试；SQLite outbox 是主重试层） */
   maxAttempts?: number;
   /** 重试基础间隔（毫秒），默认 2000 */
   retryDelayMs?: number;
+  /** 业务 ACK 信封字段映射（默认解析 TelePost {data:{review_id,reused,...}}）。 */
+  ack?: {
+    dataPath?: string;
+    idField?: string;
+    statusField?: string;
+    reusedField?: string;
+    reasonField?: string;
+    keyField?: string;
+  };
 }
 
 export type DeliveryTargetConfig = HttpMultipartDeliveryConfig;
@@ -600,7 +609,6 @@ export interface StandaloneConfig {
     timeout?: number;
   };
 }
-
 
 
 

--- a/src/delivery/DeliveryAck.ts
+++ b/src/delivery/DeliveryAck.ts
@@ -1,0 +1,125 @@
+/**
+ * Normalized acknowledgement from a downstream delivery provider (TelePost).
+ *
+ * HTTP status alone is NOT a business result. The provider response is parsed
+ * once, at the adapter boundary, into this discriminated union; everything
+ * inside Core (outbox worker, delivery ledger, slot FSM) branches on ack.kind
+ * instead of status codes or message strings.
+ */
+export type DeliveryAck =
+  | { kind: 'accepted'; remoteId?: string; remoteStatus?: string; raw?: unknown }
+  /**
+   * The provider recognised OUR idempotency_key and returned the SAME record a
+   * previous attempt created (ACK lost to a timeout/crash). This is a success
+   * and converges to exactly one remote record.
+   */
+  | { kind: 'idempotent_replay'; remoteId?: string; remoteStatus?: string; raw?: unknown }
+  /**
+   * The provider found an OLDER delivery of the same work from a DIFFERENT
+   * intent/slot (historical drift). NO new side effect was created. This is not
+   * a successful new submission.
+   */
+  | {
+      kind: 'duplicate_existing';
+      remoteId?: string;
+      remoteStatus?: string;
+      matchedKey?: string;
+      raw?: unknown;
+    }
+  /** Transient failure: timeouts, 5xx, 429, connection errors. Retryable. */
+  | { kind: 'retryable_failure'; retryAfterMs?: number; error: string }
+  /** Deterministic failure: 4xx (except 408/429), validation rejection. */
+  | { kind: 'permanent_failure'; error: string };
+
+/** Where the provider put the machine-readable result in its envelope. */
+export interface AckEnvelopeHints {
+  /** Default config: TelePost returns { ok, data: { ... } }. */
+  dataPath?: string;
+  /** Field carrying the stable downstream record id (default review_id/message_id). */
+  idField?: string;
+  /** Field carrying the downstream status string. */
+  statusField?: string;
+  /** Field that is true when a pre-existing record was reused. */
+  reusedField?: string;
+  /** Field distinguishing replay-of-our-key vs an older historical record. */
+  reasonField?: string;
+  keyField?: string;
+}
+
+const DEFAULT_HINTS: Required<AckEnvelopeHints> = {
+  dataPath: 'data',
+  idField: 'review_id',
+  statusField: 'status',
+  reusedField: 'reused',
+  reasonField: 'reuse_reason',
+  keyField: 'matched_idempotency_key',
+};
+
+function dig(body: unknown, path?: string): unknown {
+  if (!path) return body;
+  return path.split('.').reduce<unknown>((value, key) => {
+    if (value && typeof value === 'object') return (value as Record<string, unknown>)[key];
+    return undefined;
+  }, body);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+/**
+ * Parse a provider HTTP response into a DeliveryAck. Pure function of
+ * (status, body). Recognises the explicit TelePost envelope and degrades
+ * safely for plain 2xx endpoints (treated as 'accepted') so generic adapters
+ * keep working.
+ */
+export function parseDeliveryAck(
+  status: number,
+  body: unknown,
+  hints: AckEnvelopeHints = {}
+): DeliveryAck {
+  const h = { ...DEFAULT_HINTS, ...hints };
+
+  if (status === 429) {
+    return { kind: 'retryable_failure', error: 'HTTP 429 rate limited by delivery endpoint' };
+  }
+  if (status === 408 || status >= 500) {
+    return { kind: 'retryable_failure', error: `delivery endpoint HTTP ${status}` };
+  }
+  if (status < 200 || status >= 300) {
+    const preview = typeof body === 'string' ? body : safeStringify(body);
+    return { kind: 'permanent_failure', error: `delivery endpoint HTTP ${status}${preview ? ': ' + preview.slice(0, 200) : ''}` };
+  }
+
+  const data = dig(body, h.dataPath);
+  // Plain 2xx with no JSON envelope: accepted at-most-once signal.
+  if (!data || typeof data !== 'object') {
+    return { kind: 'accepted', raw: body };
+  }
+  const rec = data as Record<string, unknown>;
+  const idValue = rec[h.idField] ?? rec.message_id;
+  const remoteId =
+    typeof idValue === 'number' ? String(idValue) : asString(idValue);
+  const remoteStatus = asString(rec[h.statusField]);
+  const reused = rec[h.reusedField] === true;
+  if (!reused) {
+    return { kind: 'accepted', remoteId, remoteStatus, raw: body };
+  }
+
+  const reason = asString(rec[h.reasonField]) ?? asString(rec.reuse_kind) ?? '';
+  const matchedKey = asString(rec[h.keyField]);
+  // Explicit historical-duplicate attestation wins; bare "reused" defaults to
+  // replay because the provider only sets reused when it matched a prior key.
+  if (reason === 'duplicate_existing' || reason === 'historical' || reason === 'historical_duplicate') {
+    return { kind: 'duplicate_existing', remoteId, remoteStatus, matchedKey, raw: body };
+  }
+  return { kind: 'idempotent_replay', remoteId, remoteStatus, raw: body };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}

--- a/src/delivery/DeliveryDispatcher.ts
+++ b/src/delivery/DeliveryDispatcher.ts
@@ -38,6 +38,6 @@ export class DeliveryDispatcher {
     if (!target.notificationUrl?.trim()) {
       throw new ConfigError(`Delivery target does not configure notificationUrl: ${name}`);
     }
-    return new HttpMultipartDelivery(target, this.proxyUrl).notify(request);
+    return new HttpMultipartDelivery(target, this.proxyUrl).notifyOnce(request);
   }
 }

--- a/src/delivery/DeliveryService.ts
+++ b/src/delivery/DeliveryService.ts
@@ -1,0 +1,261 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+
+import { Database } from '../storage/Database';
+import { TargetConfig } from '../config';
+import { DownloadedArtifact } from './types';
+import { logger } from '../logger';
+
+/**
+ * The single place that turns a downloaded artifact into a durable delivery
+ * intent. It atomically:
+ *   - inserts (or reuses) the delivery ledger row (pending),
+ *   - enqueues the outbox side effect,
+ *   - moves the slot cell to delivery_pending.
+ * Because all three land in one SQLite transaction, a crash at any point
+ * leaves a state with a deterministic recovery (resume), never a false
+ * "submitted". Downstream ACK is what later promotes the cell to submitted.
+ */
+export interface EnqueueResult {
+  deliveryId: string;
+  idempotencyKey: string;
+  /** True when an already-confirmed ledger/fact short-circuited a new intent. */
+  duplicate: boolean;
+  /** True when this call created a brand new delivery row. */
+  created: boolean;
+}
+
+export class DeliveryService {
+  constructor(private readonly database: Database) {}
+
+  /** Delivery target name for a target config, or null when it is not a delivery run. */
+  static targetName(target: TargetConfig): string | null {
+    if (target.storageMode !== 'cache') return null;
+    return target.delivery?.target?.trim() || null;
+  }
+
+  /** Stable per-occurrence intent key, so ACK loss / replays converge to one row. */
+  static idempotencyKey(
+    deliveryTarget: string,
+    artifact: DownloadedArtifact,
+    slotId?: string,
+    targetId?: string
+  ): string {
+    const scope = slotId && targetId ? `${slotId}:${targetId}` : 'adhoc';
+    return `pixivflow:${deliveryTarget}:${artifact.type}:${artifact.pixivId}:${scope}`;
+  }
+
+  /**
+   * Delivery-dedup preflight: is this work already CONFIRMED delivered to this
+   * target? Runs in the candidate pipeline BEFORE work lock so a historical
+   * duplicate is skipped and the next valid candidate is chosen. This is
+   * distinct from download dedupe (which only proves local caching).
+   */
+  isAlreadyDelivered(deliveryTarget: string, workType: string, pixivId: string): boolean {
+    return this.database.deliveries.isDelivered(deliveryTarget, workType, String(pixivId));
+  }
+
+  /** Batch form for pre-lock candidate filtering. */
+  deliveredIds(deliveryTarget: string, workType: string, pixivIds: string[]): Set<string> {
+    return this.database.deliveries.deliveredIds(deliveryTarget, workType, pixivIds);
+  }
+
+  /**
+   * Atomically create the delivery intent + outbox row and advance the cell.
+   * Missing local artifact files are treated as a recoverable error (the
+   * caller re-runs the download); a crash leaves the intent pending for the
+   * OutboxWorker — it never fabricates a submitted cell.
+   */
+  enqueue(
+    artifact: DownloadedArtifact,
+    target: TargetConfig,
+    context: {
+      slotId?: string;
+      idempotencyKey?: string;
+      fields?: Record<string, unknown>;
+      extraContext?: Record<string, unknown>;
+    } = {}
+  ): EnqueueResult {
+    const deliveryTarget = DeliveryService.targetName(target);
+    if (!deliveryTarget) {
+      throw new Error('enqueue called for a non-delivery (non-cache) target');
+    }
+    if (artifact.files.length === 0) {
+      throw new Error(`no files produced for ${artifact.type} ${artifact.pixivId}`);
+    }
+    const missing = artifact.files.find((file) => !existsSync(file));
+    if (missing) {
+      // Crash between download and intent, or cache eviction. Recoverable: the
+      // cell stays selected and a resume re-downloads the SAME locked work.
+      throw new Error(`artifact file missing before enqueue: ${missing}`);
+    }
+
+    // Ledger short-circuit: a confirmed fact must never create a new intent.
+    if (this.database.deliveries.isDelivered(deliveryTarget, artifact.type, artifact.pixivId)) {
+      return { deliveryId: '', idempotencyKey: '', duplicate: true, created: false };
+    }
+
+    const idempotencyKey =
+      context.idempotencyKey ??
+      DeliveryService.idempotencyKey(deliveryTarget, artifact, context.slotId, target.id);
+
+    const result = this.database.transaction(() => {
+      const { row, created } = this.database.deliveries.insertIntent({
+        id: randomUUID(),
+        deliveryTarget,
+        workType: artifact.type,
+        pixivId: artifact.pixivId,
+        slotId: context.slotId ?? null,
+        targetId: target.id ?? null,
+        idempotencyKey,
+      });
+
+      // Reuse of our own prior intent (ACK lost / duplicate trigger / restart).
+      if (!created) {
+        if (row.status === 'delivered' || row.status === 'duplicate') {
+          return { deliveryId: row.id, duplicate: true, created: false };
+        }
+        // pending/failed: ensure an outbox row exists (idempotent) and keep the
+        // cell recoverable rather than emitting a second side effect.
+        this.database.outbox.enqueue(
+          {
+            kind: 'delivery',
+            deliveryTarget,
+            idempotencyKey: `outbox:${idempotencyKey}`,
+            deliveryId: row.id,
+            payload: {
+              files: artifact.files,
+              cleanupFiles: artifact.cleanupFiles ?? [],
+              fields: context.fields ?? null,
+              context: { ...this.contextFrom(artifact, target), ...(context.extraContext ?? {}) },
+            },
+          },
+          Date.now()
+        );
+        if (context.slotId && target.id) {
+          this.guardCell(context.slotId, target.id, 'delivery_pending');
+        }
+        return { deliveryId: row.id, duplicate: false, created: false };
+      }
+
+      this.database.outbox.enqueue({
+        kind: 'delivery',
+        deliveryTarget,
+        idempotencyKey: `outbox:${idempotencyKey}`,
+        deliveryId: row.id,
+        payload: {
+          files: artifact.files,
+          cleanupFiles: artifact.cleanupFiles ?? [],
+          fields: context.fields ?? null,
+          context: { ...this.contextFrom(artifact, target), ...(context.extraContext ?? {}) },
+        },
+      });
+
+      if (context.slotId && target.id) {
+        this.guardCell(context.slotId, target.id, 'delivery_pending');
+      }
+      return { deliveryId: row.id, duplicate: false, created: true };
+    });
+
+    logger.info('Delivery intent enqueued', {
+      deliveryId: result.deliveryId,
+      deliveryTarget,
+      pixivId: artifact.pixivId,
+      workType: artifact.type,
+      slotId: context.slotId,
+      created: result.created,
+      idempotencyKey,
+    });
+    return { ...result, idempotencyKey };
+  }
+
+  /**
+   * Record a historical downstream fact discovered via reconciliation: a work
+   * the remote already published from a different/older intent. Backfills the
+   * ledger so it never re-selects the work, and (optionally) settles the cell.
+   * This is the ONLY path that accepts a post-lock historical duplicate.
+   */
+  reconcileHistoricalDuplicate(input: {
+    deliveryTarget: string;
+    workType: string;
+    pixivId: string;
+    remoteId?: string;
+    remoteStatus?: string;
+    slotId?: string;
+    targetId?: string;
+    reason: string;
+  }): { deliveryId: string; created: boolean } {
+    const key = `reconcile:${input.deliveryTarget}:${input.workType}:${input.pixivId}`;
+    const { row, created } = this.database.deliveries.backfill({
+      id: randomUUID(),
+      deliveryTarget: input.deliveryTarget,
+      workType: input.workType,
+      pixivId: input.pixivId,
+      slotId: input.slotId ?? null,
+      targetId: input.targetId ?? null,
+      idempotencyKey: key,
+      remoteId: input.remoteId,
+      remoteStatus: input.remoteStatus ?? 'duplicate_existing',
+    });
+    // Mark the backfilled ledger row as an attested historical duplicate.
+    if (row.status !== 'duplicate') {
+      this.database.deliveries.recordAck(row.id, {
+        status: 'duplicate',
+        remoteId: input.remoteId,
+        remoteStatus: input.remoteStatus ?? 'duplicate_existing',
+        reuseReason: input.reason,
+      });
+    }
+    if (input.slotId && input.targetId) {
+      this.guardCell(input.slotId, input.targetId, 'duplicate');
+    }
+    logger.warn('Reconciled historical downstream duplicate', {
+      pixivId: input.pixivId,
+      workType: input.workType,
+      deliveryTarget: input.deliveryTarget,
+      remoteId: input.remoteId,
+      reason: input.reason,
+    });
+    return { deliveryId: row.id, created };
+  }
+
+  /** Enqueue a durable notification (retried independently; never affects content). */
+  enqueueNotification(deliveryTarget: string, text: string, idempotencyKey: string): void {
+    this.database.outbox.enqueue({
+      kind: 'notification',
+      deliveryTarget,
+      idempotencyKey,
+      payload: { text },
+    });
+  }
+
+  private guardCell(slotId: string, targetId: string, next: import('../storage/repositories/SlotRepository').CellStatus): void {
+    const cell = this.database.slots.getCell(slotId, targetId);
+    if (!cell) return;
+    if (cell.status === next) return;
+    if (cell.status === 'submitted' || cell.status === 'duplicate') return; // never downgrade
+    try {
+      this.database.slots.transitionCell(slotId, targetId, next);
+    } catch (error) {
+      logger.debug('Cell transition skipped', { slotId, targetId, from: cell.status, to: next, error: (error as Error).message });
+    }
+  }
+
+  private contextFrom(artifact: DownloadedArtifact, target: TargetConfig): Record<string, unknown> {
+    return {
+      title: artifact.title,
+      pixivId: artifact.pixivId,
+      type: artifact.type,
+      targetId: target.id,
+      tag: target.filterTag || target.tag || '',
+      topic: target.topic?.trim() || undefined,
+      workTags: artifact.tags,
+      spoiler: artifact.spoiler,
+      xRestrict: artifact.xRestrict,
+      publishedAt: artifact.publishedAt,
+      language: artifact.language,
+      bookmarkCount: artifact.bookmarkCount,
+      viewCount: artifact.viewCount,
+    };
+  }
+}

--- a/src/delivery/DeliveryService.ts
+++ b/src/delivery/DeliveryService.ts
@@ -127,7 +127,7 @@ export class DeliveryService {
               files: artifact.files,
               cleanupFiles: artifact.cleanupFiles ?? [],
               fields: context.fields ?? null,
-              context: { ...this.contextFrom(artifact, target), ...(context.extraContext ?? {}) },
+              context: { ...this.contextFrom(artifact, target), idempotencyKey, ...(context.extraContext ?? {}) },
             },
           },
           Date.now()
@@ -147,7 +147,7 @@ export class DeliveryService {
           files: artifact.files,
           cleanupFiles: artifact.cleanupFiles ?? [],
           fields: context.fields ?? null,
-          context: { ...this.contextFrom(artifact, target), ...(context.extraContext ?? {}) },
+          context: { ...this.contextFrom(artifact, target), idempotencyKey, ...(context.extraContext ?? {}) },
         },
       });
 

--- a/src/delivery/HttpMultipartDelivery.ts
+++ b/src/delivery/HttpMultipartDelivery.ts
@@ -233,13 +233,17 @@ export class HttpMultipartDelivery implements DeliveryProvider {
       slotId: request.context.slotId ?? '',
       slotName: request.context.slotName ?? '',
       slotDate: request.context.slotDate ?? '',
+      // The occurrence-scoped intent key. MUST be sent so an ACK-loss retry
+      // (same key) converges remotely as idempotent_replay instead of being
+      // mistaken for a historical duplicate or, worse, double-posting.
+      idempotencyKey: (request.context.idempotencyKey as string) ?? '',
     };
     return Object.fromEntries(
       Object.entries(fields).map(([name, value]) => {
         const values = Array.isArray(value) ? value : [value];
         const rendered = values.map((item) =>
           String(item).replace(
-            /\{\{(title|pixivId|type|targetId|tag|topic|workTags|link|topicTag|spoiler|xRestrict|xRestrictLabel|xRestrictTag|rankingDate|publishedDate|language|bookmarkCount|viewCount|scheduleId|executionId|occurrenceAt|triggerSource|slotId|slotName|slotDate)\}\}/g,
+            /\{\{(title|pixivId|type|targetId|tag|topic|workTags|link|topicTag|spoiler|xRestrict|xRestrictLabel|xRestrictTag|rankingDate|publishedDate|language|bookmarkCount|viewCount|scheduleId|executionId|occurrenceAt|triggerSource|slotId|slotName|slotDate|idempotencyKey)\}\}/g,
             (_, key: string) => variables[key]
           )
         );

--- a/src/delivery/HttpMultipartDelivery.ts
+++ b/src/delivery/HttpMultipartDelivery.ts
@@ -5,6 +5,7 @@ import { Readable } from 'node:stream';
 import { DeliveryFieldValue, HttpMultipartDeliveryConfig } from '../config';
 import { logger } from '../logger';
 import { DeliveryNotificationRequest, DeliveryProvider, DeliveryRequest, DeliveryResult } from './types';
+import { parseDeliveryAck } from './DeliveryAck';
 
 /** Render an ISO timestamp to YYYY-MM-DD (create_date is JST). */
 function formatPublishedDate(iso?: string): string {
@@ -54,85 +55,41 @@ export class HttpMultipartDelivery implements DeliveryProvider {
     }
   }
 
+  /**
+   * One delivery attempt. Retry/backoff/dead-letter belong to the outbox worker,
+   * not here, so this performs exactly ONE HTTP call and normalizes the result
+   * into a DeliveryAck. HTTP status/body is never silently treated as success.
+   */
   async deliver(request: DeliveryRequest): Promise<DeliveryResult> {
     if (request.files.length === 0) {
       throw new Error('HTTP multipart delivery requires at least one file');
     }
-
-    const maxAttempts = Math.max(1, this.config.maxAttempts ?? 3);
-    const retryDelayMs = Math.max(0, this.config.retryDelayMs ?? 2000);
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        return await this.attempt(request);
-      } catch (error) {
-        lastError = error;
-        logger.warn(`HTTP multipart delivery attempt ${attempt}/${maxAttempts} failed`, {
-          url: this.config.url,
-          error: error instanceof Error ? error.message : String(error),
-          files: request.files.length,
-        });
-        if (attempt < maxAttempts) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt));
-        }
-      }
-    }
-    throw new Error(
-      `HTTP multipart delivery failed after ${maxAttempts} attempts: ${
-        lastError instanceof Error ? lastError.message : String(lastError)
-      }`
-    );
+    const { status, body } = await this.attempt(request);
+    const httpStatus = status ?? 0;
+    return { status: httpStatus, body, ack: parseDeliveryAck(httpStatus, body, this.config.ack) };
   }
 
-  async notify(request: DeliveryNotificationRequest): Promise<DeliveryResult> {
+  /** Single notification attempt; the outbox owns retries. */
+  async notifyOnce(request: DeliveryNotificationRequest): Promise<{ status: number; body: unknown }> {
     const url = this.config.notificationUrl?.trim();
     if (!url) throw new Error('HTTP delivery notificationUrl is not configured');
-    const maxAttempts = Math.max(1, this.config.maxAttempts ?? 3);
-    const retryDelayMs = Math.max(0, this.config.retryDelayMs ?? 2000);
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        const headers = {
-          ...this.resolveHeaders(this.config.headers ?? {}),
-          'Content-Type': 'application/json',
-        };
-        const options: Record<string, unknown> = {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            text: request.text,
-            idempotency_key: request.idempotencyKey,
-          }),
-        };
-        if (this.dispatcher) options.dispatcher = this.dispatcher;
-        const response = await fetch(
-          this.interpolateEnvironment(url),
-          options as Parameters<typeof fetch>[1]
-        );
-        const text = await response.text();
-        let body: unknown = text;
-        if (text) {
-          try { body = JSON.parse(text); } catch { /* plain text is valid */ }
-        }
-        this.assertSuccess(response, body);
-        logger.info('HTTP delivery notification succeeded', { url: redactUrl(url), status: response.status });
-        return { status: response.status, body };
-      } catch (error) {
-        lastError = error;
-        logger.warn(`HTTP delivery notification attempt ${attempt}/${maxAttempts} failed`, {
-          url: redactUrl(url),
-          error: error instanceof Error ? error.message : String(error),
-        });
-        if (attempt < maxAttempts) {
-          await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt));
-        }
-      }
-    }
-    throw new Error(
-      `HTTP delivery notification failed after ${maxAttempts} attempts: ${
-        lastError instanceof Error ? lastError.message : String(lastError)
-      }`
-    );
+    const headers = {
+      ...this.resolveHeaders(this.config.headers ?? {}),
+      'Content-Type': 'application/json',
+    };
+    const options: Record<string, unknown> = {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ text: request.text, idempotency_key: request.idempotencyKey }),
+    };
+    if (this.dispatcher) options.dispatcher = this.dispatcher;
+    const response = await fetch(this.interpolateEnvironment(url), options as Parameters<typeof fetch>[1]);
+    const text = await response.text();
+    let body: unknown = text;
+    if (text) { try { body = JSON.parse(text); } catch { /* plain ok */ } }
+    if (!response.ok) throw new Error(`notification endpoint returned HTTP ${response.status}`);
+    logger.info('HTTP delivery notification sent', { url: redactUrl(url), status: response.status });
+    return { status: response.status, body };
   }
 
   private async attempt(request: DeliveryRequest): Promise<DeliveryResult> {
@@ -167,11 +124,12 @@ export class HttpMultipartDelivery implements DeliveryProvider {
         // Non-JSON responses are valid when only HTTP status is configured.
       }
     }
-    this.assertSuccess(response, body);
     const data = body && typeof body === 'object'
       ? (body as { data?: Record<string, unknown> }).data
       : undefined;
-    logger.info('HTTP multipart delivery succeeded', {
+    // Classification happens in parseDeliveryAck (DeliveryResult.ack). We keep
+    // the raw status/body and only log for correlation.
+    logger.info('HTTP multipart delivery response', {
       url: this.config.url,
       status: response.status,
       files: request.files.length,

--- a/src/delivery/LegacyOutboxMigration.ts
+++ b/src/delivery/LegacyOutboxMigration.ts
@@ -1,0 +1,164 @@
+import { existsSync, readdirSync, readFileSync, renameSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+import { Database } from '../storage/Database';
+import { logger } from '../logger';
+
+/**
+ * Idempotent migration from the legacy file-based outbox
+ * (delivery-outbox/*.json manifests) to the SQLite transactional outbox.
+ *
+ * It is crash-safe: a manifest is only ARCHIVED after its outbox row is
+ * committed, and re-running finds the row via the same idempotency key (no
+ * duplicate side effects). Pending/retryable manifests become due rows;
+ * already-delivered manifests are archived without a new intent (their work is
+ * also backfilled into the delivery ledger when resolvable).
+ */
+export interface LegacyMigrationResult {
+  scanned: number;
+  imported: number;
+  delivered: number;
+  skipped: number;
+  failed: number;
+}
+
+interface LegacyManifest {
+  version?: number;
+  id?: string;
+  kind?: 'delivery' | 'notification';
+  status?: 'pending' | 'delivered';
+  deliveryTarget?: string;
+  attempts?: number;
+  nextAttemptAt?: string;
+  lastError?: string;
+  artifact?: {
+    pixivId: string;
+    type: string;
+    files: string[];
+    cleanupFiles?: string[];
+    title?: string;
+    tags?: string[];
+    [k: string]: unknown;
+  };
+  request?: { fields?: Record<string, unknown>; context?: Record<string, unknown> };
+  notification?: { text: string; idempotencyKey?: string };
+}
+
+export function legacyOutboxDir(databasePath: string): string {
+  return join(dirname(databasePath), 'delivery-outbox');
+}
+
+export function migrateLegacyOutbox(
+  database: Database,
+  outboxDir: string = legacyOutboxDir(database.getDatabasePath())
+): LegacyMigrationResult {
+  const result: LegacyMigrationResult = { scanned: 0, imported: 0, delivered: 0, skipped: 0, failed: 0 };
+  if (!existsSync(outboxDir)) return result;
+
+  const files = readdirSync(outboxDir).filter((f) => f.endsWith('.json'));
+  const archiveDir = join(outboxDir, 'migrated');
+  for (const file of files) {
+    result.scanned++;
+    const full = join(outboxDir, file);
+    let manifest: LegacyManifest;
+    try {
+      manifest = JSON.parse(readFileSync(full, 'utf8')) as LegacyManifest;
+    } catch (error) {
+      logger.warn('Legacy outbox manifest unreadable; leaving in place', {
+        file,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      result.failed++;
+      continue;
+    }
+
+    try {
+      const kind = manifest.kind ?? (manifest.notification ? 'notification' : 'delivery');
+      const target = manifest.deliveryTarget ?? 'default';
+
+      if (kind === 'notification') {
+        const key = manifest.notification?.idempotencyKey ?? `legacy-notify:${manifest.id ?? file}`;
+        if (manifest.status === 'delivered') {
+          result.delivered++;
+        } else {
+          database.outbox.enqueue({
+            kind: 'notification',
+            deliveryTarget: target,
+            idempotencyKey: key,
+            payload: { text: manifest.notification?.text ?? '' },
+          });
+          result.imported++;
+        }
+      } else {
+        const artifact = manifest.artifact;
+        if (!artifact) {
+          result.skipped++;
+        } else if (manifest.status === 'delivered') {
+          // Backfill the ledger fact so delivery dedupe survives the migration.
+          const key = `legacy-delivery:${target}:${artifact.type}:${artifact.pixivId}:${manifest.id ?? file}`;
+          if (!database.deliveries.isDelivered(target, artifact.type, String(artifact.pixivId))) {
+            database.deliveries.backfill({
+              id: require('node:crypto').randomUUID(),
+              deliveryTarget: target,
+              workType: artifact.type,
+              pixivId: String(artifact.pixivId),
+              idempotencyKey: key,
+              remoteStatus: 'legacy_delivered',
+            });
+          }
+          result.delivered++;
+        } else {
+          const idemKey = `legacy-delivery:${target}:${artifact.type}:${artifact.pixivId}:${manifest.id ?? file}`;
+          // Create the ledger intent + outbox row atomically.
+          const { row, created } = database.deliveries.insertIntent({
+            id: require('node:crypto').randomUUID(),
+            deliveryTarget: target,
+            workType: artifact.type,
+            pixivId: String(artifact.pixivId),
+            idempotencyKey: idemKey,
+          });
+          if (created) {
+            const due = manifest.nextAttemptAt ? Date.parse(manifest.nextAttemptAt) : Date.now();
+            database.outbox.enqueue({
+              kind: 'delivery',
+              deliveryTarget: target,
+              idempotencyKey: `outbox:${idemKey}`,
+              deliveryId: row.id,
+              dueAt: Number.isFinite(due) ? due : Date.now(),
+              payload: {
+                files: artifact.files,
+                cleanupFiles: artifact.cleanupFiles ?? [],
+                fields: manifest.request?.fields ?? null,
+                context: {
+                  title: artifact.title,
+                  pixivId: artifact.pixivId,
+                  type: artifact.type,
+                  workTags: artifact.tags,
+                  ...(manifest.request?.context ?? {}),
+                },
+              },
+            });
+            result.imported++;
+          } else {
+            result.skipped++;
+          }
+        }
+      }
+
+      // Commit succeeded (better-sqlite3 is synchronous): archive the manifest.
+      mkdirSync(archiveDir, { recursive: true });
+      renameSync(full, join(archiveDir, file));
+    } catch (error) {
+      result.failed++;
+      logger.warn('Legacy outbox manifest migration failed; will retry next start', {
+        file,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (result.imported > 0 || result.delivered > 0) {
+    logger.info('Legacy JSON outbox migrated to SQLite', result as unknown as Record<string, number>);
+  }
+  return result;
+}

--- a/src/delivery/OutboxWorker.ts
+++ b/src/delivery/OutboxWorker.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from 'node:crypto';
+import { unlink } from 'node:fs/promises';
+import { Database } from '../storage/Database';
+import { OutboxRow, OutboxStatus } from '../storage/repositories/OutboxRepository';
+import { DeliveryDispatcher } from './DeliveryDispatcher';
+import { DeliveryRequest } from './types';
+import { DeliveryAck } from './DeliveryAck';
+import { logger } from '../logger';
+
+export interface OutboxWorkerOptions {
+  /** How often to scan for due rows. */
+  pollIntervalMs?: number;
+  /** Row lease duration while one attempt is in flight. */
+  leaseMs?: number;
+  /** Rows claimed per scan. */
+  batchSize?: number;
+  retryBaseMs?: number;
+  retryMaxMs?: number;
+  /** Fired when a delivery reaches a terminal business state (for the Slot ledger). */
+  onDeliveryTerminal?: (deliveryId: string, ack: DeliveryAck, payload: DeliveryPayload) => void;
+  /** Fired when a delivery is permanently dead (for notifications/doctor). */
+  onDead?: (row: OutboxRow, error: string) => void;
+}
+
+/** Delivery side-effect payload (frozen at enqueue time). */
+export interface DeliveryPayload {
+  files: string[];
+  /** Sidecars + cached media removed after confirmed delivery (cache mode). */
+  cleanupFiles?: string[];
+  deleteAfterDelivery?: boolean;
+  fields?: Record<string, unknown>;
+  context: Record<string, unknown>;
+}
+
+/** Notification side-effect payload. */
+export interface NotificationPayload {
+  text: string;
+}
+
+/** Exponential backoff with jitter, capped. */
+export function backoffDelayMs(attempt: number, base: number, max: number): number {
+  const exp = base * 2 ** Math.min(Math.max(0, attempt - 1), 18);
+  const capped = Math.min(max, exp);
+  // Full jitter: 0.5..1.0 of the delay spreads synchronized workers/retries.
+  return Math.round(capped * (0.5 + Math.random() * 0.5));
+}
+
+/**
+ * Independently pumps the SQLite outbox so deliveries and notifications retry
+ * promptly instead of piggy-backing on the next scheduled download run.
+ * Survives crashes: an in-flight row keeps an expiring lease; a restart claims
+ * it once the lease is stale and retries the SAME idempotent intent.
+ */
+export class OutboxWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private stopped = false;
+  private readonly owner = `worker-${process.pid}-${randomUUID().slice(0, 8)}`;
+  private readonly pollIntervalMs: number;
+  private readonly leaseMs: number;
+  private readonly batchSize: number;
+  private readonly retryBaseMs: number;
+  private readonly retryMaxMs: number;
+
+  constructor(
+    private readonly database: Database,
+    private readonly dispatcher: DeliveryDispatcher,
+    options: OutboxWorkerOptions = {}
+  ) {
+    this.pollIntervalMs = options.pollIntervalMs ?? 10_000;
+    this.leaseMs = options.leaseMs ?? 120_000;
+    this.batchSize = options.batchSize ?? 4;
+    this.retryBaseMs = options.retryBaseMs ?? 30_000;
+    this.retryMaxMs = options.retryMaxMs ?? 6 * 60 * 60_000;
+    if (options.onDeliveryTerminal) this.onDeliveryTerminal = options.onDeliveryTerminal;
+    if (options.onDead) this.onDead = options.onDead;
+  }
+
+  private onDeliveryTerminal: OutboxWorkerOptions['onDeliveryTerminal'] = undefined;
+  private onDead: OutboxWorkerOptions['onDead'] = undefined;
+
+  start(): void {
+    if (this.timer) return;
+    logger.info('Outbox worker started', { pollMs: this.pollIntervalMs, owner: this.owner });
+    // Pump immediately on start so a crash-resume drains without waiting.
+    void this.pump();
+    this.timer = setInterval(() => void this.pump(), this.pollIntervalMs);
+    // Don't keep the event loop alive solely for the pump during shutdown.
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Drain all currently-due rows once (used by CLI / watchdog wake). */
+  async drainOnce(maxRounds = 50): Promise<{ processed: number; done: number; retried: number; dead: number }> {
+    let processed = 0;
+    let done = 0;
+    let retried = 0;
+    let dead = 0;
+    for (let round = 0; round < maxRounds; round++) {
+      const rows = this.database.outbox.claimDue(this.owner, this.leaseMs, this.batchSize);
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        processed++;
+        const result = await this.process(row);
+        if (result === 'done') done++;
+        else if (result === 'dead') dead++;
+        else retried++;
+      }
+    }
+    return { processed, done, retried, dead };
+  }
+
+  private async pump(): Promise<void> {
+    if (this.running || this.stopped) return;
+    this.running = true;
+    try {
+      const rows = this.database.outbox.claimDue(this.owner, this.leaseMs, this.batchSize);
+      for (const row of rows) {
+        if (this.stopped) {
+          this.database.outbox.release(row.id);
+          continue;
+        }
+        await this.process(row);
+      }
+    } catch (error) {
+      logger.warn('Outbox pump failed', { error: error instanceof Error ? error.message : String(error) });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async process(row: OutboxRow): Promise<OutboxStatus> {
+    try {
+      if (row.kind === 'notification') {
+        const payload = JSON.parse(row.payloadJson) as NotificationPayload;
+        await this.dispatcher.notify(row.deliveryTarget, {
+          text: payload.text,
+          idempotencyKey: row.idempotencyKey ?? row.id,
+        });
+      } else {
+        const payload = JSON.parse(row.payloadJson) as DeliveryPayload;
+        const result = await this.dispatcher.deliver(row.deliveryTarget, {
+          files: payload.files,
+          fields: payload.fields as DeliveryRequest['fields'],
+          context: payload.context as unknown as DeliveryRequest['context'],
+        });
+        const ack: DeliveryAck = result.ack ?? {
+          kind: result.status && result.status >= 200 && result.status < 300 ? 'accepted' : 'retryable_failure',
+          error: `no ack (HTTP ${result.status})`,
+        };
+        await this.handleDeliveryAck(row, ack, payload);
+      }
+      this.database.outbox.markDone(row.id);
+      return 'done';
+    } catch (error) {
+      // Transport-level error (fetch threw): retryable.
+      const message = error instanceof Error ? error.message : String(error);
+      const delay = backoffDelayMs(row.attempts + 1, this.retryBaseMs, this.retryMaxMs);
+      const status = this.database.outbox.markRetry(row.id, Date.now() + delay, message);
+      if (status === 'dead') {
+        logger.error('Outbox item dead after max attempts', { outboxId: row.id, kind: row.kind, error: message });
+        this.onDead?.(row, message);
+        if (row.deliveryId) {
+          this.database.deliveries.recordAck(row.deliveryId, { status: 'failed', error: message });
+        }
+      } else {
+        logger.warn('Outbox item will retry', { outboxId: row.id, kind: row.kind, attempt: row.attempts + 1, delayMs: delay });
+      }
+      return status;
+    }
+  }
+
+  private async handleDeliveryAck(row: OutboxRow, ack: DeliveryAck, payload: DeliveryPayload): Promise<void> {
+    if (!row.deliveryId) return;
+    switch (ack.kind) {
+      case 'accepted':
+      case 'idempotent_replay':
+        this.database.deliveries.recordAck(row.deliveryId, {
+          status: 'delivered',
+          remoteId: ack.remoteId,
+          remoteStatus: ack.remoteStatus ?? (ack.kind === 'idempotent_replay' ? 'idempotent_replay' : 'accepted'),
+        });
+        this.onDeliveryTerminal?.(row.deliveryId, ack, payload);
+        await this.cleanup(payload);
+        break;
+      case 'duplicate_existing':
+        this.database.deliveries.recordAck(row.deliveryId, {
+          status: 'duplicate',
+          remoteId: ack.remoteId,
+          remoteStatus: ack.remoteStatus ?? 'duplicate_existing',
+          reuseReason: 'historical_duplicate',
+        });
+        this.onDeliveryTerminal?.(row.deliveryId, ack, payload);
+        break;
+      case 'permanent_failure':
+        // Deterministic rejection: still retry a couple times to survive a
+        // misconfigured blip, the outbox max-attempts then dead-letters it.
+        throw new Error(`permanent delivery failure: ${ack.error}`);
+      case 'retryable_failure':
+        throw new Error(`retryable delivery failure: ${ack.error}`);
+    }
+  }
+
+  private async cleanup(payload: DeliveryPayload): Promise<void> {
+    if (payload.deleteAfterDelivery === false) return;
+    const files = [...(payload.files ?? []), ...(payload.cleanupFiles ?? [])];
+    await Promise.all(
+      [...new Set(files)].map((file) =>
+        unlink(file).catch((error: NodeJS.ErrnoException) => {
+          if (error.code !== 'ENOENT') logger.debug('cache cleanup failed', { file, error: error.message });
+        })
+      )
+    );
+  }
+}

--- a/src/delivery/types.ts
+++ b/src/delivery/types.ts
@@ -61,6 +61,13 @@ export interface DeliveryContext {
   occurrenceAt?: string;
   /** Why the run started: cron | http | manual | catchup. */
   triggerSource?: string;
+  /**
+   * Occurrence-scoped intent key (e.g. pixivflow:<target>:<type>:<id>:<slot>:<targetId>).
+   * Sent downstream as idempotency_key so an ACK-loss retry carrying the SAME
+   * key converges to one remote record (idempotent_replay), distinct from a
+   * historical duplicate of the same work from a different occurrence.
+   */
+  idempotencyKey?: string;
   /** Schedule slot provenance for review-source labelling (external/scheduled runs). */
   slotId?: string;
   slotName?: string;

--- a/src/delivery/types.ts
+++ b/src/delivery/types.ts
@@ -73,9 +73,13 @@ export interface DeliveryRequest {
   context: DeliveryContext;
 }
 
+import type { DeliveryAck } from './DeliveryAck';
+
 export interface DeliveryResult {
   status?: number;
   body?: unknown;
+  /** Normalized business acknowledgement (present on delivery attempts). */
+  ack?: DeliveryAck;
 }
 
 export interface DeliveryNotificationRequest {
@@ -85,5 +89,6 @@ export interface DeliveryNotificationRequest {
 
 export interface DeliveryProvider {
   deliver(request: DeliveryRequest): Promise<DeliveryResult>;
+  /** One notification attempt; the durable outbox owns retries. */
   notify?(request: DeliveryNotificationRequest): Promise<DeliveryResult>;
 }

--- a/src/download/DownloadManager.ts
+++ b/src/download/DownloadManager.ts
@@ -128,8 +128,16 @@ export class DownloadManager implements IDownloadManager {
       downloadConcurrency,
       storagePath
     );
-    this.novelDownloader = new NovelDownloader(client, database, fileService);
-    this.planner = new DownloadPlanner(database);
+    this.novelDownloader = new NovelDownloader(
+      client,
+      database,
+      fileService,
+      database as unknown as import('../storage/Database').Database
+    );
+    this.planner = new DownloadPlanner(database, {
+      deliveredIds: (target, type, ids) =>
+        this.deliveryService.deliveredIds(target, type, ids),
+    });
     this.executor = new DownloadExecutor();
 
     const downloadConfig = config.download ?? {};
@@ -166,6 +174,13 @@ export class DownloadManager implements IDownloadManager {
         retryMaxDelayMs: config.delivery?.outboxRetryMaxMs,
         onDeliver: (artifact, target) => this.onWorkLocked?.(artifact, target),
       }
+    );
+
+    // Delivery ledger + SQLite outbox. Requires the concrete Database (with the
+    // deliveries/outbox repositories). Unit tests pass plain mock databases; in
+    // that case delivery dedupe/enqueue is simply inactive.
+    this.deliveryService = new DeliveryService(
+      database as unknown as import('../storage/Database').Database
     );
 
     // One lazily-created topic pipeline (shared resolver/cache) for this run.

--- a/src/download/DownloadManager.ts
+++ b/src/download/DownloadManager.ts
@@ -15,6 +15,8 @@ import { DownloadPipeline } from './pipeline/DownloadPipeline';
 import { OperationCancelledError } from '../utils/errors';
 import { DeliveryDispatcher } from '../delivery/DeliveryDispatcher';
 import { DeliveryOutbox } from '../delivery/DeliveryOutbox';
+import { DeliveryService } from '../delivery/DeliveryService';
+import { TargetOutcome } from '../scheduler/TargetOutcome';
 import { dirname, join } from 'node:path';
 import { IllustrationTargetHandler } from './handlers/IllustrationTargetHandler';
 import { NovelTargetHandler } from './handlers/NovelTargetHandler';
@@ -59,13 +61,14 @@ export class DownloadManager implements IDownloadManager {
   private cancelled = false;
   private cancelReason = '';
   private readonly deliveryOutbox: DeliveryOutbox;
-  /** Per-target outcome hook (used by the Slot ledger to record cell results). */
-  private onTargetOutcome: ((target: TargetConfig, error?: string) => void) | null = null;
-  /** Fired when a work is locked for delivery (fresh or outbox replay). */
+  private readonly deliveryService!: DeliveryService;
+  /** Per-target TYPED outcome hook (the Slot ledger maps it to cell transitions). */
+  private onTargetOutcome: ((target: TargetConfig, outcome: TargetOutcome) => void) | null = null;
+  /** Fired when a Pixiv work is selected and locked for a target. */
   private onWorkLocked: ((artifact: { pixivId: string; type: string }, target: TargetConfig) => void) | null = null;
 
-  /** Register a callback fired after each target with the error if it failed. */
-  public setTargetOutcomeHook(fn: (target: TargetConfig, error?: string) => void): void {
+  /** Register a callback fired after each target with its explicit business outcome. */
+  public setTargetOutcomeHook(fn: (target: TargetConfig, outcome: TargetOutcome) => void): void {
     this.onTargetOutcome = fn;
   }
 
@@ -73,6 +76,21 @@ export class DownloadManager implements IDownloadManager {
   public setWorkLockedHook(fn: (artifact: { pixivId: string; type: string }, target: TargetConfig) => void): void {
     this.onWorkLocked = fn;
   }
+
+  /** Expose delivery service for handlers (preflight + intent creation). */
+  public get deliveries(): DeliveryService {
+    return this.deliveryService;
+  }
+
+  /** Slot context propagated to delivery templates/outcomes for scheduled runs. */
+  public slotContext?: {
+    slotId: string;
+    scheduleId: string;
+    occurrenceAtIso: string;
+    triggerSource: string;
+    slotName: string;
+    slotDate: string;
+  };
 
   /**
    * Request cooperative cancellation of the current run. In-flight item
@@ -166,7 +184,8 @@ export class DownloadManager implements IDownloadManager {
       this.illustrationDownloader,
       this.pipeline,
       this.deliveryOutbox,
-      topicFactory
+      topicFactory,
+      this.deliveryService
     );
 
     this.novelHandler = new NovelTargetHandler(
@@ -176,7 +195,8 @@ export class DownloadManager implements IDownloadManager {
       this.pipeline,
       this.novelDownloader,
       this.deliveryOutbox,
-      topicFactory
+      topicFactory,
+      this.deliveryService
     );
   }
 
@@ -189,13 +209,8 @@ export class DownloadManager implements IDownloadManager {
   }
 
   public async runAllTargets() {
-    const pending = await this.deliveryOutbox.retryPending();
-    if (pending.succeeded > 0 || pending.failed > 0) {
-      logger.info('Processed pending deliveries', { ...pending });
-    } else if (pending.deferred > 0) {
-      logger.debug('Pending deliveries remain in backoff', { ...pending });
-    }
-
+    // NOTE: pending deliveries are pumped independently by the OutboxWorker,
+    // not piggy-backed onto the next download run. No retryPending() here.
     const totalTargets = this.config.targets.length;
 
     if (totalTargets === 0) {
@@ -217,13 +232,17 @@ export class DownloadManager implements IDownloadManager {
       this.updateProgress(currentTarget, totalTargets, `处理目标: ${targetName} (${target.type})`);
 
       try {
-        await this.dispatchTarget(target);
-        this.onTargetOutcome?.(target);
+        const outcome = await this.dispatchTarget(target);
+        this.onTargetOutcome?.(target, outcome);
+        if (outcome.kind === 'failed' && !outcome.retryable) {
+          errors.push({ target: `${targetName} (${target.type})`, error: outcome.error });
+        }
       } catch (error) {
+        // A raw escape means an unexpected/retryable infrastructure failure.
         const errorMessage = error instanceof Error ? error.message : String(error);
         errors.push({ target: `${targetName} (${target.type})`, error: errorMessage });
         logger.error(`Target ${targetName} (${target.type}) failed, continuing with next target`, { error: errorMessage });
-        this.onTargetOutcome?.(target, errorMessage);
+        this.onTargetOutcome?.(target, { kind: 'failed', retryable: true, error: errorMessage });
       }
     }
 
@@ -246,16 +265,15 @@ export class DownloadManager implements IDownloadManager {
     }
   }
 
-  private async dispatchTarget(target: TargetConfig): Promise<void> {
+  private async dispatchTarget(target: TargetConfig): Promise<TargetOutcome> {
     switch (target.type) {
       case 'illustration':
-        await this.illustrationHandler.handle(target);
-            break;
+        return await this.illustrationHandler.handle(target);
       case 'novel':
-        await this.novelHandler.handle(target);
-              break;
+        return await this.novelHandler.handle(target);
       default:
         logger.warn(`Unsupported target type ${target.type}`);
+        return { kind: 'failed', retryable: false, error: `unsupported target type ${target.type}` };
     }
   }
 

--- a/src/download/NovelDownloader.ts
+++ b/src/download/NovelDownloader.ts
@@ -7,15 +7,42 @@ import { IFileService } from '../interfaces/IFileService';
 import { PixivNovel } from '../pixiv/PixivClient';
 import { detectLanguage } from '../utils/language-detection';
 import { DownloadedArtifact } from '../delivery/types';
+import type { Database } from '../storage/Database';
+
+const LANGUAGE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export class NovelDownloader {
   constructor(
     private readonly client: IPixivClient,
     private readonly database: IDatabase,
-    private readonly fileService: IFileService
+    private readonly fileService: IFileService,
+    private readonly metadataDb?: Database
   ) {}
 
   async download(novel: PixivNovel, tag: string, target: TargetConfig): Promise<DownloadedArtifact | undefined> {
+    // Metadata cache: language filtering otherwise pulls FULL text per candidate
+    // on every fallback run. A cached classification short-circuits to the same
+    // skip decision without any Pixiv request (bounded detail/text fetch volume).
+    if (target.languageFilter && this.metadataDb) {
+      const cached = this.metadataDb?.metadata?.fresh?.(String(novel.id), 'novel', LANGUAGE_CACHE_TTL_MS);
+      if (cached?.language) {
+        const isChinese = cached.language.includes('Chinese') || cached.language.startsWith('zh');
+        const wanted =
+          (target.languageFilter === 'chinese' && isChinese) ||
+          (target.languageFilter === 'non-chinese' && !isChinese);
+        if (!wanted) {
+          const reason = target.languageFilter === 'chinese' ? 'not Chinese' : 'is Chinese';
+          logger.info(`Novel ${novel.id} language filter from cache (${cached.language}): ${reason}`, {
+            novelId: novel.id, filter: target.languageFilter, cached: true,
+          });
+          throw new Error(
+            `Novel ${novel.id} skipped: language filter mismatch (cached: ${cached.language}, required: ${target.languageFilter})`
+          );
+        }
+        // Cached match: still need full text to deliver; fall through to fetch.
+      }
+    }
+
     const { novel: detail, tags } = await this.client.getNovelDetailWithTags(novel.id);
     // getNovelText resolves to the API envelope { novel_text }; unwrap it here,
     // otherwise the object gets stringified to "[object Object]" and the
@@ -38,7 +65,7 @@ export class NovelDownloader {
 
     if (enableDetection) {
       const fullContent = `${detail.title}\n${text}`;
-      detectedLang = detectLanguage(fullContent);
+      detectedLang = await detectLanguage(fullContent);
 
       if (detectedLang) {
         logger.info(`Detected language for novel ${detail.id}: ${detectedLang.name} (${detectedLang.code})`, {
@@ -46,6 +73,12 @@ export class NovelDownloader {
           language: detectedLang.name,
           code: detectedLang.code,
           isChinese: detectedLang.isChinese,
+        });
+        this.metadataDb?.metadata?.put?.(String(detail.id), 'novel', {
+          language: detectedLang.name,
+          xRestrict: (detail as { x_restrict?: number }).x_restrict ?? (novel as { x_restrict?: number }).x_restrict ?? null,
+          publishedAt: detail.create_date ?? novel.create_date ?? null,
+          title: detail.title,
         });
       } else {
         logger.debug(`Language detection inconclusive for novel ${detail.id} (text may be too short)`);

--- a/src/download/handlers/IllustrationTargetHandler.ts
+++ b/src/download/handlers/IllustrationTargetHandler.ts
@@ -10,10 +10,15 @@ import { NetworkError } from '../../utils/errors';
 import { calculatePopularityScore } from '../../utils/pixiv-utils';
 import { PixivIllust } from '../../pixiv/PixivClient';
 import { DeliveryOutbox } from '../../delivery/DeliveryOutbox';
+import { DeliveryService } from '../../delivery/DeliveryService';
+import { TargetOutcome } from '../../scheduler/TargetOutcome';
 import type { TopicPipelineFactory } from '../../topic/createTopicPipeline';
 import { getTargetLabel } from '../../utils/target-label';
 
 export class IllustrationTargetHandler {
+  /** Outcomes produced during this handle() call (deliveries + terminal non-matches). */
+  private outcomes: TargetOutcome[] = [];
+
   constructor(
     private readonly client: IPixivClient,
     private readonly database: IDatabase,
@@ -21,18 +26,20 @@ export class IllustrationTargetHandler {
     private readonly illustrationDownloader: IllustrationDownloader,
     private readonly pipeline: DownloadPipeline,
     private readonly deliveryOutbox?: DeliveryOutbox,
-    private readonly topicPipelineFactory?: TopicPipelineFactory
+    private readonly topicPipelineFactory?: TopicPipelineFactory,
+    private readonly deliveryService?: DeliveryService
   ) {}
 
-  async handle(target: TargetConfig): Promise<void> {
+  async handle(target: TargetConfig): Promise<TargetOutcome> {
+    this.outcomes = [];
     if (target.illustId) {
       await this.handleSingleIllustration(target);
-      return;
+      return this.summarize(target);
     }
 
     if (target.userId) {
       await this.handleUserIllustrations(target);
-      return;
+      return this.summarize(target);
     }
 
     const mode = target.mode || 'search';
@@ -42,7 +49,7 @@ export class IllustrationTargetHandler {
     try {
       if (mode === 'topic') {
         await this.handleTopicWithLookback(target, displayTag);
-        return;
+        return this.summarize(target);
       }
       const illusts = await this.fetchIllustrations(target, mode);
       const result = await this.pipeline.run(
@@ -52,12 +59,41 @@ export class IllustrationTargetHandler {
         (illust, tag) => this.downloadAndDeliver(illust, tag, target)
       );
       this.handleDownloadResult(result, target, mode, illusts.length);
+      return this.summarize(target);
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith('No matching illustrations found after checking')) {
-        throw error;
-      }
-      await this.handleError(error, displayTag, mode, target);
+      return this.classifyError(error, displayTag, mode, target);
     }
+  }
+
+  /** Reduce the outcomes collected while processing one target to one cell result. */
+  private summarize(target: TargetConfig): TargetOutcome {
+    const submitted = this.outcomes.find((o) => o.kind === 'submitted');
+    if (submitted) return submitted;
+    const stored = this.outcomes.find((o) => o.kind === 'stored');
+    if (stored) return stored;
+    const pending = this.outcomes.find((o) => o.kind === 'delivery_pending');
+    if (pending) return pending;
+    const duplicate = this.outcomes.find((o) => o.kind === 'duplicate');
+    if (duplicate) return duplicate;
+    const failed = this.outcomes.find((o) => o.kind === 'failed');
+    if (failed) return failed;
+    return { kind: 'no_candidate', reason: 'no matching illustration after filtering/dedupe' };
+  }
+
+  private classifyError(error: unknown, displayTag: string, mode: string, target: TargetConfig): TargetOutcome {
+    const message = error instanceof Error ? error.message : String(error);
+    this.database.logExecution(displayTag, 'illustration', 'failed', message);
+    logger.error(`Illustration ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, {
+      error: message,
+      errorType: error instanceof Error ? error.constructor.name : typeof error,
+    });
+    // Explicit no-candidate signals are business outcomes, not failures.
+    if (/no matching|all .*filtered|no_candidate/i.test(message)) {
+      return { kind: 'no_candidate', reason: message };
+    }
+    // Network/transient => retryable so the SAME work resumes on next trigger.
+    const retryable = error instanceof NetworkError || /timeout|econn|enotfound|etimed|429|5dd/i.test(message);
+    return { kind: 'failed', retryable, error: message };
   }
 
   private async fetchIllustrations(target: TargetConfig, mode: string): Promise<PixivIllust[]> {
@@ -131,8 +167,7 @@ export class IllustrationTargetHandler {
     const message = `No matching illustrations found after checking ${checkedDays.length} day(s): ${checkedDays.join(', ')}`;
     this.database.logExecution(displayTag, 'illustration', 'success', message);
     logger.warn(`Illustration topic ${displayTag} produced no matching result`, { checkedDays });
-    await this.notifyNoMatch(target, displayTag, checkedDays);
-    throw new Error(message);
+    this.outcomes.push({ kind: 'no_candidate', reason: message });
   }
 
   private resolveTopicDay(target: TargetConfig): string {
@@ -294,72 +329,18 @@ export class IllustrationTargetHandler {
             `多为网络/Pixiv 瞬时错误，下次计划会自动重试；同一作品持续失败请查日志（可能为已删除/私密/R-18 权限）。`
           : `No new illustrations for ${tagForLog}: requested ${targetLimit}, but no matching illustrations were found.`;
       this.database.logExecution(tagForLog, 'illustration', 'failed', errorMessage);
-      logger.error(`Illustration ${mode === 'ranking' ? 'ranking' : 'tag'} ${tagForLog} failed: ${errorMessage}`);
-      throw new Error(errorMessage);
+      logger.warn(`Illustration ${mode === 'ranking' ? 'ranking' : 'tag'} ${tagForLog}: ${errorMessage}`);
+      // Skipped due to transient errors => no terminal submitted; caller retries.
+      this.outcomes.push({
+        kind: 'failed',
+        retryable: skipped > 0,
+        error: errorMessage,
+      });
     }
   }
 
-  private async handleError(error: unknown, displayTag: string, mode: string, target?: TargetConfig): Promise<void> {
-    let errorMessage = error instanceof Error ? error.message : String(error);
-
-    if (error instanceof NetworkError && error.cause) {
-      const causeMsg = error.cause instanceof Error ? error.cause.message : String(error.cause);
-      errorMessage = `${errorMessage} (原因: ${causeMsg})`;
-    }
-
-    if (error instanceof NetworkError && error.url) {
-      errorMessage = `${errorMessage} [URL: ${error.url}]`;
-    }
-
-    this.database.logExecution(displayTag, 'illustration', 'failed', errorMessage);
-    logger.error(`Illustration ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, {
-      error: errorMessage,
-      errorType: error instanceof Error ? error.constructor.name : typeof error,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    await this.notifyDownloadFailure(target, displayTag, errorMessage);
-
-    throw error;
-  }
-
-  /** Notify the review group when a target's download hard-fails (not just a no-match). */
-  private async notifyDownloadFailure(target: TargetConfig | undefined, label: string, errorMessage: string): Promise<void> {
-    if (!target?.delivery?.target?.trim()) return;
-    if (!this.deliveryOutbox) {
-      logger.warn('Download-failure notification requested but delivery outbox is unavailable');
-      return;
-    }
-    const truncated = errorMessage.length > 200 ? `${errorMessage.slice(0, 200)}…` : errorMessage;
-    const text = [
-      '❌ PixivFlow 本次下载失败',
-      `目标：${target.id || label}（${label} · 插画）`,
-      `错误：${truncated}`,
-      '处理结果：本次未投递；可点击「🔄 重抓/换一张」重试，或等待下次定时任务。',
-    ].join('\n');
-    const key = `pixivflow:hard-fail:${target.id || label}:illustration:${getTodayDate()}`;
-    try {
-      await this.deliveryOutbox.notifyNoMatch(target, text, key);
-    } catch (notifyError) {
-      logger.warn('Failed to send download-failure notification', { label, errorMessage, notifyError });
-    }
-  }
-
-  private async notifyNoMatch(target: TargetConfig, label: string, checkedDays: string[]): Promise<void> {
-    if (target.noMatchPolicy?.notify !== true || !this.deliveryOutbox) return;
-    const text = [
-      '⚠️ PixivFlow 本次没有可投稿内容',
-      `目标：${target.id || label}（${label} · 插画）`,
-      `检查日期：${checkedDays.join('、')}`,
-      '处理结果：未创建空投稿；下次定时任务会继续正常执行。',
-    ].join('\n');
-    const key = `pixivflow:no-match:${target.id || label}:illustration:${checkedDays[0]}:${checkedDays.at(-1)}`;
-    try {
-      await this.deliveryOutbox.notifyNoMatch(target, text, key);
-    } catch (error) {
-      logger.warn('Failed to send no-match notification', { label, error });
-    }
-  }
+  // Notifications are produced centrally by NotificationPolicy (slot-scoped
+  // keys), not per-handler with date-based keys. See noteOutcome/sendSlotSummary.
 
   private async handleSingleIllustration(target: TargetConfig): Promise<void> {
     const illustId = Number(target.illustId);
@@ -481,8 +462,54 @@ export class IllustrationTargetHandler {
         maxPageCount: target.maxPageCount,
       }
     );
-    if (artifact && this.deliveryOutbox) {
-      await this.deliveryOutbox.deliver(artifact, target);
+    if (!artifact) return;
+    this.recordArtifactOutcome(artifact, target);
+  }
+
+  /**
+   * Turn a downloaded artifact into the target's business outcome. In cache
+   * delivery mode the DeliveryService creates the durable intent atomically and
+   * the result is 'delivery_pending' (NOT submitted — the OutboxWorker confirms
+   * the ACK). Persistent/download-only runs are 'stored'.
+   */
+  private recordArtifactOutcome(
+    artifact: import('../../delivery/types').DownloadedArtifact,
+    target: TargetConfig
+  ): void {
+    const isDelivery = target.storageMode === 'cache' && target.delivery?.target?.trim();
+    if (!isDelivery || !this.deliveryService) {
+      this.outcomes.push({ kind: 'stored', workId: artifact.pixivId, workType: artifact.type });
+      return;
     }
+    // Pre-lock delivery dedupe (after selection): if the ledger already knows it,
+    // that is a confirmed fact, not a new submission.
+    const slotId = (target.delivery as { executionContext?: { slotId?: string } } | undefined)?.executionContext?.slotId;
+    if (this.deliveryService.isAlreadyDelivered(target.delivery!.target!, artifact.type, artifact.pixivId)) {
+      this.outcomes.push({ kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered to target (ledger)' });
+      return;
+    }
+    const res = this.deliveryService.enqueue(artifact, target, {
+      slotId,
+      fields: target.delivery?.fields as Record<string, unknown> | undefined,
+      extraContext: this.executionContextFields(target),
+    });
+    if (res.duplicate) {
+      this.outcomes.push({ kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered to target (ledger)' });
+    } else {
+      this.outcomes.push({ kind: 'delivery_pending', workId: artifact.pixivId, workType: artifact.type, deliveryId: res.deliveryId });
+    }
+  }
+
+  private executionContextFields(target: TargetConfig): Record<string, unknown> {
+    const ec = (target.delivery as { executionContext?: Record<string, unknown>; slotContext?: Record<string, unknown> } | undefined);
+    return {
+      scheduleId: ec?.executionContext?.scheduleId,
+      executionId: ec?.executionContext?.slotId,
+      occurrenceAt: ec?.executionContext?.occurrenceAtIso,
+      triggerSource: ec?.executionContext?.triggerSource,
+      slotId: ec?.slotContext?.slotId ?? ec?.executionContext?.slotId,
+      slotName: ec?.slotContext?.slotName ?? ec?.executionContext?.slotName,
+      slotDate: ec?.slotContext?.slotDate ?? ec?.executionContext?.slotDate,
+    };
   }
 }

--- a/src/download/handlers/NovelTargetHandler.ts
+++ b/src/download/handlers/NovelTargetHandler.ts
@@ -10,10 +10,14 @@ import { getTodayDate, getYesterdayDate } from '../../utils/pixiv-date-utils';
 import { calculatePopularityScore } from '../../utils/pixiv-utils';
 import { PixivNovel } from '../../pixiv/PixivClient';
 import { DeliveryOutbox } from '../../delivery/DeliveryOutbox';
+import { DeliveryService } from '../../delivery/DeliveryService';
+import { TargetOutcome } from '../../scheduler/TargetOutcome';
 import type { TopicPipelineFactory } from '../../topic/createTopicPipeline';
 import { getTargetLabel } from '../../utils/target-label';
 
 export class NovelTargetHandler {
+  private outcomes: TargetOutcome[] = [];
+
   constructor(
     private readonly client: IPixivClient,
     private readonly database: IDatabase,
@@ -21,23 +25,33 @@ export class NovelTargetHandler {
     private readonly pipeline: DownloadPipeline,
     private readonly novelDownloader: NovelDownloader,
     private readonly deliveryOutbox?: DeliveryOutbox,
-    private readonly topicPipelineFactory?: TopicPipelineFactory
+    private readonly topicPipelineFactory?: TopicPipelineFactory,
+    private readonly deliveryService?: DeliveryService
   ) {}
 
-  async handle(target: TargetConfig): Promise<void> {
-    if (target.novelId) {
+  async handle(target: TargetConfig): Promise<TargetOutcome> {
+    this.outcomes = [];
+    if (target.novelId !== undefined && target.novelId !== null && target.novelId !== ('' as unknown)) {
+      const novelNum = typeof target.novelId === 'number' ? target.novelId : Number(target.novelId);
+      if (!Number.isFinite(novelNum)) {
+        return { kind: 'failed', retryable: false, error: `Invalid novelId: ${String(target.novelId)}` };
+      }
       await this.handleSingleNovel(target);
-      return;
+      return this.summarize();
     }
 
-    if (target.seriesId) {
+    if (target.seriesId !== undefined && target.seriesId !== null && target.seriesId !== ('' as unknown)) {
+      const seriesNum = typeof target.seriesId === 'number' ? target.seriesId : Number(target.seriesId);
+      if (!Number.isFinite(seriesNum)) {
+        return { kind: 'failed', retryable: false, error: `Invalid seriesId: ${String(target.seriesId)}` };
+      }
       await this.handleSeries(target);
-      return;
+      return this.summarize();
     }
 
     if (target.userId) {
       await this.handleUserNovels(target);
-      return;
+      return this.summarize();
     }
 
     const mode = target.mode || 'search';
@@ -47,7 +61,7 @@ export class NovelTargetHandler {
     try {
       if (mode === 'topic' && target.languageFilter && (target.noMatchPolicy?.lookbackDays ?? 0) > 0) {
         await this.handleTopicWithLookback(target, displayTag);
-        return;
+        return this.summarize();
       }
       const novels = await this.fetchNovels(target, mode);
       const result = await this.pipeline.run(
@@ -57,9 +71,34 @@ export class NovelTargetHandler {
         (novel, tag) => this.downloadAndDeliver(novel, tag, target)
       );
       await this.handleDownloadResult(result, target, mode, novels.length);
+      return this.summarize();
     } catch (error) {
-      await this.handleError(error, displayTag, mode, target);
+      return this.classifyError(error, displayTag, mode);
     }
+  }
+
+  private summarize(): TargetOutcome {
+    return (
+      this.outcomes.find((o) => o.kind === 'submitted') ??
+      this.outcomes.find((o) => o.kind === 'stored') ??
+      this.outcomes.find((o) => o.kind === 'delivery_pending') ??
+      this.outcomes.find((o) => o.kind === 'duplicate') ??
+      this.outcomes.find((o) => o.kind === 'failed') ?? {
+        kind: 'no_candidate',
+        reason: 'no matching novel after filtering/dedupe',
+      }
+    );
+  }
+
+  private classifyError(error: unknown, displayTag: string, mode: string): TargetOutcome {
+    const message = error instanceof Error ? error.message : String(error);
+    this.database.logExecution(displayTag, 'novel', 'failed', message);
+    logger.error(`Novel ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, { error: message });
+    if (/no matching|all .*filtered|no_candidate|language filter/i.test(message)) {
+      return { kind: 'no_candidate', reason: message };
+    }
+    const retryable = error instanceof NetworkError || /timeout|econn|enotfound|etimed|429|5\d\d/i.test(message);
+    return { kind: 'failed', retryable, error: message };
   }
 
   private async fetchNovels(target: TargetConfig, mode: string): Promise<PixivNovel[]> {
@@ -297,7 +336,7 @@ export class NovelTargetHandler {
         candidates: totalFound,
         checkedDays: days,
       });
-      await this.notifyNoMatch(target, tagForLog, totalFound, days);
+      this.outcomes.push({ kind: 'no_candidate', reason: message });
     } else if (alreadyDownloaded > 0 && skipped === 0) {
       logger.info(`All ${alreadyDownloaded} novel(s) for tag ${tagForLog} were already downloaded`);
       this.database.logExecution(
@@ -327,87 +366,12 @@ export class NovelTargetHandler {
             `多为网络/Pixiv 瞬时错误，下次计划会自动重试；持续失败请查日志。`
           : `Failed to download any novels. Requested ${targetLimit}, but no matching novels were found.`;
       this.database.logExecution(tagForLog, 'novel', 'failed', errorMessage);
-      logger.error(`Novel ${mode === 'ranking' ? 'ranking' : 'tag'} ${tagForLog} failed: ${errorMessage}`);
-      throw new Error(errorMessage);
+      logger.warn(`Novel ${mode === 'ranking' ? 'ranking' : 'tag'} ${tagForLog}: ${errorMessage}`);
+      this.outcomes.push({ kind: 'failed', retryable: skipped > 0, error: errorMessage });
     }
   }
 
-  private async notifyNoMatch(
-    target: TargetConfig,
-    label: string,
-    candidateCount: number,
-    checkedDays: string[]
-  ): Promise<void> {
-    if (target.noMatchPolicy?.notify !== true) return;
-    if (!this.deliveryOutbox) {
-      logger.warn('No-match notification requested but delivery outbox is unavailable');
-      return;
-    }
-    const language = target.languageFilter === 'chinese' ? '中文正文' : '非中文正文';
-    const text = [
-      '⚠️ PixivFlow 本次没有可投稿内容',
-      `目标：${target.id || label}（${label} · 小说）`,
-      `要求：${language}，主题与语言条件未放宽`,
-      `检查日期：${checkedDays.join('、')}`,
-      `候选数量：${candidateCount}`,
-      '处理结果：未创建空投稿；下次定时任务会继续正常执行。',
-    ].join('\n');
-    const key = `pixivflow:no-match:${target.id || label}:novel:${checkedDays[0]}:${checkedDays.at(-1)}`;
-    try {
-      await this.deliveryOutbox.notifyNoMatch(target, text, key);
-    } catch (error) {
-      logger.warn('Failed to send no-match notification', {
-        target: target.id || label,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  private async handleError(error: unknown, displayTag: string, mode: string, target?: TargetConfig): Promise<void> {
-    let errorMessage = error instanceof Error ? error.message : String(error);
-
-    if (error instanceof NetworkError && error.cause) {
-      const causeMsg = error.cause instanceof Error ? error.cause.message : String(error.cause);
-      errorMessage = `${errorMessage} (原因: ${causeMsg})`;
-    }
-
-    if (error instanceof NetworkError && error.url) {
-      errorMessage = `${errorMessage} [URL: ${error.url}]`;
-    }
-
-    this.database.logExecution(displayTag, 'novel', 'failed', errorMessage);
-    logger.error(`Novel ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, {
-      error: errorMessage,
-      errorType: error instanceof Error ? error.constructor.name : typeof error,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    await this.notifyDownloadFailure(target, displayTag, errorMessage);
-
-    throw error;
-  }
-
-  /** Notify the review group when a target's download hard-fails (not just a no-match). */
-  private async notifyDownloadFailure(target: TargetConfig | undefined, label: string, errorMessage: string): Promise<void> {
-    if (!target?.delivery?.target?.trim()) return;
-    if (!this.deliveryOutbox) {
-      logger.warn('Download-failure notification requested but delivery outbox is unavailable');
-      return;
-    }
-    const truncated = errorMessage.length > 200 ? `${errorMessage.slice(0, 200)}…` : errorMessage;
-    const text = [
-      '❌ PixivFlow 本次下载失败',
-      `目标：${target.id || label}（${label} · 小说）`,
-      `错误：${truncated}`,
-      '处理结果：本次未投递；可点击「🔄 重抓/换一张」重试，或等待下次定时任务。',
-    ].join('\n');
-    const key = `pixivflow:hard-fail:${target.id || label}:novel:${getTodayDate()}`;
-    try {
-      await this.deliveryOutbox.notifyNoMatch(target, text, key);
-    } catch (notifyError) {
-      logger.warn('Failed to send download-failure notification', { label, errorMessage, notifyError });
-    }
-  }
+  // Notifications are centralized in NotificationPolicy (slot-scoped keys).
 
   private async handleSingleNovel(target: TargetConfig): Promise<void> {
     const novelId = Number(target.novelId);
@@ -571,8 +535,26 @@ export class NovelTargetHandler {
     target: TargetConfig
   ): Promise<void> {
     const artifact = await this.novelDownloader.download(novel, tag, target);
-    if (artifact && this.deliveryOutbox) {
-      await this.deliveryOutbox.deliver(artifact, target);
+    if (!artifact) return;
+    const isDelivery = target.storageMode === 'cache' && target.delivery?.target?.trim();
+    if (!isDelivery || !this.deliveryService) {
+      this.outcomes.push({ kind: 'stored', workId: artifact.pixivId, workType: artifact.type });
+      return;
     }
+    const ec = target.delivery as { executionContext?: { slotId?: string } } | undefined;
+    const slotId = ec?.executionContext?.slotId;
+    if (this.deliveryService.isAlreadyDelivered(target.delivery!.target!, artifact.type, artifact.pixivId)) {
+      this.outcomes.push({ kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered to target (ledger)' });
+      return;
+    }
+    const res = this.deliveryService.enqueue(artifact, target, {
+      slotId,
+      fields: target.delivery?.fields as Record<string, unknown> | undefined,
+    });
+    this.outcomes.push(
+      res.duplicate
+        ? { kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered (ledger)' }
+        : { kind: 'delivery_pending', workId: artifact.pixivId, workType: artifact.type, deliveryId: res.deliveryId }
+    );
   }
 }

--- a/src/download/plan/DownloadPlanner.ts
+++ b/src/download/plan/DownloadPlanner.ts
@@ -30,8 +30,16 @@ export interface PlannedDownload<T extends DownloadItem> {
 /**
  * Centralizes planning logic (filtering, deduplication, already-downloaded detection, random selection).
  */
+export interface DeliveryDedupeSource {
+  /** Returns the subset of ids already CONFIRMED delivered to this target. */
+  deliveredIds?(deliveryTarget: string, workType: 'illustration' | 'novel', ids: string[]): Set<string>;
+}
+
 export class DownloadPlanner {
-  constructor(private readonly database: IDatabase) {}
+  constructor(
+    private readonly database: IDatabase,
+    private readonly deliveryDedupe?: DeliveryDedupeSource
+  ) {}
 
   planDownloads<T extends DownloadItem>(
     items: T[],
@@ -44,8 +52,38 @@ export class DownloadPlanner {
     const itemIds = deduplicatedItems.map((item) => String(item.id));
     const downloadedIds =
       itemIds.length > 0 ? this.database.getDownloadedIds(itemIds, itemType) : new Set<string>();
-    const available = deduplicatedItems.filter((item) => !downloadedIds.has(String(item.id)));
+    let available = deduplicatedItems.filter((item) => !downloadedIds.has(String(item.id)));
     const alreadyDownloadedCount = deduplicatedItems.length - available.length;
+
+    // DELIVERY dedupe (pre-lock, distinct from download dedupe): skip works
+    // already CONFIRMED delivered to THIS target so ranking falls through to
+    // the next valid candidate instead of selecting a historical duplicate.
+    // Best-effort only: downstream reconciliation remains the final safety net.
+    const deliveryTarget = target.delivery?.target?.trim();
+    let deliveryDuplicateCount = 0;
+    if (
+      deliveryTarget &&
+      this.deliveryDedupe?.deliveredIds &&
+      typeof (this.database as { deliveries?: unknown }).deliveries === 'object'
+    ) {
+      try {
+        const delivered = this.deliveryDedupe.deliveredIds(
+          deliveryTarget,
+          itemType,
+          available.map((item) => String(item.id))
+        );
+        const before = available.length;
+        available = available.filter((item) => !delivered.has(String(item.id)));
+        deliveryDuplicateCount = before - available.length;
+        if (deliveryDuplicateCount > 0) {
+          logger.info(`Delivery dedupe skipped ${deliveryDuplicateCount} already-delivered ${itemType}(s) for ${deliveryTarget}`);
+        }
+      } catch (error) {
+        logger.warn('Delivery dedupe preflight failed; continuing (downstream net remains)', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     const limit = target.limit && target.limit > 0 ? target.limit : 10;
 

--- a/src/notification/NotificationPolicy.ts
+++ b/src/notification/NotificationPolicy.ts
@@ -1,0 +1,108 @@
+import { Database } from '../storage/Database';
+import { DeliveryService } from '../delivery/DeliveryService';
+import { ScheduleConfig, StandaloneConfig, TargetConfig } from '../config';
+import { TargetOutcome } from '../scheduler/TargetOutcome';
+import { SlotContext } from '../scheduler/SlotCoordinator';
+
+/**
+ * Central policy for all operational notifications. Handlers/scheduler do not
+ * decide how or when to notify — they emit domain outcomes and this policy
+ * turns them into durable outbox notifications (kind=notification).
+ *
+ * Every key is anchored to the SLOT identity (slotId), never target+date: the
+ * 10:00 and 18:00 occurrences of one day have distinct slotIds and therefore
+ * distinct notifications. Notification failure never changes a content result.
+ */
+export class NotificationPolicy {
+  constructor(
+    private readonly database: Database,
+    private readonly config: StandaloneConfig
+  ) {}
+
+  private targetName(target: TargetConfig): string | null {
+    return target.delivery?.target?.trim() || null;
+  }
+
+  /** Stable slot-scoped keys (two occurrences on one date never collide). */
+  static keys = {
+    noMatch: (slotId: string, targetId: string) => `notification:${slotId}:${targetId}:no-candidate`,
+    hardFail: (slotId: string, targetId: string) => `notification:${slotId}:${targetId}:failed`,
+    summary: (slotId: string) => `notification:${slotId}:summary`,
+    dead: (slotId: string, targetId: string) => `notification:${slotId}:${targetId}:delivery-dead`,
+  };
+
+  noteOutcome(
+    slotId: string,
+    slot: SlotContext,
+    schedule: ScheduleConfig,
+    target: TargetConfig,
+    outcome: TargetOutcome
+  ): void {
+    const name = this.targetName(target);
+    if (!name) return;
+    const label = target.id || target.filterTag || target.tag || target.type;
+
+    if (outcome.kind === 'no_candidate' && target.noMatchPolicy?.notify === true) {
+      this.send(name, NotificationPolicy.keys.noMatch(slotId, target.id ?? label), [
+        '⚠️ PixivFlow 本次没有可投稿内容',
+        `计划：${schedule.name?.trim() || schedule.id} · ${slot.occurrenceLabel}`,
+        `目标：${label}（${target.type === 'novel' ? '小说' : '插画'}）`,
+        `原因：${outcome.reason.slice(0, 160)}`,
+        '处理结果：未创建空投稿；下次定时任务继续执行。',
+      ].join('\n'));
+    }
+
+    if (outcome.kind === 'failed' && !outcome.retryable) {
+      this.send(name, NotificationPolicy.keys.hardFail(slotId, target.id ?? label), [
+        '❌ PixivFlow 本次处理失败',
+        `计划：${schedule.name?.trim() || schedule.id} · ${slot.occurrenceLabel}`,
+        `目标：${label}（${target.type === 'novel' ? '小说' : '插画'}）`,
+        `错误：${outcome.error.slice(0, 200)}`,
+      ].join('\n'));
+    }
+  }
+
+  /** One consolidated summary per slot, delivered to every notifying target's endpoint. */
+  sendSlotSummary(
+    slot: SlotContext,
+    schedule: ScheduleConfig,
+    rows: Array<{ targetId: string; label: string; workType: string; status: string; workId: string | null; error: string | null }>
+  ): void {
+    const targets = this.config.delivery?.targets ?? {};
+    const notifiable = new Set(
+      Object.keys(targets).filter((n) => targets[n]?.notificationUrl?.trim())
+    );
+    if (notifiable.size === 0 || rows.length === 0) return;
+
+    const icon = (s: string) =>
+      s === 'submitted' ? '✅' : s === 'no_candidate' ? '⚠️' : s === 'duplicate' ? '♱' : s === 'delivery_pending' ? '🕓' : '❌';
+    const lines = rows.map((r) =>
+      `${icon(r.status)} ${r.label}（${r.workType === 'novel' ? '小说' : '插画'}）` +
+      (r.workId ? ` #${r.workId}` : '') +
+      (r.status === 'delivery_pending' ? ' 投递中' : '') +
+      (r.status === 'no_candidate' ? ' 无候选' : '') +
+      (r.status === 'failed' && r.error ? ` ${r.error.slice(0, 120)}` : '')
+    );
+    const submitted = rows.filter((r) => r.status === 'submitted').length;
+    const text = [
+      `${schedule.name?.trim() || schedule.id} · ${slot.occurrenceLabel}`,
+      ...lines,
+      `结果：${submitted === rows.length ? 'success' : submitted > 0 ? 'partial' : 'failed'}（${submitted}/${rows.length} 已确认投递）`,
+    ].join('\n');
+
+    const service = new DeliveryService(this.database);
+    for (const name of notifiable) {
+      service.enqueueNotification(name, text, NotificationPolicy.keys.summary(slot.slotId));
+    }
+  }
+
+  private send(targetName: string, key: string, text: string): void {
+    try {
+      new DeliveryService(this.database).enqueueNotification(targetName, text, key);
+    } catch (error) {
+      // Durable enqueue failure must not unwind the content run.
+      // eslint-disable-next-line no-console
+      console.warn('notification enqueue failed', { targetName, key, error: (error as Error).message });
+    }
+  }
+}

--- a/src/pixiv/PixivClient.ts
+++ b/src/pixiv/PixivClient.ts
@@ -10,6 +10,7 @@ import { PixivAuth } from './AuthClient';
 import { IPixivClient } from '../interfaces/IPixivClient';
 import type { PixivUser, PixivIllust, PixivNovel, PixivIllustPage, PixivNovelTextResponse, PixivTag } from './types';
 import { PixivApiCore } from './client/PixivApiCore';
+import { RateLimitCoordinator } from './RateLimitCoordinator';
 import { IllustService } from './client/IllustService';
 import { NovelService } from './client/NovelService';
 import { MediaDownloadService } from './client/MediaDownloadService';
@@ -22,6 +23,7 @@ export class PixivClient implements IPixivClient {
   private readonly baseUrl = 'https://app-api.pixiv.net/';
   private readonly proxyAgent?: ProxyAgent;
   private readonly apiCore: PixivApiCore;
+  private readonly rateLimiter: RateLimitCoordinator;
   private readonly illustService: IllustService;
   private readonly novelService: NovelService;
   private readonly mediaService: MediaDownloadService;
@@ -77,14 +79,21 @@ export class PixivClient implements IPixivClient {
       }
       return undefined;
     })();
+    // ONE global gate: a 429 anywhere parks the whole Pixiv client, avoiding
+    // inner*outer request amplification. Default request retry is small (the
+    // outbox/scheduler own durable retry across runs).
+    // Default pacing is 0: the gate's job is the shared 429 cooldown, not an
+    // artificial per-request delay. Operators can opt into pacing explicitly.
+    const pace = (network as { requestPacingMs?: number }).requestPacingMs ?? 0;
+    this.rateLimiter = new RateLimitCoordinator(pace);
     this.apiCore = new PixivApiCore({
       baseUrl: 'https://app-api.pixiv.net',
       userAgent: this.config.pixiv.userAgent,
       defaultTimeoutMs: network.timeoutMs ?? 30_000,
-      maxRetries: network.retries ?? 10,
-      rateLimitPerSecond: undefined,
+      maxRetries: network.retries ?? 2,
       proxyUrl: proxyUrlStr,
       getAccessToken: () => this.auth.getAccessToken(),
+      rateLimiter: this.rateLimiter,
     });
 
     // Initialize domain services
@@ -92,6 +101,11 @@ export class PixivClient implements IPixivClient {
     this.novelService = new NovelService(this.apiCore);
     this.mediaService = new MediaDownloadService(this.apiCore);
     this.searchService = new SearchService(this.apiCore);
+  }
+
+  /** Process-wide Pixiv rate-limit gate (used by doctor/health). */
+  getRateLimiter(): RateLimitCoordinator {
+    return this.rateLimiter;
   }
 
   /**

--- a/src/pixiv/RateLimitCoordinator.ts
+++ b/src/pixiv/RateLimitCoordinator.ts
@@ -1,0 +1,64 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+/**
+ * Process-wide Pixiv rate-limit coordinator.
+ *
+ * Every Pixiv HTTP request routes through the SAME gate. On a 429 (or an
+ * explicit Retry-After) the WHOLE client enters a cooldown: other candidate
+ * requests due meanwhile wait at the gate instead of hammering Pixiv in
+ * parallel, which is what produced inner*outer retry storms.
+ */
+export class RateLimitCoordinator {
+  private nextAllowedAt = 0;
+  private cooldownUntil = 0;
+  private signals = 0;
+
+  constructor(
+    private readonly minIntervalMs: number = 500,
+    private readonly defaultCooldownMs: number = 2_000,
+    private readonly maxCooldownMs: number = 10 * 60_000,
+    private readonly clock: () => number = () => Date.now()
+  ) {}
+
+  preflightDelay(now: number = this.clock()): number {
+    const dueCooldown = Math.max(0, this.cooldownUntil - now);
+    const duePace = Math.max(0, this.nextAllowedAt - now);
+    return Math.max(dueCooldown, duePace);
+  }
+
+  async acquire(signal?: AbortSignal): Promise<void> {
+    const wait = this.preflightDelay();
+    this.nextAllowedAt = this.clock() + Math.max(wait, this.minIntervalMs);
+    if (wait > 0) await this.sleep(wait, signal);
+  }
+
+  reportRateLimited(retryAfter?: string | null, now: number = this.clock()): number {
+    this.signals++;
+    const hinted = parseRetryAfter(retryAfter, now);
+    const base = hinted ?? Math.min(this.maxCooldownMs, this.defaultCooldownMs * 2 ** Math.min(this.signals - 1, 6));
+    const until = now + Math.min(this.maxCooldownMs, Math.max(1000, base));
+    this.cooldownUntil = Math.max(this.cooldownUntil, until);
+    this.nextAllowedAt = Math.max(this.nextAllowedAt, until);
+    return until - now;
+  }
+
+  reportSuccess(): void { this.signals = 0; }
+
+  get cooldownRemainingMs(): number { return Math.max(0, this.cooldownUntil - this.clock()); }
+
+  status(now: number = this.clock()) {
+    return { cooldownUntil: this.cooldownUntil, cooldownRemainingMs: Math.max(0, this.cooldownUntil - now), signals: this.signals };
+  }
+
+  private async sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    await delay(ms, undefined, signal ? { ref: false, signal } : { ref: false });
+  }
+}
+
+function parseRetryAfter(value: string | null | undefined, now: number): number | null {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return seconds * 1000;
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - now) : null;
+}

--- a/src/pixiv/client/PixivApiCore.ts
+++ b/src/pixiv/client/PixivApiCore.ts
@@ -5,6 +5,7 @@ import { SocksProxyAgent } from 'socks-proxy-agent';
 import axios, { AxiosInstance } from 'axios';
 import { logger } from '../../logger';
 import { NetworkError, is404Error } from '../../utils/errors';
+import { RateLimitCoordinator } from '../RateLimitCoordinator';
 
 export interface PixivApiCoreOptions {
   baseUrl?: string;
@@ -18,6 +19,8 @@ export interface PixivApiCoreOptions {
    * If provided, it will be attached as Authorization: Bearer <token>.
    */
   getAccessToken?: () => Promise<string> | string;
+  /** Shared process-wide 429 gate. When provided all requests share one cooldown. */
+  rateLimiter?: RateLimitCoordinator;
 }
 
 export interface PixivApiErrorBody {
@@ -39,6 +42,7 @@ export class PixivApiCore {
   private readonly socksAgent?: SocksProxyAgent;
   private readonly useAxiosForProxy: boolean;
   private readonly axiosInstance?: AxiosInstance;
+  private readonly rateLimiter?: RateLimitCoordinator;
 
   constructor(options: PixivApiCoreOptions = {}) {
     this.baseUrl = options.baseUrl ?? 'https://app-api.pixiv.net';
@@ -48,6 +52,7 @@ export class PixivApiCore {
     this.rateLimitPerSecond = options.rateLimitPerSecond;
     this.proxyUrl = options.proxyUrl ? new URL(options.proxyUrl) : undefined;
     this.getAccessToken = options.getAccessToken;
+    this.rateLimiter = options.rateLimiter;
     
     // Determine if we need to use axios for SOCKS proxy
     let useAxios = false;
@@ -132,10 +137,12 @@ export class PixivApiCore {
             }
           }
 
-          // Basic client-side rate limiting
-          const waitMs = this.calculateRateLimitWaitTime();
-          if (waitMs > 0) {
-            await delay(waitMs);
+          // Shared global rate-limit gate (429 cooldown + pacing).
+          if (this.rateLimiter) {
+            await this.rateLimiter.acquire(controller.signal);
+          } else {
+            const waitMs = this.calculateRateLimitWaitTime();
+            if (waitMs > 0) await delay(waitMs);
           }
 
           let res: Response;
@@ -249,9 +256,11 @@ export class PixivApiCore {
             }
           }
 
-          const waitMs = this.calculateRateLimitWaitTime();
-          if (waitMs > 0) {
-            await delay(waitMs);
+          if (this.rateLimiter) {
+            await this.rateLimiter.acquire(controller.signal);
+          } else {
+            const waitMs = this.calculateRateLimitWaitTime();
+            if (waitMs > 0) await delay(waitMs);
           }
 
           if (this.useAxiosForProxy && this.axiosInstance) {
@@ -388,12 +397,14 @@ export class PixivApiCore {
     if (response.status === 429) {
       const body = await this.tryReadText(response);
       const retryAfter = response.headers.get('Retry-After');
-      const explicitWaitMs = retryAfter ? Math.max(parseInt(retryAfter, 10) * 1000, 60_000) : undefined;
+      const waitMs = this.rateLimiter
+        ? this.rateLimiter.reportRateLimited(retryAfter)
+        : this.parseRetryAfterHeader(retryAfter) ?? this.exponentialBackoffMs(attempt);
       throw new NetworkError(
-        `Pixiv API error: 429 Rate Limit${body ? ` - ${body}` : ''}`,
+        `Pixiv API error: 429 Rate Limit${body ? ` - ${body.slice(0, 120)}` : ''}`,
         url,
         undefined,
-        { isRateLimit: true, waitTime: explicitWaitMs ?? this.exponentialBackoffMs(attempt) }
+        { isRateLimit: true, waitTime: waitMs }
       );
     }
 
@@ -405,11 +416,21 @@ export class PixivApiCore {
       );
     }
 
+    this.rateLimiter?.reportSuccess();
+
     if (responseType === 'text') {
       return (await response.text()) as unknown as T;
     }
 
     return (await response.json()) as T;
+  }
+
+  private parseRetryAfterHeader(value: string | null): number | undefined {
+    if (!value) return undefined;
+    const seconds = Number(value);
+    if (Number.isFinite(seconds)) return seconds * 1000;
+    const date = Date.parse(value);
+    return Number.isFinite(date) ? Math.max(0, date - Date.now()) : undefined;
   }
 
   private resolveUrl(pathOrUrl: string): string {

--- a/src/scheduler/ScheduleTriggerServer.ts
+++ b/src/scheduler/ScheduleTriggerServer.ts
@@ -44,6 +44,8 @@ export interface TriggerHandlers {
   run(scheduleId: string, context: SlotContext): Promise<TriggerRunResult>;
   /** Read-only snapshot of a schedule's current occurrence (for GET). */
   status(scheduleId: string): unknown;
+  /** Optional: pump due durable outbox rows (used to converge after cold start). */
+  drainOutbox?(): Promise<{ processed?: number; done?: number; retried?: number; dead?: number }>;
 }
 
 export class ScheduleTriggerServer {
@@ -106,6 +108,23 @@ export class ScheduleTriggerServer {
         // The slot ledger resumes on the next trigger; a 500 tells the clock to
         // retry safely (idempotent — the same occurrence/ slot is reused).
         res.status(500).json({ status: 'error', error: 'schedule run failed; the occurrence will resume on the next trigger' });
+      }
+    });
+
+    // Convergence endpoint: after a machine stop/start, an operator or an
+    // external watcher can ask the process to flush due deliveries/notifications
+    // without running candidate selection. Deployment-agnostic (no platform refs).
+    app.post('/internal/outbox/drain', this.auth, async (_req: Request, res: Response) => {
+      try {
+        if (!this.handlers.drainOutbox) {
+          res.status(503).json({ status: 'error', error: 'outbox worker not available in this runtime' });
+          return;
+        }
+        const result = await this.handlers.drainOutbox();
+        res.json({ status: 'ok', result });
+      } catch (error) {
+        logger.error('Outbox drain failed', { error: error instanceof Error ? error.message : String(error) });
+        res.status(500).json({ status: 'error', error: 'outbox drain failed; rows remain durable and retry' });
       }
     });
 

--- a/src/scheduler/SlotCoordinator.ts
+++ b/src/scheduler/SlotCoordinator.ts
@@ -14,6 +14,7 @@ import {
   resolveOccurrence,
   scheduleTimezone,
 } from './OccurrenceResolver';
+import { TargetOutcome } from './TargetOutcome';
 
 /**
  * Durable execution context attached to a run. A scheduled occurrence always
@@ -182,6 +183,84 @@ export class SlotCoordinator {
     this.database.slots.setCellStatus(slotId, targetId, status, error);
   }
 
+  /**
+   * Map a typed TargetOutcome onto the explicit cell FSM. This is the ONLY
+   * place a target result becomes a cell state, and it never infers success
+   * from a missing exception. A confirmed downstream ACK ('submitted') is the
+   * sole path to the submitted cell state.
+   */
+  applyOutcome(slotId: string, targetId: string, outcome: TargetOutcome): void {
+    const cell = this.database.slots.getCell(slotId, targetId);
+    if (!cell) return;
+    switch (outcome.kind) {
+      case 'submitted':
+        this.database.slots.lockCellWork(slotId, targetId, outcome.workId, outcome.workType);
+        this.safeTransition(slotId, targetId, 'submitted');
+        return;
+      case 'stored':
+        // No downstream delivery target (persistent/download-only): a finished
+        // cell, but labelled via the ledger-free 'submitted' aggregate state so
+        // download-only schedules do not rerun forever.
+        this.database.slots.lockCellWork(slotId, targetId, outcome.workId, outcome.workType);
+        this.safeTransition(slotId, targetId, 'submitted');
+        return;
+      case 'delivery_pending':
+        this.database.slots.lockCellWork(slotId, targetId, outcome.workId, outcome.workType);
+        this.safeTransition(slotId, targetId, 'delivery_pending');
+        return;
+      case 'no_candidate':
+        // Only terminal if the cell never locked a work; a locked work whose
+        // delivery is still pending must not be collapsed to no_candidate.
+        if (!cell.workId) this.safeTransition(slotId, targetId, 'no_candidate', outcome.reason);
+        return;
+      case 'duplicate':
+        this.database.slots.lockCellWork(slotId, targetId, outcome.workId, cell.workType ?? 'unknown');
+        this.safeTransition(slotId, targetId, 'duplicate', outcome.reason);
+        return;
+      case 'failed':
+        if (outcome.retryable) {
+          // Leave non-terminal (selected/delivery_pending) so a later trigger
+          // resumes the SAME work. Record the error without a terminal state.
+          this.database.slots.setCellError?.(slotId, targetId, outcome.error);
+          return;
+        }
+        this.safeTransition(slotId, targetId, 'failed', outcome.error);
+        return;
+    }
+  }
+
+  /** Promote a delivery_pending cell to submitted from a confirmed ACK. */
+  markDelivered(slotId: string, targetId: string, workId: string, workType: string): void {
+    this.database.slots.lockCellWork(slotId, targetId, workId, workType);
+    this.safeTransition(slotId, targetId, 'submitted');
+  }
+
+  private safeTransition(
+    slotId: string,
+    targetId: string,
+    next: import('../storage/repositories/SlotRepository').CellStatus,
+    error?: string
+  ): void {
+    try {
+      this.database.slots.transitionCell(slotId, targetId, next, error);
+    } catch (e) {
+      logger.debug('Cell transition rejected', { slotId, targetId, next, error: (e as Error).message });
+    }
+  }
+
+  /** Cross-process execution lease. Duplicate triggers converge, never parallel-run. */
+  claimRunLease(slotId: string, owner: string, leaseMs: number): boolean {
+    return this.database.slots.claimSlotLease(slotId, owner, Date.now() + leaseMs);
+  }
+
+  heartbeatLease(slotId: string, owner: string, leaseMs: number): void {
+    this.database.slots.heartbeatSlotLease(slotId, owner, Date.now() + leaseMs);
+  }
+
+  releaseRunLease(slotId: string, owner: string): void {
+    this.database.slots.releaseSlotLease(slotId, owner);
+  }
+
   /** Roll cell results up into the slot status (one place computes the aggregate). */
   finish(slot: SlotContext, schedule: ScheduleConfig, targets: TargetConfig[]): SlotRunSummary {
     const membership = this.database.slots.getSlotTargetIds(slot.slotId);
@@ -189,6 +268,9 @@ export class SlotCoordinator {
     for (const targetId of ids) {
       const cell = this.database.slots.getCell(slot.slotId, targetId);
       if (!cell) continue;
+      // delivery_pending / artifact_ready are recoverable: the OutboxWorker (or
+      // the next trigger) resumes the SAME work, so the slot stays running.
+      if (cell.status === 'delivery_pending' || cell.status === 'artifact_ready') continue;
       if (cell.status === 'pending' || cell.status === 'selected') {
         // Ran but never reached a terminal state (target threw before delivery).
         this.database.slots.setCellStatus(slot.slotId, targetId, 'failed', cell.lastError ?? 'target did not complete');

--- a/src/scheduler/SlotStateMachine.ts
+++ b/src/scheduler/SlotStateMachine.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure, testable finite state machine for one schedule Slot cell.
+ *
+ * A cell tracks ONE target within ONE scheduled occurrence. The crucial
+ * distinction the old code lacked: delivery_pending is NOT submitted. Only a
+ * confirmed downstream ACK moves a cell to 'submitted'.
+ *
+ *   pending -> selected -> artifact_ready -> delivery_pending -> submitted
+ *                                  \----------------------------/-> duplicate
+ *   pending/selected/... -> no_candidate | failed
+ *
+ * Work-lock invariant: once a cell holds a work_id it is never silently
+ * swapped by an automatic retry. Historical-duplicate replacement after a
+ * lock is the single narrow exception and is expressed by its own transition.
+ */
+export type CellState =
+  | 'pending'
+  | 'selected'
+  | 'artifact_ready'
+  | 'delivery_pending'
+  | 'submitted'
+  | 'no_candidate'
+  | 'duplicate'
+  | 'failed';
+
+export const TERMINAL_CELL_STATES: ReadonlySet<CellState> = new Set([
+  'submitted',
+  'no_candidate',
+  'duplicate',
+  'failed',
+]);
+
+const ALLOWED: Record<CellState, CellState[]> = {
+  pending: ['selected', 'artifact_ready', 'delivery_pending', 'submitted', 'no_candidate', 'duplicate', 'failed'],
+  selected: ['artifact_ready', 'delivery_pending', 'submitted', 'no_candidate', 'duplicate', 'failed'],
+  artifact_ready: ['delivery_pending', 'submitted', 'duplicate', 'failed'],
+  // A pending delivery may still prove to be an attested historical duplicate,
+  // or fail permanently. A retryable failure stays delivery_pending (worker).
+  delivery_pending: ['submitted', 'duplicate', 'failed'],
+  // Terminal states are immutable under normal transitions.
+  submitted: [],
+  no_candidate: [],
+  duplicate: [],
+  failed: [],
+};
+
+export function canTransition(from: CellState, to: CellState): boolean {
+  if (from === to) return false;
+  return ALLOWED[from].includes(to);
+}
+
+export class IllegalCellTransition extends Error {
+  constructor(public readonly from: CellState, public readonly to: CellState) {
+    super(`illegal slot cell transition: ${from} -> ${to}`);
+    this.name = 'IllegalCellTransition';
+  }
+}
+
+/**
+ * Validate a transition. Never downgrades a terminal/confirmed cell: a late
+ * failure or a duplicate trigger cannot erase an already-submitted result.
+ */
+export function assertTransition(from: CellState, to: CellState): void {
+  if (from === to) return;
+  if (!canTransition(from, to)) {
+    throw new IllegalCellTransition(from, to);
+  }
+}
+
+/** Roll cell states up into an aggregate slot status. */
+export type SlotAggregate = 'pending' | 'running' | 'success' | 'partial' | 'failed';
+
+export function aggregateSlot(cells: CellState[]): SlotAggregate {
+  if (cells.length === 0) return 'pending';
+  const terminal = cells.filter((c) => TERMINAL_CELL_STATES.has(c));
+  if (terminal.length < cells.length) return 'running';
+  if (cells.every((c) => c === 'submitted')) return 'success';
+  if (cells.some((c) => c === 'submitted')) return 'partial';
+  return 'failed';
+}

--- a/src/scheduler/TargetOutcome.ts
+++ b/src/scheduler/TargetOutcome.ts
@@ -1,0 +1,68 @@
+/**
+ * Strongly-typed business result of running ONE target in a (scheduled) slot.
+ *
+ * This replaces the old implicit protocol "handler.handle() did not throw =>
+ * submitted". Undefined / a 2xx HTTP response / a caught-and-swallowed error
+ * must NEVER be inferred as a successful submission. Every target produces one
+ * of these explicit outcomes; the Slot ledger maps it to a cell transition.
+ */
+export type WorkType = 'illustration' | 'novel';
+
+export type TargetOutcome =
+  | {
+      kind: 'submitted';
+      workId: string;
+      workType: WorkType;
+      /** Durable delivery row that recorded the downstream ACK. */
+      deliveryId?: string;
+    }
+  /**
+   * The work was processed locally but there is no downstream delivery target
+   * (persistent storageMode / pure-download config). For a scheduled slot this
+   * is a business success for that target, but it is NEVER confused with a
+   * confirmed remote submission.
+   */
+  | { kind: 'stored'; workId: string; workType: WorkType }
+  /**
+   * A delivery intent + outbox item were created durably, but the downstream
+   * ACK has not been confirmed yet. The OutboxWorker drives this to
+   * 'submitted'; a crash/restart resumes it. delivery_pending != submitted.
+   */
+  | { kind: 'delivery_pending'; workId: string; workType: WorkType; deliveryId: string }
+  /** No work matched after the full candidate pipeline (filter/topic/lookback). */
+  | { kind: 'no_candidate'; reason: string }
+  /**
+   * Downstream proved this work was already delivered by a DIFFERENT intent
+   * (historical drift). This is a terminal business duplicate, not a new
+   * submission. Produced only by the explicit reconciliation path.
+   */
+  | { kind: 'duplicate'; workId: string; reason: string }
+  /** The target failed. retryable=true => a later trigger/outbox may resume. */
+  | { kind: 'failed'; retryable: boolean; error: string };
+
+/** Terminal outcomes settle the cell; others leave it recoverable. */
+export function isTerminalOutcome(outcome: TargetOutcome): boolean {
+  return (
+    outcome.kind === 'submitted' ||
+    outcome.kind === 'stored' ||
+    outcome.kind === 'no_candidate' ||
+    outcome.kind === 'duplicate' ||
+    (outcome.kind === 'failed' && !outcome.retryable)
+  );
+}
+
+export function outcomeSummary(outcome: TargetOutcome): string {
+  switch (outcome.kind) {
+    case 'submitted':
+    case 'stored':
+      return outcome.kind;
+    case 'delivery_pending':
+      return 'delivery_pending';
+    case 'no_candidate':
+      return `no_candidate: ${outcome.reason}`;
+    case 'duplicate':
+      return `duplicate: ${outcome.reason}`;
+    case 'failed':
+      return `failed(${outcome.retryable ? 'retryable' : 'permanent'}): ${outcome.error}`;
+  }
+}

--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -11,6 +11,9 @@ import { SchedulerRepository } from './repositories/SchedulerRepository';
 import { ConfigHistoryRepository } from './repositories/ConfigHistoryRepository';
 import { TaskHistoryRepository } from './repositories/TaskHistoryRepository';
 import { SlotRepository } from './repositories/SlotRepository';
+import { DeliveryRepository } from './repositories/DeliveryRepository';
+import { OutboxRepository } from './repositories/OutboxRepository';
+import { MetadataRepository } from './repositories/MetadataRepository';
 
 export interface AccessTokenStore {
   accessToken: string;
@@ -53,6 +56,9 @@ export class Database implements IDatabase {
   private configHistoryRepo: ConfigHistoryRepository;
   private taskHistoryRepo: TaskHistoryRepository;
   private slotRepo: SlotRepository;
+  private deliveryRepo: DeliveryRepository;
+  private outboxRepo: OutboxRepository;
+  private metadataRepo: MetadataRepository;
 
   constructor(private readonly databasePath: string) {
     try {
@@ -77,6 +83,9 @@ export class Database implements IDatabase {
       this.configHistoryRepo = new ConfigHistoryRepository(this.db);
       this.taskHistoryRepo = new TaskHistoryRepository(this.db);
       this.slotRepo = new SlotRepository(this.db);
+      this.deliveryRepo = new DeliveryRepository(this.db);
+      this.outboxRepo = new OutboxRepository(this.db);
+      this.metadataRepo = new MetadataRepository(this.db);
     } catch (error) {
       throw new DatabaseError(
         `Failed to initialize database at ${this.databasePath}`,
@@ -100,6 +109,31 @@ export class Database implements IDatabase {
   /** Schedule Slot ledger (business-level idempotency for scheduled batches). */
   public get slots(): SlotRepository {
     return this.slotRepo;
+  }
+
+  /** Confirmed downstream delivery facts (delivery dedupe, distinct from downloads). */
+  public get deliveries(): DeliveryRepository {
+    return this.deliveryRepo;
+  }
+
+  /** Durable transactional outbox for content delivery and notifications. */
+  public get outbox(): OutboxRepository {
+    return this.outboxRepo;
+  }
+
+  /** Lightweight Pixiv metadata cache (novel language / rating). */
+  public get metadata(): MetadataRepository {
+    return this.metadataRepo;
+  }
+
+  /** Raw transactional boundary for atomic multi-table intents. */
+  public transaction<T>(fn: () => T): T {
+    return this.db.transaction(fn)();
+  }
+
+  /** Expose a prepared-statement helper if needed by services (pragmas etc). */
+  public pragma(sql: string): unknown {
+    return this.db.pragma(sql);
   }
 
   // Token management - delegated to TokenRepository
@@ -561,4 +595,3 @@ export function isolateCorruptDatabase(databasePath: string): string {
   }
   return isolatedPath;
 }
-

--- a/src/storage/DatabaseMigration.ts
+++ b/src/storage/DatabaseMigration.ts
@@ -93,6 +93,9 @@ export class DatabaseMigration {
             trigger_source TEXT,
             slot_date TEXT NOT NULL DEFAULT '',
             slot_name TEXT NOT NULL DEFAULT '',
+            lease_owner TEXT,
+            lease_until INTEGER,
+            heartbeat_at INTEGER,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             started_at DATETIME,
             completed_at DATETIME,
@@ -114,6 +117,61 @@ export class DatabaseMigration {
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             completed_at DATETIME,
             UNIQUE(slot_id, target_id)
+          )`,
+        // Delivery ledger: confirmed downstream submissions. This is separate
+        // from downloads (local file facts). The natural idempotency key makes
+        // ACK-lost retries converge to one row; (target, type, pixiv_id) marks
+        // which works are already CONFIRMED delivered to which target.
+        `CREATE TABLE IF NOT EXISTS deliveries (
+            id TEXT PRIMARY KEY,
+            delivery_target TEXT NOT NULL,
+            work_type TEXT NOT NULL,
+            pixiv_id TEXT NOT NULL,
+            slot_id TEXT,
+            target_id TEXT,
+            idempotency_key TEXT NOT NULL UNIQUE,
+            status TEXT NOT NULL DEFAULT 'pending',
+            remote_id TEXT,
+            remote_status TEXT,
+            reuse_reason TEXT,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            delivered_at DATETIME
+          )`,
+        // Durable transactional outbox: every external side effect (content
+        // delivery or notification) originates from one row here. The worker
+        // leases due rows; crashes leave an expired lease that a restart claims.
+        `CREATE TABLE IF NOT EXISTS outbox (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            idempotency_key TEXT,
+            delivery_id TEXT,
+            delivery_target TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempts INTEGER NOT NULL DEFAULT 0,
+            max_attempts INTEGER NOT NULL DEFAULT 12,
+            next_attempt_at INTEGER NOT NULL,
+            lease_owner TEXT,
+            lease_until INTEGER,
+            last_error TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            completed_at INTEGER
+          )`,
+        // Lightweight Pixiv metadata cache (novel language, rating) to cut
+        // repeated detail/full-text requests and 429 amplification.
+        `CREATE TABLE IF NOT EXISTS pixiv_metadata (
+            pixiv_id TEXT NOT NULL,
+            work_type TEXT NOT NULL,
+            language TEXT,
+            x_restrict INTEGER,
+            published_at TEXT,
+            title TEXT,
+            checked_at INTEGER NOT NULL,
+            PRIMARY KEY (pixiv_id, work_type)
           )`,
       ];
 
@@ -138,6 +196,9 @@ export class DatabaseMigration {
         occurrence_label: `ALTER TABLE schedule_slots ADD COLUMN occurrence_label TEXT NOT NULL DEFAULT ''`,
         timezone: `ALTER TABLE schedule_slots ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'`,
         target_ids: 'ALTER TABLE schedule_slots ADD COLUMN target_ids TEXT',
+        lease_owner: 'ALTER TABLE schedule_slots ADD COLUMN lease_owner TEXT',
+        lease_until: 'ALTER TABLE schedule_slots ADD COLUMN lease_until INTEGER',
+        heartbeat_at: 'ALTER TABLE schedule_slots ADD COLUMN heartbeat_at INTEGER',
       };
       const columnAlters: string[] = [];
       for (const [col, sql] of Object.entries(slotColumnMigrations)) {
@@ -159,6 +220,11 @@ export class DatabaseMigration {
         `CREATE INDEX IF NOT EXISTS idx_slots_schedule_occ ON schedule_slots(schedule_id, occurrence_at DESC)`,
         `CREATE INDEX IF NOT EXISTS idx_slot_items_slot ON schedule_slot_items(slot_id)`,
         `CREATE INDEX IF NOT EXISTS idx_slot_items_work ON schedule_slot_items(work_id, work_type)`,
+        `CREATE INDEX IF NOT EXISTS idx_deliveries_dedupe ON deliveries(delivery_target, work_type, pixiv_id, status)`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS idx_outbox_key ON outbox(kind, idempotency_key) WHERE idempotency_key IS NOT NULL`,
+        `CREATE INDEX IF NOT EXISTS idx_outbox_due ON outbox(status, next_attempt_at)`,
+        `CREATE INDEX IF NOT EXISTS idx_outbox_delivery ON outbox(delivery_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_slots_lease ON schedule_slots(lease_until)`,
       ];
 
       const postMigration = this.db.transaction((stmts: string[]) => {
@@ -218,7 +284,6 @@ export class DatabaseMigration {
     }
   }
 }
-
 
 
 

--- a/src/storage/repositories/DeliveryRepository.ts
+++ b/src/storage/repositories/DeliveryRepository.ts
@@ -1,0 +1,189 @@
+import { BaseRepository } from './BaseRepository';
+
+export type DeliveryStatus = 'pending' | 'delivered' | 'duplicate' | 'failed';
+
+export interface DeliveryRow {
+  id: string;
+  deliveryTarget: string;
+  workType: string;
+  pixivId: string;
+  slotId: string | null;
+  targetId: string | null;
+  idempotencyKey: string;
+  status: DeliveryStatus;
+  remoteId: string | null;
+  remoteStatus: string | null;
+  reuseReason: string | null;
+  attempts: number;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deliveredAt: string | null;
+}
+
+export interface NewDelivery {
+  id: string;
+  deliveryTarget: string;
+  workType: string;
+  pixivId: string;
+  slotId?: string | null;
+  targetId?: string | null;
+  idempotencyKey: string;
+}
+
+/**
+ * The delivery ledger. Answers "has this work actually been CONFIRMED delivered
+ * to this target?" — distinct from the downloads table ("was the file cached
+ * locally?"). downloaded != delivered.
+ *
+ * Dedup scope is (delivery_target, work_type, pixiv_id): bot1 having posted a
+ * work does not forbid bot2 posting it.
+ */
+export class DeliveryRepository extends BaseRepository {
+  /** Insert a pending intent. No-op if the idempotency key already exists. */
+  insertIntent(input: NewDelivery): { row: DeliveryRow; created: boolean } {
+    const info = this.db
+      .prepare(
+        `INSERT INTO deliveries
+           (id, delivery_target, work_type, pixiv_id, slot_id, target_id, idempotency_key, status)
+         VALUES
+           (@id, @deliveryTarget, @workType, @pixivId, @slotId, @targetId, @idempotencyKey, 'pending')
+         ON CONFLICT(idempotency_key) DO NOTHING`
+      )
+      .run({
+        id: input.id,
+        deliveryTarget: input.deliveryTarget,
+        workType: input.workType,
+        pixivId: input.pixivId,
+        slotId: input.slotId ?? null,
+        targetId: input.targetId ?? null,
+        idempotencyKey: input.idempotencyKey,
+      });
+    const created = info.changes > 0;
+    return { row: created ? this.getById(input.id)! : this.getByIdempotencyKey(input.idempotencyKey)!, created };
+  }
+
+  getById(id: string): DeliveryRow | null {
+    const row = this.db.prepare(`SELECT * FROM deliveries WHERE id = ?`).get(id) as any;
+    return row ? this.toRow(row) : null;
+  }
+
+  getByIdempotencyKey(key: string): DeliveryRow | null {
+    const row = this.db.prepare(`SELECT * FROM deliveries WHERE idempotency_key = ?`).get(key) as any;
+    return row ? this.toRow(row) : null;
+  }
+
+  /**
+   * True when this exact work is already CONFIRMED (delivered, or an attested
+   * historical duplicate) for this target. Pending/failed intents do not block
+   * selection — they are retried, not treated as a delivered fact.
+   */
+  isDelivered(deliveryTarget: string, workType: string, pixivId: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT 1 FROM deliveries
+         WHERE delivery_target = ? AND work_type = ? AND pixiv_id = ?
+           AND status IN ('delivered','duplicate')
+         LIMIT 1`
+      )
+      .get(deliveryTarget, workType, String(pixivId));
+    return Boolean(row);
+  }
+
+  /** Batch form for candidate-pipeline pre-lock dedupe. */
+  deliveredIds(deliveryTarget: string, workType: string, pixivIds: string[]): Set<string> {
+    const out = new Set<string>();
+    if (pixivIds.length === 0) return out;
+    const CHUNK = 400;
+    for (let i = 0; i < pixivIds.length; i += CHUNK) {
+      const slice = pixivIds.slice(i, i + CHUNK);
+      const placeholders = slice.map(() => '?').join(',');
+      const rows = this.db
+        .prepare(
+          `SELECT DISTINCT pixiv_id FROM deliveries
+           WHERE delivery_target = ? AND work_type = ? AND status IN ('delivered','duplicate')
+             AND pixiv_id IN (${placeholders})`
+        )
+        .all(deliveryTarget, workType, ...slice) as Array<{ pixiv_id: string }>;
+      for (const r of rows) out.add(r.pixiv_id);
+    }
+    return out;
+  }
+
+  recordAck(
+    id: string,
+    ack: { status: DeliveryStatus; remoteId?: string; remoteStatus?: string; reuseReason?: string; error?: string }
+  ): void {
+    const terminal = ack.status === 'delivered' || ack.status === 'duplicate' || ack.status === 'failed';
+    const sets = [
+      'status = @status',
+      'remote_id = COALESCE(@remoteId, remote_id)',
+      'remote_status = @remoteStatus',
+      'reuse_reason = @reuseReason',
+      'last_error = @error',
+      'attempts = attempts + 1',
+      'updated_at = CURRENT_TIMESTAMP',
+    ];
+    if (terminal) sets.push(`delivered_at = COALESCE(delivered_at, CASE WHEN @status IN ('delivered','duplicate') THEN CURRENT_TIMESTAMP ELSE NULL END)`);
+    this.db
+      .prepare(`UPDATE deliveries SET ${sets.join(', ')} WHERE id = @id`)
+      .run({
+        id,
+        status: ack.status,
+        remoteId: ack.remoteId ?? null,
+        remoteStatus: ack.remoteStatus ?? null,
+        reuseReason: ack.reuseReason ?? null,
+        error: ack.error ?? null,
+      });
+  }
+
+  /** Backfill a delivery fact discovered during downstream reconciliation. */
+  backfill(input: NewDelivery & { remoteId?: string; remoteStatus?: string }): { row: DeliveryRow; created: boolean } {
+    const { row, created } = this.insertIntent(input);
+    if (created || row.status !== 'delivered') {
+      this.recordAck(input.id, {
+        status: 'delivered',
+        remoteId: input.remoteId,
+        remoteStatus: input.remoteStatus ?? 'reconciled',
+      });
+    }
+    return { row: this.getById(input.id)!, created };
+  }
+
+  pending(limit = 200): DeliveryRow[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM deliveries WHERE status = 'pending' ORDER BY created_at ASC LIMIT ?`)
+      .all(limit) as any[];
+    return rows.map((r) => this.toRow(r));
+  }
+
+  countByStatus(): Record<DeliveryStatus, number> {
+    const rows = this.db
+      .prepare(`SELECT status, COUNT(*) AS n FROM deliveries GROUP BY status`)
+      .all() as Array<{ status: DeliveryStatus; n: number }>;
+    const out: Record<DeliveryStatus, number> = { pending: 0, delivered: 0, duplicate: 0, failed: 0 };
+    for (const r of rows) out[r.status] = r.n;
+    return out;
+  }
+
+  private toRow(row: any): DeliveryRow {
+    return {
+      id: row.id,
+      deliveryTarget: row.delivery_target,
+      workType: row.work_type,
+      pixivId: row.pixiv_id,
+      slotId: row.slot_id,
+      targetId: row.target_id,
+      idempotencyKey: row.idempotency_key,
+      status: row.status,
+      remoteId: row.remote_id,
+      remoteStatus: row.remote_status,
+      reuseReason: row.reuse_reason,
+      attempts: row.attempts,
+      lastError: row.last_error,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      deliveredAt: row.delivered_at,
+    };
+  }
+}

--- a/src/storage/repositories/MetadataRepository.ts
+++ b/src/storage/repositories/MetadataRepository.ts
@@ -1,0 +1,70 @@
+import { BaseRepository } from './BaseRepository';
+
+export interface PixivMetadata {
+  pixivId: string;
+  workType: string;
+  language: string | null;
+  xRestrict: number | null;
+  publishedAt: string | null;
+  title: string | null;
+  checkedAt: number;
+}
+
+/**
+ * Lightweight SQLite metadata cache. Novel language filtering otherwise issues
+ * a full detail + full-text request for every candidate on every fallback run;
+ * caching the classified result bounds request volume and reduces 429 storms.
+ * Entries expire after a TTL so fresh classifications still happen eventually.
+ */
+export class MetadataRepository extends BaseRepository {
+  get(pixivId: string, workType: string): PixivMetadata | null {
+    const row = this.db
+      .prepare(`SELECT * FROM pixiv_metadata WHERE pixiv_id = ? AND work_type = ?`)
+      .get(String(pixivId), workType) as any;
+    if (!row) return null;
+    return {
+      pixivId: row.pixiv_id,
+      workType: row.work_type,
+      language: row.language,
+      xRestrict: row.x_restrict,
+      publishedAt: row.published_at,
+      title: row.title,
+      checkedAt: row.checked_at,
+    };
+  }
+
+  fresh(pixivId: string, workType: string, ttlMs: number, now: number = Date.now()): PixivMetadata | null {
+    const row = this.get(pixivId, workType);
+    if (!row) return null;
+    if (now - row.checkedAt > ttlMs) return null;
+    return row;
+  }
+
+  put(
+    pixivId: string,
+    workType: string,
+    data: { language?: string | null; xRestrict?: number | null; publishedAt?: string | null; title?: string | null },
+    now: number = Date.now()
+  ): void {
+    this.db
+      .prepare(
+        `INSERT INTO pixiv_metadata (pixiv_id, work_type, language, x_restrict, published_at, title, checked_at)
+         VALUES (@pixivId, @workType, @language, @xRestrict, @publishedAt, @title, @now)
+         ON CONFLICT(pixiv_id, work_type) DO UPDATE SET
+           language=excluded.language,
+           x_restrict=excluded.x_restrict,
+           published_at=excluded.published_at,
+           title=excluded.title,
+           checked_at=excluded.checked_at`
+      )
+      .run({
+        pixivId: String(pixivId),
+        workType,
+        language: data.language ?? null,
+        xRestrict: data.xRestrict ?? null,
+        publishedAt: data.publishedAt ?? null,
+        title: data.title ?? null,
+        now,
+      });
+  }
+}

--- a/src/storage/repositories/OutboxRepository.ts
+++ b/src/storage/repositories/OutboxRepository.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from 'node:crypto';
+import { BaseRepository } from './BaseRepository';
+
+export type OutboxKind = 'delivery' | 'notification';
+export type OutboxStatus = 'pending' | 'processing' | 'retry_wait' | 'done' | 'dead';
+
+export interface OutboxRow {
+  id: string;
+  kind: OutboxKind;
+  idempotencyKey: string | null;
+  deliveryId: string | null;
+  deliveryTarget: string;
+  payloadJson: string;
+  status: OutboxStatus;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: number;
+  leaseOwner: string | null;
+  leaseUntil: number | null;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+}
+
+export interface NewOutboxItem {
+  kind: OutboxKind;
+  deliveryTarget: string;
+  idempotencyKey?: string | null;
+  deliveryId?: string | null;
+  payload: unknown;
+  /** Initial due time (epoch ms). Default now. */
+  dueAt?: number;
+  maxAttempts?: number;
+}
+
+/**
+ * SQLite transactional outbox. One durable row per intended external side
+ * effect (a content delivery or a notification). A single OutboxWorker claims
+ * due rows with a short lease, performs the effect, and marks them done. Rows
+ * survive process kill / machine stop; a restart simply resumes due rows.
+ */
+export class OutboxRepository extends BaseRepository {
+  static owner(): string {
+    return `${process.pid}-${randomUUID().slice(0, 8)}`;
+  }
+
+  /** Insert an intent. Returns the row. Idempotent on (kind, idempotency_key). */
+  enqueue(input: NewOutboxItem, now: number = Date.now()): OutboxRow {
+    const id = randomUUID();
+    const payloadJson = JSON.stringify(input.payload ?? {});
+    this.db
+      .prepare(
+        `INSERT INTO outbox
+           (id, kind, idempotency_key, delivery_id, delivery_target, payload_json,
+            status, attempts, max_attempts, next_attempt_at, created_at, updated_at)
+         VALUES
+           (@id, @kind, @idempotencyKey, @deliveryId, @deliveryTarget, @payloadJson,
+            'pending', 0, @maxAttempts, @dueAt, @now, @now)
+         ON CONFLICT(kind, idempotency_key) WHERE idempotency_key IS NOT NULL
+         DO UPDATE SET updated_at = @now`
+      )
+      .run({
+        id,
+        kind: input.kind,
+        idempotencyKey: input.idempotencyKey ?? null,
+        deliveryId: input.deliveryId ?? null,
+        deliveryTarget: input.deliveryTarget,
+        payloadJson,
+        maxAttempts: input.maxAttempts ?? 12,
+        dueAt: input.dueAt ?? now,
+        now,
+      });
+    // On conflict the existing row is authoritative; fetch by the natural key.
+    if (input.idempotencyKey) {
+      return this.getByKey(input.kind, input.idempotencyKey)!;
+    }
+    return this.get(id)!;
+  }
+
+  get(id: string): OutboxRow | null {
+    const row = this.db.prepare(`SELECT * FROM outbox WHERE id = ?`).get(id) as any;
+    return row ? this.toRow(row) : null;
+  }
+
+  getByKey(kind: OutboxKind, key: string): OutboxRow | null {
+    const row = this.db
+      .prepare(`SELECT * FROM outbox WHERE kind = ? AND idempotency_key = ?`)
+      .get(kind, key) as any;
+    return row ? this.toRow(row) : null;
+  }
+
+  /**
+   * Claim up to `limit` due rows for `owner`. Due = pending/retry_wait whose
+   * next_attempt_at has passed, OR processing rows whose lease expired (a
+   * crashed prior worker). The claim is a compare-and-set inside one
+   * statement, so two workers/processes never grab the same row.
+   */
+  claimDue(owner: string, leaseMs: number, limit: number, now: number = Date.now()): OutboxRow[] {
+    const ids = (this.db
+      .prepare(
+        `SELECT id FROM outbox
+         WHERE status IN ('pending','retry_wait') AND next_attempt_at <= @now
+            OR (status = 'processing' AND lease_until IS NOT NULL AND lease_until <= @now)
+         ORDER BY next_attempt_at ASC
+         LIMIT @limit`
+      )
+      .all({ now, limit }) as Array<{ id: string }>).map((r) => r.id);
+
+    if (ids.length === 0) return [];
+    const claim = this.db.prepare(
+      `UPDATE outbox
+       SET status = 'processing', lease_owner = @owner, lease_until = @until, updated_at = @now
+       WHERE id = @id
+         AND (status IN ('pending','retry_wait') AND next_attempt_at <= @now
+              OR (status = 'processing' AND lease_until IS NOT NULL AND lease_until <= @now))`
+    );
+    const out: OutboxRow[] = [];
+    const tx = this.db.transaction((rows: string[]) => {
+      for (const id of rows) {
+        const info = claim.run({ id, owner, until: now + leaseMs, now });
+        if (info.changes > 0) {
+          const row = this.get(id);
+          if (row) out.push(row);
+        }
+      }
+    });
+    tx(ids);
+    return out;
+  }
+
+  markDone(id: string, now: number = Date.now()): void {
+    this.db
+      .prepare(
+        `UPDATE outbox
+         SET status='done', lease_owner=NULL, lease_until=NULL, last_error=NULL,
+             completed_at=@now, updated_at=@now
+         WHERE id=@id`
+      )
+      .run({ id, now });
+  }
+
+  /** Schedule a later retry, or flip to dead once attempts are exhausted. */
+  markRetry(
+    id: string,
+    nextAt: number,
+    error: string,
+    now: number = Date.now()
+  ): OutboxStatus {
+    const row = this.get(id);
+    if (!row) return 'dead';
+    const attempts = row.attempts + 1;
+    const dead = attempts >= row.maxAttempts;
+    this.db
+      .prepare(
+        `UPDATE outbox
+         SET attempts=@attempts,
+             status=@status,
+             next_attempt_at=@nextAt,
+             lease_owner=NULL, lease_until=NULL,
+             last_error=@error, updated_at=@now
+         WHERE id=@id`
+      )
+      .run({
+        id,
+        attempts,
+        status: dead ? 'dead' : 'retry_wait',
+        nextAt: dead ? row.nextAttemptAt : nextAt,
+        error: error.slice(0, 1000),
+        now,
+      });
+    return dead ? 'dead' : 'retry_wait';
+  }
+
+  /** Release a processing row back to pending without counting a retry. */
+  release(id: string, now: number = Date.now()): void {
+    this.db
+      .prepare(
+        `UPDATE outbox SET status='pending', lease_owner=NULL, lease_until=NULL,
+                 next_attempt_at=@now, updated_at=@now WHERE id=@id AND status='processing'`
+      )
+      .run({ id, now });
+  }
+
+  /** Reopen a dead row for one more attempt (operator / reconcile action). */
+  requeue(id: string, dueAt: number = Date.now()): void {
+    this.db
+      .prepare(
+        `UPDATE outbox SET status='retry_wait', next_attempt_at=@dueAt, attempts=0,
+                 last_error=NULL, lease_owner=NULL, lease_until=NULL,
+                 completed_at=NULL, updated_at=@dueAt WHERE id=@id`
+      )
+      .run({ id, dueAt });
+  }
+
+  counts(now: number = Date.now()): {
+    pending: number;
+    retryWait: number;
+    processing: number;
+    dead: number;
+    done24h: number;
+    oldestPendingMs: number | null;
+  } {
+    const one = (sql: string, ...params: unknown[]) =>
+      (this.db.prepare(sql).get(...params) as { n: number }).n;
+    const pending = one(`SELECT COUNT(*) n FROM outbox WHERE status IN ('pending','retry_wait')`);
+    const retryWait = one(`SELECT COUNT(*) n FROM outbox WHERE status='retry_wait'`);
+    const processing = one(`SELECT COUNT(*) n FROM outbox WHERE status='processing'`);
+    const dead = one(`SELECT COUNT(*) n FROM outbox WHERE status='dead'`);
+    const done24h = one(`SELECT COUNT(*) n FROM outbox WHERE status='done' AND completed_at >= ?`, now - 86_400_000);
+    const oldest = this.db
+      .prepare(`SELECT MIN(next_attempt_at) t FROM outbox WHERE status IN ('pending','retry_wait')`)
+      .get() as { t: number | null };
+    return {
+      pending,
+      retryWait,
+      processing,
+      dead,
+      done24h,
+      oldestPendingMs: oldest.t == null ? null : Math.max(0, now - oldest.t),
+    };
+  }
+
+  /** Rows still non-terminal (used by reconcile/doctor). */
+  staleProcessing(now: number = Date.now()): OutboxRow[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM outbox WHERE status='processing' AND lease_until IS NOT NULL AND lease_until <= ?`)
+      .all(now) as any[];
+    return rows.map((r) => this.toRow(r));
+  }
+
+  private toRow(row: any): OutboxRow {
+    return {
+      id: row.id,
+      kind: row.kind,
+      idempotencyKey: row.idempotency_key,
+      deliveryId: row.delivery_id,
+      deliveryTarget: row.delivery_target,
+      payloadJson: row.payload_json,
+      status: row.status,
+      attempts: row.attempts,
+      maxAttempts: row.max_attempts,
+      nextAttemptAt: row.next_attempt_at,
+      leaseOwner: row.lease_owner,
+      leaseUntil: row.lease_until,
+      lastError: row.last_error,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      completedAt: row.completed_at,
+    };
+  }
+}

--- a/src/storage/repositories/SlotRepository.ts
+++ b/src/storage/repositories/SlotRepository.ts
@@ -1,7 +1,15 @@
 import { BaseRepository } from './BaseRepository';
 
 export type SlotStatus = 'pending' | 'running' | 'success' | 'partial' | 'failed' | 'expired';
-export type CellStatus = 'pending' | 'selected' | 'submitted' | 'no_candidate' | 'failed';
+export type CellStatus =
+  | 'pending'
+  | 'selected'
+  | 'artifact_ready'
+  | 'delivery_pending'
+  | 'submitted'
+  | 'no_candidate'
+  | 'duplicate'
+  | 'failed';
 
 export interface SlotRecord {
   id: string;
@@ -25,6 +33,9 @@ export interface SlotRecord {
   startedAt: string | null;
   completedAt: string | null;
   lastError: string | null;
+  leaseOwner: string | null;
+  leaseUntil: number | null;
+  heartbeatAt: number | null;
 }
 
 export interface SlotItemRecord {
@@ -219,12 +230,103 @@ export class SlotRepository extends BaseRepository {
   }
 
   public setCellStatus(slotId: string, targetId: string, status: CellStatus, error?: string): void {
-    const terminal = status === 'submitted' || status === 'no_candidate' || status === 'failed';
+    const terminal =
+      status === 'submitted' ||
+      status === 'no_candidate' ||
+      status === 'duplicate' ||
+      status === 'failed';
     const sets = ['status = @status', 'last_error = @error', 'updated_at = CURRENT_TIMESTAMP'];
     if (terminal) sets.push('completed_at = CURRENT_TIMESTAMP');
     this.db
       .prepare(`UPDATE schedule_slot_items SET ${sets.join(', ')} WHERE slot_id = @slotId AND target_id = @targetId`)
       .run({ slotId, targetId, status, error: error ?? null });
+  }
+
+  /**
+   * Transition a cell with FSM validation. Never downgrades a confirmed cell;
+   * an illegal transition throws rather than silently corrupting state.
+   */
+  public transitionCell(
+    slotId: string,
+    targetId: string,
+    next: CellStatus,
+    error?: string
+  ): SlotItemRecord {
+    const cell = this.getCell(slotId, targetId);
+    if (!cell) throw new Error(`cell not found: ${slotId}/${targetId}`);
+    if (cell.status === next) return cell;
+    // Imported lazily to keep the repository free of a circular module graph.
+    // The FSM table is the single authority for legal moves.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { assertTransition } = require('../../scheduler/SlotStateMachine') as typeof import('../../scheduler/SlotStateMachine');
+    assertTransition(cell.status as Parameters<typeof assertTransition>[0], next as Parameters<typeof assertTransition>[1]);
+    this.setCellStatus(slotId, targetId, next, error);
+    return this.getCell(slotId, targetId)!;
+  }
+
+  /**
+   * Claim execution ownership of a slot for `owner` until `leaseUntil`
+   * (epoch ms). Returns true when this caller now owns the lease. A second
+   * process/trigger sees an active lease and must converge (resume/observe),
+   * not start a parallel run. An expired lease is reclaimable.
+   */
+  public claimSlotLease(slotId: string, owner: string, leaseUntil: number, now: number = Date.now()): boolean {
+    const info = this.db
+      .prepare(
+        `UPDATE schedule_slots
+         SET lease_owner = @owner, lease_until = @leaseUntil, heartbeat_at = @now
+         WHERE id = @id
+           AND (lease_until IS NULL OR lease_until <= @now OR lease_owner = @owner)`
+      )
+      .run({ id: slotId, owner, leaseUntil, now });
+    return info.changes > 0;
+  }
+
+  public heartbeatSlotLease(slotId: string, owner: string, leaseUntil: number, now: number = Date.now()): void {
+    this.db
+      .prepare(
+        `UPDATE schedule_slots SET lease_until = @leaseUntil, heartbeat_at = @now
+         WHERE id = @id AND lease_owner = @owner`
+      )
+      .run({ id: slotId, owner, leaseUntil, now });
+  }
+
+  public releaseSlotLease(slotId: string, owner: string): void {
+    this.db
+      .prepare(
+        `UPDATE schedule_slots SET lease_owner = NULL, lease_until = NULL
+         WHERE id = @id AND lease_owner = @owner`
+      )
+      .run({ id: slotId, owner });
+  }
+
+  public getSlotLease(slotId: string): { owner: string | null; until: number | null } {
+    const row = this.db
+      .prepare(`SELECT lease_owner, lease_until FROM schedule_slots WHERE id = ?`)
+      .get(slotId) as { lease_owner: string | null; lease_until: number | null } | undefined;
+    return { owner: row?.lease_owner ?? null, until: row?.lease_until ?? null };
+  }
+
+  /** Slots whose lease expired while still non-terminal (crashed workers). */
+  public slotsWithStaleLease(now: number = Date.now()): string[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id FROM schedule_slots
+         WHERE lease_until IS NOT NULL AND lease_until < @now
+           AND status IN ('pending','running')`
+      )
+      .all({ now }) as Array<{ id: string }>;
+    return rows.map((r) => r.id);
+  }
+
+  /** Record an error without changing terminality (retryable failure keeps the cell resumable). */
+  public setCellError(slotId: string, targetId: string, error: string): void {
+    this.db
+      .prepare(
+        `UPDATE schedule_slot_items SET last_error = @error, updated_at = CURRENT_TIMESTAMP
+         WHERE slot_id = @slotId AND target_id = @targetId`
+      )
+      .run({ slotId, targetId, error: error.slice(0, 1000) });
   }
 
   /** Work ids already locked in THIS slot (to stop two cells taking the same work). */
@@ -239,7 +341,8 @@ export class SlotRepository extends BaseRepository {
   public deriveSlotStatus(slotId: string): SlotStatus {
     const cells = this.getCells(slotId);
     if (cells.length === 0) return 'pending';
-    const terminal = cells.filter((c) => c.status === 'submitted' || c.status === 'no_candidate' || c.status === 'failed');
+    const isTerminal = (s: string) => s === 'submitted' || s === 'no_candidate' || s === 'duplicate' || s === 'failed';
+    const terminal = cells.filter((c) => isTerminal(c.status));
     if (terminal.length < cells.length) return 'running';
     if (cells.every((c) => c.status === 'submitted')) return 'success';
     if (cells.some((c) => c.status === 'submitted')) return 'partial';
@@ -270,6 +373,9 @@ export class SlotRepository extends BaseRepository {
       startedAt: row.started_at,
       completedAt: row.completed_at,
       lastError: row.last_error,
+      leaseOwner: row.lease_owner ?? null,
+      leaseUntil: row.lease_until ?? null,
+      heartbeatAt: row.heartbeat_at ?? null,
     };
   }
 


### PR DESCRIPTION
## 生产级可靠性收敛：typed outcomes → delivery ledger → SQLite outbox → occurrence 级幂等键（at-least-once → effectively-once）

### 变更
- **typed TargetOutcome**：取代「没抛错=成功」，显式区分 submitted / stored / delivery_pending / no_candidate / duplicate / failed（可重试 vs 不可重试）；slot FSM 只沿确认结果前进，已 submitted 永不被迟到结果降级。
- **delivery ledger**（`deliveries`，`UNIQUE(idempotency_key)`，去重域 target+type+pixiv_id）：回答「是否已确认送达」，选择期/对账双重去重。
- **SQLite 事务 outbox + OutboxWorker**：每种外部副作用一行（内容投递/通知独立泵送），行级租约 + 指数退避 + maxAttempts→dead；崩溃残留 processing 租约过期即被接管，重试同一 intent。
- **运行租约**：重复 HTTP 触发对同一 slot 只有一个 owner，冲突触发收敛不并行。
- **全局 429 协调器**（所有 Pixiv 请求共享冷却）；**novel 语言元数据缓存**（TTL）；下载前 **delivery 预去重**；**legacy JSON outbox 启动自动迁移**（幂等）。
- **doctor / reconcile CLI**：诊断 + `--repair` 收敛 stale 行/过期租约；把下游确认的历史重复登记进账本（默认 dry-run）；受认证 outbox drain 端点。
- **fix**: occurrence 级幂等键真正随 multipart 内容投递发送（此前只生成未发送，ACK 丢失重试会重复发帖）。

### 测试
故障注入（ACK 丢失→replay 恰一条、重复触发恰一次、stale 租约续跑、dead-letter、通知解耦、submitted 不可降级）、真实 HTTP e2e 契约、doctor/reconcile CLI。628 tests passed，tsc clean。

详见总 PR 描述（三仓）。本仓无破坏性变更；旧 JSON outbox 自动幂等迁移。