### PR TITLE
feat: add readiness-gated preview delivery recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- Cache-mode illustration delivery can send aligned Pixiv previews alongside immutable originals.
+- Delivery targets can define a readiness endpoint; outbox consumption waits without consuming attempts.
+- Added `pixivflow outbox` list, inspect, dead-letter retry, and pending-intent cancel operations.
+
 ## [2.13.0](https://github.com/redtidev1918/PixivFlow/compare/v2.12.3...v2.13.0) (2026-09-09)
 
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ pixivflow scheduler             # 按 cron 配置长期挂机自动收集
       "tg-example": {
         "type": "httpMultipart",
         "url": "https://your-domain.example/api/bot1/v1/submissions",
+        "readinessUrl": "https://your-domain.example/ready",
         "notificationUrl": "https://your-domain.example/api/bot1/v1/notifications",
         "headers": { "Authorization": "Bearer ${TG_SUBMIT_TOKEN}" },
         "fileField": "files",
@@ -149,7 +150,9 @@ pixivflow scheduler             # 按 cron 配置长期挂机自动收集
 }
 ```
 
-`headers` 和 `url` 里可用 `${环境变量名}` 引用环境变量（Token 别写死进配置）。
+`headers`、`url` 和 `readinessUrl` 里可用 `${环境变量名}` 引用环境变量（Token 别写死进配置）。
+插画 cache 投递会在 multipart 的 `previews` 字段携带 Pixiv 的低分辨率预览（与 `files`
+一一对应），原图仍是权威素材；通用接收端可以忽略该可选字段。
 
 投递是**事务发件箱（SQLite outbox）**式的，at-least-once 执行、effectively-once
 可见效果：每个外部副作用（一次内容投递、一条通知）在 `outbox` 表落一行，带幂等键和
@@ -160,6 +163,20 @@ pixivflow scheduler             # 按 cron 配置长期挂机自动收集
 频道里仍然只有一条消息。旧版文件型 `delivery-outbox/*.json` 清单在启动时自动一次性
 迁移进 SQLite，迁移幂等。「今天没有可投稿内容」这类通知与内容投递走同一张表、独立泵送，
 审核端暂时挂掉不会互相阻塞。
+
+配置 `readinessUrl` 后，worker 每次认领都先检查依赖 `/ready`。非 2xx 只把 row 放回 pending，
+不增加 attempt；这与 `/live` 的“进程还活着”语义严格分开。dead letter 通过正式 CLI 恢复：
+
+```bash
+pixivflow outbox list --status dead
+pixivflow outbox inspect <id>
+pixivflow outbox retry <id>   # 只接受 dead row，保留 idempotency key
+pixivflow outbox retry --dead
+pixivflow outbox cancel <id>  # 只取消尚未执行的 row
+```
+
+`run-once` 会重新执行下载计划，不等价于 outbox replay；不要手改 SQLite 的
+`next_attempt_at`。
 
 运维通知可直接把 `notificationUrl` 指向 [Apprise API](docs/APPRISE.md)，由 Apprise 统一发送
 Email、Telegram、Discord、ntfy 等渠道；PixivFlow 不实现这些通知协议。
@@ -182,6 +199,7 @@ Email、Telegram、Discord、ntfy 等渠道；PixivFlow 不实现这些通知协
 | `pixivflow health` | 健康检查：配置、目录可写性、连通性 |
 | `pixivflow doctor` | 可靠性体检：卡住的 slot/outbox 租约、pending 投递、dead 行；`--repair` 收敛 |
 | `pixivflow reconcile` | 把下游已确认的历史重复登记进投递账本（默认 dry-run，`--repair` 落库） |
+| `pixivflow outbox` | 列出、检查、重放 dead letter 或取消尚未执行的 durable intent |
 | `pixivflow tags discover <词>` | 发现相关 Tag（Pixiv 联想 + 作品标签共现），只列候选不改配置 |
 | `pixivflow tags apply <清单> --target <id> --select <tag1,tag2>` | 人工确认后把所选 Tag 原子写入配置并触发热重载 |
 | `pixivflow topic resolve <主题>` | 查看自动推导出的相关 Tag 空间（`--type illustration\|novel`、`--refresh`） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -102,6 +102,7 @@ merely translates an HTTP multipart submission API into configuration:
       "sharing-api": {
         "type": "httpMultipart",
         "url": "https://example.test/submissions",
+        "readinessUrl": "https://example.test/ready",
         "notificationUrl": "https://example.test/notifications",
         "headers": { "Authorization": "Bearer ${SHARING_TOKEN}" },
         "fileField": "files",
@@ -125,11 +126,18 @@ merely translates an HTTP multipart submission API into configuration:
 }
 ```
 
-Headers and URLs accept arbitrary `${ENV_NAME}` interpolation. Failed delivery
-keeps both files and the durable outbox manifest beside the SQLite database;
-the next run retries them before processing new targets. Final no-match
+Headers and URLs accept arbitrary `${ENV_NAME}` interpolation. Cache-mode
+illustration delivery also sends an optional, one-to-one Pixiv preview in the
+`previews` multipart field while retaining the original as the authoritative
+artifact. Failed delivery keeps both files in the SQLite outbox; the worker
+retries the same intent after restart. Final no-match
 notifications use the same durable outbox, so a restart or a temporary review
 endpoint outage does not silently lose the alert.
+
+When `readinessUrl` is configured, a non-2xx readiness response defers the row
+without incrementing its attempt count. Use `pixivflow outbox list`,
+`inspect <id>`, `retry <id>` / `retry --dead`, and `cancel <id>` for recovery;
+`run-once` is not an outbox replay command.
 
 Interactive configuration wizard: `pixivflow setup`.
 

--- a/config/fly-two-bots.example.json
+++ b/config/fly-two-bots.example.json
@@ -78,6 +78,7 @@
       "telepost-bot1": {
         "type": "httpMultipart",
         "url": "http://127.0.0.1:8080/api/bot1/v1/submissions",
+        "readinessUrl": "http://127.0.0.1:8080/ready",
         "notificationUrl": "http://127.0.0.1:8080/api/bot1/v1/notifications",
         "headers": {
           "Authorization": "Bearer ${TELEPOST_BOT1_SUBMIT_TOKEN}"
@@ -110,6 +111,7 @@
       "telepost-bot2": {
         "type": "httpMultipart",
         "url": "http://127.0.0.1:8080/api/bot2/v1/submissions",
+        "readinessUrl": "http://127.0.0.1:8080/ready",
         "notificationUrl": "http://127.0.0.1:8080/api/bot2/v1/notifications",
         "headers": {
           "Authorization": "Bearer ${TELEPOST_BOT2_SUBMIT_TOKEN}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,6 +173,8 @@ executeCommand():command.validate?(args) → command.execute(context, args)
 - **Cell FSM**：`pending → selected → artifact_ready → delivery_pending → submitted`，另有终态 `no_candidate`（有界候选集里没有合法作品，正常业务终态）、`duplicate`（对账证实该作品已被**另一次意图**投递的历史漂移）、`failed`（仅不可重试失败）。可重试失败与 `delivery_pending` 都不是终态：重启/重复触发会沿同一 `work_id` 继续，永不下调已确认的 `submitted`。slot 聚合状态由一处计算（全成功→`success`；成功+no_candidate/duplicate/失败→`partial`；无一成功且不可恢复→`failed`）。
 - **投递账本 + Outbox**：`deliveries` 表回答“此作品是否已**确认**送达此 target”（去重域 = delivery_target + work_type + pixiv_id；只有 delivered/duplicate 算数，pending 不阻塞选择）；`outbox` 表是每种外部副作用（内容投递、通知）一行的事务性发件箱，worker 以租约认领、指数退避重试、超 maxAttempts 进 dead 状态并记 `deliveries.status=failed`。ACK 丢失后的重试由下游用 `idempotent_replay` 确认收敛为一条远端记录。
 - **Outbox 边界**：outbox 只保证“已产生的投递”最终送达，重放**永不**重新进入候选选择。
+- **Readiness 边界**：delivery target 配置 `readinessUrl` 后，非 2xx 只释放租约并延后消费，attempt 不增加；`/live` 不能代替 `/ready`。
+- **媒体边界**：cache 模式插画可在 `previews` multipart 字段提供一一对应的 Pixiv preview；原图仍保留在 `files`，接收端决定审核展示与安全 fallback，PixivFlow 不替接收端解码原图。
 - **运行租约**：重复 HTTP 触发对同一 slot 只会有一个 owner（`claimSlotLease` 比较-设置）；冲突触发观察/恢复而非并行执行，崩溃后租约过期才可被接管。
 - **Scheduled vs Ad-hoc**：`run-once` / 「重抓」是 ad-hoc 执行，跑下载计划但**不**打开 occurrence，绝不能把某次定时 occurrence 标记为完成或被 resume。
 
@@ -186,11 +188,12 @@ executeCommand():command.validate?(args) → command.execute(context, args)
 6. 自动重试不改变已锁定作品。
 7. 候选 fallback 只发生在作品加锁之前。
 8. outbox 重放永不重新进入候选选择。
-9. 成功的 item 永不自动重跑；已确认的 `submitted` 永不被迟到结果降级。
-10. HTTP 状态码不是业务结果——只有解析后的 `DeliveryAck`（accepted/idempotent_replay/duplicate_existing/retryable/permanent）驱动账本。
-11. external 模式永不做历史 catch-up。
-12. 手动 ad-hoc 执行 ≠ scheduled occurrence。
-13. Core 不依赖 TelePost / Fly / Cloudflare；`if (fly)…`、`morning/evening` 枚举、bot 编号都不属于 Core。
+9. dependency 未 ready 不消耗 outbox attempt。
+10. 成功的 item 永不自动重跑；已确认的 `submitted` 永不被迟到结果降级。
+11. HTTP 状态码不是业务结果——只有解析后的 `DeliveryAck`（accepted/idempotent_replay/duplicate_existing/retryable/permanent）驱动账本。
+12. external 模式永不做历史 catch-up。
+13. 手动 ad-hoc 执行 ≠ scheduled occurrence。
+14. Core 不依赖 TelePost / Fly / Cloudflare；`if (fly)…`、`morning/evening` 枚举、bot 编号都不属于 Core。
 
 ## 存储层
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -207,10 +207,12 @@ delivery outbox 持久化、携带稳定幂等标识、指数退避重试。`not
       "my-api": {
         "type": "httpMultipart",
         "url": "https://example.test/submissions",
+        "readinessUrl": "https://example.test/ready",
         "notificationUrl": "https://example.test/notifications",
         "method": "POST",
         "headers": { "Authorization": "Bearer ${MY_API_TOKEN}" },
         "fileField": "files",
+        "previewFileField": "previews",
         "fields": { "title": "{{title}}", "source_id": "{{pixivId}}" },
         "arrayFormat": "comma",
         "success": { "statuses": [201], "jsonPath": "ok", "equals": true },
@@ -236,6 +238,11 @@ delivery outbox 持久化、携带稳定幂等标识、指数退避重试。`not
 标签，以逗号连接。需要同时投稿来源、计划主题和作品标签时可配置
 `"tags": ["Pixiv", "{{tag}}", "{{workTags}}"]`。headers
 和 URL 支持 `${ENV_NAME}`。`arrayFormat` 可设 `comma`、`repeat` 或 `json`。
+
+`readinessUrl` 是可选消费屏障：非 2xx 时 worker 放回 outbox row，不增加 attempt；
+不要用只表示进程存活的 `/live`。cache 模式插画会从 Pixiv 下载较小的 `large`/`medium`
+preview，并按 `previewFileField`（默认 `previews`）与 `fileField` 原图一一对应发送；原图
+仍是权威 artifact，接收端可以忽略 preview。
 
 #### Telegraph（telegra.ph）相册上传
 
@@ -283,12 +290,13 @@ telepress-server --host 0.0.0.0 --port 8000
 `success` 判定 `ok == true`。注意 telepress 相册要求图片文件，小说正文请走
 TelePost 等其他渠道。
 
-交付前会把任务写入数据库同目录的 `delivery-outbox/`。作品投递失败不会删除下载文件；
-无候选通知也先写入该 outbox，不需要依赖当前进程的内存状态。
-下次 `download` 或 scheduler 执行时先检查待投递项。`outboxRetryBaseMs` 默认
+交付前会把任务写入 SQLite `outbox` 表。作品投递失败不会删除下载文件；无候选通知也先
+写入该 outbox，不需要依赖当前进程的内存状态。独立 worker 在进程启动后持续消费；
+`outboxRetryBaseMs` 默认
 `300000`（5 分钟），`outboxRetryMaxMs` 默认 `21600000`（6 小时），失败后指数退避，
-避免远端故障时反复消耗带宽。成功后才删除作品文件、元数据 sidecar 和 outbox
-清单。`delivery.deleteAfterDelivery: false` 可用于调试时保留文件。
+避免远端故障时反复消耗带宽。成功后才删除作品文件和元数据 sidecar。
+dead row 用 `pixivflow outbox retry <id>` 或 `retry --dead` 正式重放，幂等键保持不变；
+`run-once` 不是 outbox 恢复命令。`delivery.deleteAfterDelivery: false` 可用于调试时保留文件。
 
 ## storage 存储与目录组织
 

--- a/docs/project/CHANGELOG.md
+++ b/docs/project/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### 新增
+
+- 缓存模式插画可把与原图一一对应的 Pixiv preview 交给通用 multipart 接收端。
+- delivery target 可配置 readiness endpoint；依赖未 ready 时 outbox 不消耗 attempt。
+- 新增 `pixivflow outbox` 的 list、inspect、dead-letter retry 和 pending cancel 运维入口。
+
 ## [2.10.31] - 2026-09-06
 
 ### 修复

--- a/src/__tests__/commands/DoctorReconcile.test.ts
+++ b/src/__tests__/commands/DoctorReconcile.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import { Database } from '../../storage/Database';
 import { DoctorCommand } from '../../commands/DoctorCommand';
 import { ReconcileCommand } from '../../commands/ReconcileCommand';
+import { OutboxCommand } from '../../commands/OutboxCommand';
 import { logger } from '../../logger';
 
 function ctx(dbPath: string) {
@@ -128,5 +129,48 @@ describe('reconcile command', () => {
     expect(badType.success).toBe(false);
     const missing = await command.execute(ctx(dbPath), { options: { target: 'bot1' }, positional: [] });
     expect(missing.success).toBe(false);
+  });
+});
+
+describe('outbox command', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pf-outbox-cli-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('lists, inspects, retries dead rows and cancels pending rows', async () => {
+    const dbPath = join(dir, 't.db');
+    const db = new Database(dbPath);
+    db.migrate();
+    const dead = db.outbox.enqueue({
+      kind: 'notification', deliveryTarget: 't', idempotencyKey: 'dead',
+      payload: { text: 'x' }, maxAttempts: 1,
+    });
+    db.outbox.markRetry(dead.id, Date.now(), 'boom');
+    const pending = db.outbox.enqueue({
+      kind: 'notification', deliveryTarget: 't', idempotencyKey: 'pending',
+      payload: { text: 'y' },
+    });
+    db.close();
+
+    const command = new OutboxCommand();
+    expect((await command.execute(ctx(dbPath), {
+      options: { status: 'dead' }, positional: ['list'],
+    })).data).toEqual([expect.objectContaining({ id: dead.id, status: 'dead' })]);
+    expect((await command.execute(ctx(dbPath), {
+      options: {}, positional: ['inspect', dead.id],
+    })).success).toBe(true);
+    expect((await command.execute(ctx(dbPath), {
+      options: { dead: true }, positional: ['retry'],
+    })).success).toBe(true);
+    expect((await command.execute(ctx(dbPath), {
+      options: {}, positional: ['cancel', pending.id],
+    })).success).toBe(true);
+
+    const check = new Database(dbPath);
+    expect(check.outbox.get(dead.id)).toMatchObject({ status: 'retry_wait', attempts: 0 });
+    expect(check.outbox.get(pending.id)).toMatchObject({ status: 'cancelled' });
+    check.close();
   });
 });

--- a/src/__tests__/delivery/OutboxFailureInjection.test.ts
+++ b/src/__tests__/delivery/OutboxFailureInjection.test.ts
@@ -32,10 +32,14 @@ class FakeDispatcher {
   deliverCalls = 0;
   notifyCalls = 0;
   deliveredKeys: string[] = [];
+  ready = true;
   constructor(
     private deliverScript: Array<() => Promise<{ ack: DeliveryAck }>> = [],
     private notifyScript: Array<() => Promise<void>> = [],
   ) {}
+  async isReady(): Promise<boolean> {
+    return this.ready;
+  }
   async deliver(_name: string, request: { context: Record<string, unknown> }): Promise<{ ack: DeliveryAck }> {
     this.deliverCalls++;
     const step = this.deliverScript.shift();
@@ -117,6 +121,29 @@ describe('OutboxWorker failure injection', () => {
       }
       const res = await worker.drainOnce();
       expect(res.done).toBe(1);
+      expect(dispatcher.deliverCalls).toBe(1);
+    });
+  });
+
+  it('does not consume an attempt while the dependency is live but not ready', async () => {
+    await withDb(async (db) => {
+      const dispatcher = new FakeDispatcher([
+        async () => ({ ack: { kind: 'accepted', remoteId: 'm-ready' } as DeliveryAck }),
+      ]);
+      dispatcher.ready = false;
+      const worker = new OutboxWorker(db, dispatcher as any);
+      const row = db.outbox.enqueue({
+        kind: 'delivery', deliveryTarget: 'bot1', idempotencyKey: 'k-ready',
+        payload: { files: [], context: { idempotencyKey: 'k-ready' } },
+      });
+
+      expect(await worker.drainOnce()).toEqual({ processed: 0, done: 0, retried: 0, dead: 0 });
+      expect(db.outbox.get(row.id)).toMatchObject({ status: 'pending', attempts: 0 });
+      expect(dispatcher.deliverCalls).toBe(0);
+
+      dispatcher.ready = true;
+      expect(await worker.drainOnce()).toMatchObject({ processed: 1, done: 1 });
+      expect(db.outbox.get(row.id)).toMatchObject({ status: 'done', attempts: 0 });
       expect(dispatcher.deliverCalls).toBe(1);
     });
   });

--- a/src/__tests__/delivery/http-multipart.test.ts
+++ b/src/__tests__/delivery/http-multipart.test.ts
@@ -94,6 +94,52 @@ describe('HttpMultipartDelivery', () => {
     expect(multipart).toContain('name="anonymous"\r\n\r\nfalse');
   });
 
+  it('sends aligned previews in their own multipart field', async () => {
+    const original = join(directory, 'original.png');
+    const preview = join(directory, 'preview.jpg');
+    await Promise.all([fs.writeFile(original, 'original'), fs.writeFile(preview, 'preview')]);
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    global.fetch = fetchMock as typeof fetch;
+    const provider = new HttpMultipartDelivery({
+      type: 'httpMultipart', url: 'https://example.test/submissions',
+      fileField: 'files', previewFileField: 'previews',
+    });
+
+    await provider.deliver({
+      files: [original], previewFiles: [preview],
+      context: { title: 'T', pixivId: '1', type: 'illustration' },
+    });
+
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    const chunks: Buffer[] = [];
+    for await (const chunk of options.body as unknown as AsyncIterable<Buffer>) chunks.push(Buffer.from(chunk));
+    const multipart = Buffer.concat(chunks).toString('utf8');
+    expect(multipart).toContain('name="files"; filename="original.png"');
+    expect(multipart).toContain('name="previews"; filename="preview.jpg"');
+  });
+
+  it('checks readiness independently of liveness', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(new Response('live', { status: 200 }))
+      .mockResolvedValueOnce(new Response('starting', { status: 503 }))
+      .mockResolvedValueOnce(new Response('ready', { status: 200 }));
+    global.fetch = fetchMock as typeof fetch;
+    const provider = new HttpMultipartDelivery({
+      type: 'httpMultipart', url: 'https://example.test/submissions',
+      readinessUrl: 'https://example.test/ready',
+    });
+
+    expect((await fetch('https://example.test/live')).status).toBe(200);
+    expect(await provider.isReady()).toBe(false);
+    expect(await provider.isReady()).toBe(true);
+    expect(fetchMock.mock.calls[1][0]).toBe('https://example.test/ready');
+  });
+
   it('sends authenticated JSON no-match notifications', async () => {
     const fetchMock = jest.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true, data: { status: 'notified' } }), { status: 201 })

--- a/src/__tests__/download/IllustrationDownloader.test.ts
+++ b/src/__tests__/download/IllustrationDownloader.test.ts
@@ -8,6 +8,56 @@ import { convertUgoira } from '../../download/UgoiraConverter';
 jest.mock('../../download/UgoiraConverter');
 
 describe('IllustrationDownloader', () => {
+  it('downloads an aligned lower-resolution delivery preview without replacing the original', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pixivflow-preview-'));
+    const originalPath = join(directory, '123_work_1.png');
+    const client = {
+      getIllustDetailWithTags: jest.fn().mockResolvedValue({
+        illust: {
+          id: 123, title: 'work', page_count: 1,
+          user: { id: '1', name: 'author' },
+          image_urls: { large: 'https://example.test/large.jpg' },
+          meta_single_page: { original_image_url: 'https://example.test/original.png' },
+        },
+        tags: [],
+      }),
+      downloadImage: jest.fn()
+        .mockResolvedValueOnce(Buffer.from('original'))
+        .mockResolvedValueOnce(Buffer.from('preview')),
+    };
+    const downloader = new IllustrationDownloader(
+      client as any,
+      { hasDownloaded: jest.fn().mockReturnValue(false), insertDownload: jest.fn() } as any,
+      {
+        sanitizeFileName: jest.fn((name) => name),
+        saveImage: jest.fn(async (data) => {
+          await writeFile(originalPath, Buffer.from(data));
+          return originalPath;
+        }),
+        saveMetadata: jest.fn().mockResolvedValue(undefined),
+      } as any,
+      1,
+      directory
+    );
+    try {
+      const result = await downloader.downloadIllustration(
+        { id: 123 } as any, 'tag', { includeDeliveryPreviews: true }
+      );
+      expect(client.downloadImage.mock.calls.map(([url]) => url)).toEqual([
+        'https://example.test/original.png',
+        'https://example.test/large.jpg',
+      ]);
+      expect(result?.files).toEqual([originalPath]);
+      expect(result?.previewFiles).toEqual([`${originalPath}.preview.jpg`]);
+      await expect(Promise.all([
+        import('node:fs/promises').then((mod) => mod.readFile(originalPath, 'utf8')),
+        import('node:fs/promises').then((mod) => mod.readFile(`${originalPath}.preview.jpg`, 'utf8')),
+      ])).resolves.toEqual(['original', 'preview']);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('converts retained ugoira frames before recording or delivering them', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'pixivflow-ugoira-'));
     const zip = join(directory, '123_work_ugoira.zip');

--- a/src/commands/OutboxCommand.ts
+++ b/src/commands/OutboxCommand.ts
@@ -1,0 +1,99 @@
+import { BaseCommand } from './Command';
+import { CommandCategory } from './metadata';
+import { CommandArgs, CommandContext, CommandResult } from './types';
+import { Database } from '../storage/Database';
+import { OutboxRow, OutboxStatus } from '../storage/repositories/OutboxRepository';
+
+const STATUSES = new Set<OutboxStatus>([
+  'pending', 'processing', 'retry_wait', 'done', 'dead', 'cancelled',
+]);
+
+export class OutboxCommand extends BaseCommand {
+  readonly name = 'outbox';
+  readonly description = 'List, inspect, retry or cancel durable delivery intents';
+  readonly requiresToken = false;
+  readonly metadata = {
+    category: CommandCategory.MAINTENANCE,
+    requiresAuth: true,
+    longRunning: false,
+  };
+
+  getUsage(): string {
+    return [
+      'pixivflow outbox list [--status dead] [--limit 100]',
+      'pixivflow outbox inspect <id>',
+      'pixivflow outbox retry <id>',
+      'pixivflow outbox retry --dead',
+      'pixivflow outbox cancel <id>',
+    ].join('\n');
+  }
+
+  async execute(context: CommandContext, args: CommandArgs): Promise<CommandResult> {
+    const action = args.positional[0] ?? 'list';
+    const id = args.positional[1];
+    const db = new Database(
+      context.config.storage?.databasePath ?? './data/pixiv-downloader.db'
+    );
+    try {
+      db.migrate();
+      if (action === 'list') {
+        const rawStatus = typeof args.options.status === 'string'
+          ? args.options.status as OutboxStatus : undefined;
+        if (rawStatus && !STATUSES.has(rawStatus)) {
+          return this.failure(`unknown outbox status: ${rawStatus}`);
+        }
+        const limit = Number(args.options.limit ?? 100);
+        const rows = db.outbox.list(rawStatus, Number.isFinite(limit) ? limit : 100);
+        for (const row of rows) context.logger.info('outbox', this.summary(row));
+        return this.success(`${rows.length} outbox row(s)`, rows.map((row) => this.summary(row)));
+      }
+      if (action === 'inspect') {
+        if (!id) return this.failure('Usage: pixivflow outbox inspect <id>');
+        const row = db.outbox.get(id);
+        return row ? this.success('outbox row', row) : this.failure(`outbox row not found: ${id}`);
+      }
+      if (action === 'retry') {
+        const rows = args.options.dead ? db.outbox.list('dead', 500) : [];
+        if (!args.options.dead) {
+          if (!id) return this.failure('Usage: pixivflow outbox retry <id> | --dead');
+          const row = db.outbox.get(id);
+          if (!row) return this.failure(`outbox row not found: ${id}`);
+          if (row.status !== 'dead') {
+            return this.failure(`outbox row is not dead: ${id}`);
+          }
+          rows.push(row);
+        }
+        for (const row of rows) db.outbox.requeue(row.id);
+        return this.success(`requeued ${rows.length} outbox row(s)`, { ids: rows.map((row) => row.id) });
+      }
+      if (action === 'cancel') {
+        if (!id) return this.failure('Usage: pixivflow outbox cancel <id>');
+        const row = db.outbox.get(id);
+        if (!row || !db.outbox.cancel(id)) {
+          return this.failure(`outbox row is missing, processing or already terminal: ${id}`);
+        }
+        if (row.deliveryId) {
+          db.deliveries.recordAck(row.deliveryId, {
+            status: 'failed', remoteStatus: 'cancelled', error: 'cancelled by operator',
+          });
+        }
+        return this.success('outbox row cancelled', { id });
+      }
+      return this.failure(this.getUsage());
+    } finally {
+      db.close();
+    }
+  }
+
+  private summary(row: OutboxRow) {
+    return {
+      id: row.id,
+      kind: row.kind,
+      status: row.status,
+      deliveryTarget: row.deliveryTarget,
+      attempts: row.attempts,
+      nextAttemptAt: row.nextAttemptAt,
+      lastError: row.lastError,
+    };
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -28,6 +28,7 @@ import { DirsCommand } from './DirsCommand';
 import { VersionCommand } from './VersionCommand';
 import { TagsCommand } from './TagsCommand';
 import { TopicCommand } from './TopicCommand';
+import { OutboxCommand } from './OutboxCommand';
 
 /**
  * Create and register all commands
@@ -58,6 +59,7 @@ export function registerAllCommands(registry: CommandRegistry): void {
   registry.register(new VersionCommand());
   registry.register(new TagsCommand());
   registry.register(new TopicCommand());
+  registry.register(new OutboxCommand());
 }
 
 /**
@@ -89,4 +91,5 @@ export {
   VersionCommand,
   TagsCommand,
   TopicCommand,
+  OutboxCommand,
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -493,6 +493,10 @@ export interface HttpMultipartDeliveryConfig {
   headers?: Record<string, string>;
   /** multipart 文件字段名，默认 files */
   fileField?: string;
