### PR TITLE
fix(packaging): bundle @redtidev/pixiv-client so npm install pixivflow works

### DIFF
--- a/docs/PIXIV_CLIENT_KIT.md
+++ b/docs/PIXIV_CLIENT_KIT.md
@@ -127,6 +127,18 @@ one Pixiv HTTP stack remains.
 
 Dependency change: added `undici` (kit); removed unused `https-proxy-agent`.
 
+### The published artifact stays self-contained
+
+`pixivflow` is consumed straight from npm by the Fly/Docker deployments, so the
+kit is **bundled** into the published tarball rather than resolved from the
+registry: the root `package.json` lists it in `bundleDependencies`, and npm
+ships the workspace package at `node_modules/@redtidev/pixiv-client` inside the
+tarball (its runtime deps — axios, socks-proxy-agent, undici — are already
+direct dependencies of `pixivflow`). Publishing the kit separately is only
+needed once an external consumer wants it directly; do NOT turn the dependency
+into a plain registry range before that, or every `npm install pixivflow` fails
+with a 404.
+
 ## When to split out into its own repository
 
 Not yet. The honest gating conditions are:

--- a/package.json
+++ b/package.json
@@ -227,5 +227,8 @@
     "systemd",
     "electron",
     "desktop-app"
+  ],
+  "bundleDependencies": [
+    "@redtidev/pixiv-client"
   ]
 }


### PR DESCRIPTION
Published **2.16.0 is uninstallable**: it depends on `@redtidev/pixiv-client@0.1.0`, which does not exist on the registry, so `npm install pixivflow` fails with E404. Found by the Fly deploy (the combined image installs pixivflow from npm):

```
npm error 404 Not Found - GET https://registry.npmjs.org/@redtidev%2fpixiv-client
npm error 404  The requested resource '@redtidev/pixiv-client@0.1.0' could not be found
```

Fix: list the kit in root `bundleDependencies`. npm then ships the workspace package inside the tarball at `node_modules/@redtidev/pixiv-client`; its runtime deps (axios, socks-proxy-agent, undici) are already direct deps of pixivflow, so no registry lookup is needed.

Verified locally:
- `npm pack` → tarball contains `package/node_modules/@redtidev/pixiv-client/dist/*` (118 entries)
- install into an empty project from the tarball: 177 packages in 5s, no 404 (previously fatal)
- adapter + kit exports load from inside the installed package
- `docs/PIXIV_CLIENT_KIT.md` documents why the dependency must stay bundled until an external consumer needs the kit directly