### PR TITLE
chore(release-infra): bump ReleaseGraph to v1.4.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   release:
-    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@6b3843bfdd73338831630e004eaf3535b84dcfd3 # ReleaseGraph v1.4.3
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@f0b1da0a62a7f4f26eab36353a58c6254b751c07 # ReleaseGraph v1.4.4
     with:
       version: ${{ inputs.version || '' }}
       dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}


### PR DESCRIPTION
Bumps the reusable release workflow pin to ReleaseGraph v1.4.4 (f0b1da0a62a7f4f26eab36353a58c6254b751c07).

v1.4.4 makes published images report a real build date (`BUILD_DATE` plus the OCI `image.created` label) instead of `build_date=dev`, and leaves `autorelease` label acknowledgement to the provider alone.

Verified on the fleet canary first: TelePost is already pinned to v1.4.4 and its release workflow runs (PR dry-run and main push) concluded success. Repositories pinning `@v1` already follow this version.