+  /** 可选预览文件字段名，默认 previews；与 files 一一对应 */
+  previewFileField?: string;
+  /** Optional dependency readiness endpoint. Non-200 defers outbox attempts. */
+  readinessUrl?: string;
   /** 普通表单字段，支持 title/pixivId/type/tag/topic/workTags 模板变量 */
   fields?: Record<string, DeliveryFieldValue>;
   /** 数组字段编码方式，默认 comma */
@@ -609,7 +613,6 @@ export interface StandaloneConfig {
     timeout?: number;
   };
 }
-
 
 
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -226,6 +226,14 @@ export function validateConfig(config: Partial<StandaloneConfig>, location: stri
         errors.push(`${prefix}.notificationUrl: Must be a valid HTTP or HTTPS URL`);
       }
     }
+    if (delivery.readinessUrl && !/\$\{[A-Za-z_][A-Za-z0-9_]*\}/.test(delivery.readinessUrl)) {
+      try {
+        const url = new URL(delivery.readinessUrl);
+        if (!['http:', 'https:'].includes(url.protocol)) throw new Error('unsupported protocol');
+      } catch {
+        errors.push(`${prefix}.readinessUrl: Must be a valid HTTP or HTTPS URL`);
+      }
+    }
     if (delivery.method && !['POST', 'PUT'].includes(delivery.method)) {
       errors.push(`${prefix}.method: Must be "POST" or "PUT"`);
     }

