### PR TITLE
fix(ci): grant issues:write so releasegraph v1 can start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
+  # releasegraph's reusable workflow (v1, "provider reconciliation") labels the
+  # release PR while reconciling provider state. A called workflow can never
+  # request more than its caller, and a mismatch fails the whole run at startup
+  # with no jobs, so this must stay in sync with that workflow.
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
releasegraph's v1 tag moved to the provider-reconciliation workflow, whose jobs request `issues: write`. A called reusable workflow cannot exceed its caller's permissions, so the Release workflow now fails at **startup** with zero jobs on every push and dispatch — blocking the 2.16.0 publish.

This adds the missing permission. Verified by the Release run on this PR (it must start instead of reporting startup_failure).