--- a/src/delivery/DeliveryDispatcher.ts
+++ b/src/delivery/DeliveryDispatcher.ts
@@ -14,6 +14,14 @@ export class DeliveryDispatcher {
     return Boolean(this.config?.targets?.[name]);
   }
 
+  async isReady(name: string): Promise<boolean> {
+    const target = this.config?.targets?.[name];
+    // Readiness is an optional preflight. Missing targets still flow through
+    // deliver/notify so the durable outbox records the normal retry error.
+    if (!target) return true;
+    return new HttpMultipartDelivery(target, this.proxyUrl).isReady();
+  }
+
   async deliver(name: string, request: DeliveryRequest): Promise<DeliveryResult> {
     const target = this.config?.targets?.[name];
     if (!target) {

--- a/src/delivery/DeliveryService.ts
+++ b/src/delivery/DeliveryService.ts
@@ -125,6 +125,7 @@ export class DeliveryService {
             deliveryId: row.id,
             payload: {
               files: artifact.files,
+              previewFiles: artifact.previewFiles ?? [],
               cleanupFiles: artifact.cleanupFiles ?? [],
               fields: context.fields ?? null,
               context: { ...this.contextFrom(artifact, target), idempotencyKey, ...(context.extraContext ?? {}) },
@@ -145,6 +146,7 @@ export class DeliveryService {
         deliveryId: row.id,
         payload: {
           files: artifact.files,
+          previewFiles: artifact.previewFiles ?? [],
           cleanupFiles: artifact.cleanupFiles ?? [],
           fields: context.fields ?? null,
           context: { ...this.contextFrom(artifact, target), idempotencyKey, ...(context.extraContext ?? {}) },

--- a/src/delivery/HttpMultipartDelivery.ts
+++ b/src/delivery/HttpMultipartDelivery.ts
@@ -55,6 +55,22 @@ export class HttpMultipartDelivery implements DeliveryProvider {
     }
   }
 
+  async isReady(): Promise<boolean> {
+    const url = this.config.readinessUrl?.trim();
+    if (!url) return true;
+    const options: Record<string, unknown> = { method: 'GET' };
+    if (this.dispatcher) options.dispatcher = this.dispatcher;
+    try {
+      const response = await fetch(
+        this.interpolateEnvironment(url),
+        options as Parameters<typeof fetch>[1]
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
   /**
    * One delivery attempt. Retry/backoff/dead-letter belong to the outbox worker,
    * not here, so this performs exactly ONE HTTP call and normalizes the result
@@ -97,7 +113,9 @@ export class HttpMultipartDelivery implements DeliveryProvider {
       { ...(this.config.fields ?? {}), ...(request.fields ?? {}) },
       request
     );
-    const multipart = await this.createMultipartBody(request.files, fields);
+    const multipart = await this.createMultipartBody(
+      request.files, fields, request.previewFiles
+    );
     const headers: Record<string, string> = {
       ...this.resolveHeaders(this.config.headers ?? {}),
       'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
@@ -271,8 +289,12 @@ export class HttpMultipartDelivery implements DeliveryProvider {
 
   private async createMultipartBody(
     files: string[],
-    fields: Record<string, string[]>
+    fields: Record<string, string[]>,
+    previewFiles: string[] = []
   ): Promise<{ boundary: string; body: Readable; contentLength: number }> {
+    if (previewFiles.length > 0 && previewFiles.length !== files.length) {
+      throw new Error('previewFiles must be empty or align one-to-one with files');
+    }
     const boundary = `pixivflow-${randomUUID()}`;
     const fileField = this.escapeDispositionValue(this.config.fileField ?? 'files');
     const fileParts: Array<{ header: Buffer; path: string; size: number }> = [];
@@ -283,6 +305,20 @@ export class HttpMultipartDelivery implements DeliveryProvider {
       const header = Buffer.from(
         `--${boundary}\r\n` +
           `Content-Disposition: form-data; name="${fileField}"; filename="${filename}"\r\n` +
+          'Content-Type: application/octet-stream\r\n\r\n'
+      );
+      const stat = await fs.promises.stat(file);
+      fileParts.push({ header, path: file, size: stat.size });
+      contentLength += header.length + stat.size + 2;
+    }
+    const previewField = this.escapeDispositionValue(
+      this.config.previewFileField ?? 'previews'
+    );
+    for (const file of previewFiles) {
+      const filename = this.escapeDispositionValue(path.basename(file));
+      const header = Buffer.from(
+        `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="${previewField}"; filename="${filename}"\r\n` +
           'Content-Type: application/octet-stream\r\n\r\n'
       );
       const stat = await fs.promises.stat(file);

--- a/src/delivery/OutboxWorker.ts
+++ b/src/delivery/OutboxWorker.ts
@@ -25,6 +25,7 @@ export interface OutboxWorkerOptions {
 /** Delivery side-effect payload (frozen at enqueue time). */
 export interface DeliveryPayload {
   files: string[];
+  previewFiles?: string[];
   /** Sidecars + cached media removed after confirmed delivery (cache mode). */
   cleanupFiles?: string[];
   deleteAfterDelivery?: boolean;
@@ -106,13 +107,20 @@ export class OutboxWorker {
     for (let round = 0; round < maxRounds; round++) {
       const rows = this.database.outbox.claimDue(this.owner, this.leaseMs, this.batchSize);
       if (rows.length === 0) break;
+      let deferred = false;
       for (const row of rows) {
+        if (!(await this.dispatcher.isReady(row.deliveryTarget))) {
+          this.database.outbox.release(row.id);
+          deferred = true;
+          continue;
+        }
         processed++;
         const result = await this.process(row);
         if (result === 'done') done++;
         else if (result === 'dead') dead++;
         else retried++;
       }
+      if (deferred) break;
     }
     return { processed, done, retried, dead };
   }
@@ -124,6 +132,10 @@ export class OutboxWorker {
       const rows = this.database.outbox.claimDue(this.owner, this.leaseMs, this.batchSize);
       for (const row of rows) {
         if (this.stopped) {
+          this.database.outbox.release(row.id);
+          continue;
+        }
+        if (!(await this.dispatcher.isReady(row.deliveryTarget))) {
           this.database.outbox.release(row.id);
           continue;
         }
@@ -148,6 +160,7 @@ export class OutboxWorker {
         const payload = JSON.parse(row.payloadJson) as DeliveryPayload;
         const result = await this.dispatcher.deliver(row.deliveryTarget, {
           files: payload.files,
+          previewFiles: payload.previewFiles,
           fields: payload.fields as DeliveryRequest['fields'],
           context: payload.context as unknown as DeliveryRequest['context'],
         });
@@ -210,7 +223,11 @@ export class OutboxWorker {
 
   private async cleanup(payload: DeliveryPayload): Promise<void> {
     if (payload.deleteAfterDelivery === false) return;
-    const files = [...(payload.files ?? []), ...(payload.cleanupFiles ?? [])];
+    const files = [
+      ...(payload.files ?? []),
+      ...(payload.previewFiles ?? []),
+      ...(payload.cleanupFiles ?? []),
+    ];
     await Promise.all(
       [...new Set(files)].map((file) =>
         unlink(file).catch((error: NodeJS.ErrnoException) => {

--- a/src/delivery/types.ts
+++ b/src/delivery/types.ts
@@ -11,6 +11,8 @@ export interface DownloadedArtifact {
   tags?: string[];
   /** Files sent to the configured delivery target. */
   files: string[];
+  /** Optional per-file lightweight preview sources, aligned with ``files``. */
+  previewFiles?: string[];
   /** Local sidecars deleted with cache files after successful delivery. */
   cleanupFiles?: string[];
   /** R-18 work (x_restrict > 0): delivery templates may open Telegram spoiler. */
@@ -76,6 +78,8 @@ export interface DeliveryContext {
 
 export interface DeliveryRequest {
   files: string[];
+  /** Optional per-file preview sources, aligned with ``files``. */
+  previewFiles?: string[];
   fields?: Record<string, DeliveryFieldValue>;
   context: DeliveryContext;
 }

--- a/src/download/IllustrationDownloader.ts
+++ b/src/download/IllustrationDownloader.ts
@@ -38,7 +38,11 @@ export class IllustrationDownloader {
   async downloadIllustration(
     illust: PixivIllust,
     tag: string,
-    options: { aiMetadataCheck?: boolean; maxPageCount?: number } = {}
+    options: {
+      aiMetadataCheck?: boolean;
+      maxPageCount?: number;
+      includeDeliveryPreviews?: boolean;
+    } = {}
   ): Promise<DownloadedArtifact | null> {
     // Check if files already exist in file system but not in database
     const existingFiles = await this.findExistingIllustrationFiles(illust.id);
@@ -125,6 +129,21 @@ export class IllustrationDownloader {
         );
         const filePath = await this.fileService.saveImage(buffer, fileName, metadata);
 
+        let previewPath: string | undefined;
+        const previewUrl = page.image_urls.large ?? page.image_urls.medium;
+        if (options.includeDeliveryPreviews && previewUrl && previewUrl !== originalUrl) {
+          try {
+            const preview = await withTimeout(
+              this.client.downloadImage(previewUrl), 120000,
+              `Timeout: Failed to download preview for illustration ${detail.id} page ${index + 1}`
+            );
+            previewPath = `${filePath}.preview.jpg`;
+            await fs.writeFile(previewPath, Buffer.from(preview));
+          } catch (error) {
+            logger.warn(`Preview unavailable for illustration ${detail.id} page ${index + 1}: ${getErrorMessage(error)}`);
+          }
+        }
+
         // Release the page buffer promptly: ArrayBuffers are external memory,
         // NOT capped by --max-old-space-size. Without explicit GC they linger
         // and accumulate while downloading multi-page works, ballooning node
@@ -166,7 +185,7 @@ export class IllustrationDownloader {
           logger.warn(`Failed to save metadata for illustration ${detail.id} page ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
         }
 
-        return { filePath, index: index + 1, metadataPath };
+        return { filePath, index: index + 1, metadataPath, previewPath };
       },
       concurrency
     );
@@ -175,6 +194,7 @@ export class IllustrationDownloader {
     let successCount = 0;
     const files: string[] = [];
     const cleanupFiles: string[] = [];
+    const previewFiles: string[] = [];
     for (const result of downloadResults) {
       if (result.success) {
         this.database.insertDownload({
@@ -197,6 +217,10 @@ export class IllustrationDownloader {
         files.push(result.result.filePath);
         if (result.result.metadataPath) {
           cleanupFiles.push(result.result.metadataPath);
+        }
+        if (result.result.previewPath) {
+          previewFiles.push(result.result.previewPath);
+          cleanupFiles.push(result.result.previewPath);
         }
       } else {
         logger.warn(`Failed to download page ${result.error.message}`, { 
@@ -249,6 +273,7 @@ export class IllustrationDownloader {
       title: detail.title,
       tags: tags.map((item) => item.name).filter(Boolean),
       files,
+      previewFiles: previewFiles.length === files.length ? previewFiles : undefined,
       cleanupFiles,
       spoiler: (detail.x_restrict ?? 0) > 0,
       xRestrict: detail.x_restrict,

--- a/src/download/handlers/IllustrationTargetHandler.ts
+++ b/src/download/handlers/IllustrationTargetHandler.ts
@@ -458,6 +458,9 @@ export class IllustrationTargetHandler {
       {
         aiMetadataCheck: target.aiMetadataCheck === true,
         maxPageCount: target.maxPageCount,
+        includeDeliveryPreviews: Boolean(
+          target.storageMode === 'cache' && target.delivery?.target?.trim()
+        ),
       }
     );
     if (!artifact) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ async function bootstrap() {
   let config: StandaloneConfig;
   try {
     const isLoginCommand = ['login', 'l', 'login-interactive', 'li', 'login-headless'].includes(commandName || '');
-    const tokenOptionalCommands = new Set(['config', 'dirs', 'logs', 'setup', 'status', 'health', 'maintain', 'normalize', 'migrate-config', 'backup', 'monitor', 'webui', 'w']);
+    const tokenOptionalCommands = new Set(['config', 'dirs', 'logs', 'setup', 'status', 'health', 'maintain', 'normalize', 'migrate-config', 'backup', 'monitor', 'outbox', 'webui', 'w']);
     const isTokenOptional = commandName ? tokenOptionalCommands.has(commandName) : true;
     
     config = loadConfig(configPath, isLoginCommand || isTokenOptional || !commandName);

--- a/src/storage/repositories/OutboxRepository.ts
+++ b/src/storage/repositories/OutboxRepository.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { BaseRepository } from './BaseRepository';
 
 export type OutboxKind = 'delivery' | 'notification';
-export type OutboxStatus = 'pending' | 'processing' | 'retry_wait' | 'done' | 'dead';
+export type OutboxStatus = 'pending' | 'processing' | 'retry_wait' | 'done' | 'dead' | 'cancelled';
 
 export interface OutboxRow {
   id: string;
@@ -88,6 +88,18 @@ export class OutboxRepository extends BaseRepository {
       .prepare(`SELECT * FROM outbox WHERE kind = ? AND idempotency_key = ?`)
       .get(kind, key) as any;
     return row ? this.toRow(row) : null;
+  }
+
+  list(status?: OutboxStatus, limit = 100): OutboxRow[] {
+    const bounded = Math.max(1, Math.min(Math.trunc(limit), 500));
+    const rows = status
+      ? this.db.prepare(
+          `SELECT * FROM outbox WHERE status=? ORDER BY created_at DESC LIMIT ?`
+        ).all(status, bounded)
+      : this.db.prepare(
+          `SELECT * FROM outbox ORDER BY created_at DESC LIMIT ?`
+        ).all(bounded);
+    return (rows as any[]).map((row) => this.toRow(row));
   }
 
   /**
@@ -191,6 +203,15 @@ export class OutboxRepository extends BaseRepository {
                  completed_at=NULL, updated_at=@dueAt WHERE id=@id`
       )
       .run({ id, dueAt });
+  }
+
+  cancel(id: string, now: number = Date.now()): boolean {
+    const result = this.db.prepare(
+      `UPDATE outbox SET status='cancelled', lease_owner=NULL, lease_until=NULL,
+              last_error='cancelled by operator', completed_at=@now, updated_at=@now
+       WHERE id=@id AND status IN ('pending','retry_wait','dead')`
+    ).run({ id, now });
+    return result.changes === 1;
   }
 
   counts(now: number = Date.now()): {

--- a/src/utils/config-validator-unified.ts
+++ b/src/utils/config-validator-unified.ts
@@ -276,6 +276,18 @@ export class ConfigValidator {
           });
         }
       }
+      if (delivery.readinessUrl && !/\$\{[A-Za-z_][A-Za-z0-9_]*\}/.test(delivery.readinessUrl)) {
+        try {
+          const url = new URL(delivery.readinessUrl);
+          if (!['http:', 'https:'].includes(url.protocol)) throw new Error('unsupported protocol');
+        } catch {
+          errors.push({
+            code: 'CONFIG_VALIDATION_DELIVERY_READINESS_URL_INVALID',
+            field: `${prefix}.readinessUrl`,
+            message: `Delivery target '${name}': readinessUrl must be valid HTTP or HTTPS`,
+          });
+        }
+      }
       if (delivery.maxAttempts !== undefined && (!Number.isInteger(delivery.maxAttempts) || delivery.maxAttempts < 1)) {
         errors.push({
           code: 'CONFIG_VALIDATION_DELIVERY_ATTEMPTS_INVALID',


### PR DESCRIPTION
## Summary
- send optional aligned Pixiv previews while retaining originals
- defer outbox work until dependency readiness without consuming attempts
- add supported outbox list/inspect/dead-letter retry/cancel operations

## Verification
- npm run build
- 51 suites, 626 tests passed
- readiness, ACK loss/idempotency, multipart preview and CLI recovery covered