### PR TITLE
docs: 侧边栏按信息架构规约收敛，拆分语言侧边栏

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 - 开始使用
-  - [文档中心](/)
+  - [概览](/)
   - [📥 下载](/download.md)
   - [快速开始](/QUICKSTART.md)
   - [账号登录](/LOGIN.md)
@@ -11,20 +11,13 @@
   - [Docker 部署](/DOCKER.md)
   - [Apprise 通知网关](/APPRISE.md)
   - [Termux 安装](/TERMUX_INSTALL.md)
-- 开发者
+- 开发
   - [架构说明](/ARCHITECTURE.md)
   - [Pixiv Client Kit](/PIXIV_CLIENT_KIT.md)
-  - [Pixiv Client Kit (EN)](/en/PIXIV_CLIENT_KIT.md)
   - [WebUI API](/API.md)
   - [v1 → v2 迁移指南](/MIGRATION.md)
   - [发版流程](/RELEASING.md)
-  - [贡献指南](https://github.com/redtidev1918/PixivFlow/blob/master/CONTRIBUTING.md)
-  - [更新日志](https://github.com/redtidev1918/PixivFlow/blob/master/CHANGELOG.md)
-- 其他
+- 项目
   - [致谢](/ACKNOWLEDGMENTS.md)
-- English
-  - [Documentation](/en/)
-  - [📥 Download](/en/download.md)
-  - [Quick start](/en/QUICKSTART.md)
-  - [Login guide](/en/LOGIN.md)
-  - [Pixiv Client Kit](/en/PIXIV_CLIENT_KIT.md)
+  - [贡献指南（GitHub）](https://github.com/redtidev1918/PixivFlow/blob/master/CONTRIBUTING.md)
+  - [更新日志（GitHub）](https://github.com/redtidev1918/PixivFlow/blob/master/CHANGELOG.md)

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -1,0 +1,6 @@
+- Documentation
+  - [Overview](/en/)
+  - [📥 Download](/en/download.md)
+  - [Quick Start](/en/QUICKSTART.md)
+  - [Login Guide](/en/LOGIN.md)
+  - [Pixiv Client Kit](/en/PIXIV_CLIENT_KIT.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,11 +50,13 @@
       name: '🐱 PixivFlow',
       nameLink: '#/',
       repo: 'redtidev1918/PixivFlow',
-      loadSidebar: true,
+            loadSidebar: true,
+      // 语言是站点维度：docsify 原生按页面所在目录取 _sidebar.md——
+      // 根页面读 /_sidebar.md，/en/ 页面读 /en/_sidebar.md，无需 alias。
+      // 注意：不要配置 '/.*/_sidebar.md' 之类的通配 alias，它会把 /en/_sidebar.md
+      // 改写回根侧边栏，破坏分语言导航；页内标题也不注入 sidebar（无 subMaxLevel）。
+
       // 子目录页面（如 zh-CN/）也统一用根侧边栏；链接用根绝对路径（/FOO.md）
-      alias: { '/.*/_sidebar.md': '/_sidebar.md' },
-      subMaxLevel: 2,
-      maxLevel: 3,
       auto2top: true,
       search: {
         placeholder: '搜索文档…',


### PR DESCRIPTION
按 [docsite 导航与信息架构规约](https://github.com/redtidev1918/docsite/pull/3) 收敛（DAViewer 试点后第二批）：

- `docs/_sidebar.md` 改为**中文单语**、任务型分类：首页条目称「概览」（Overview）；下载仅保留一个入口；删除页内锚点项、底部 English 整组与单页面顶级分类
- 新增 `docs/en/_sidebar.md`（**英文单语**）：与中文结构语义对称、页面一一对应；无英文翻译的页面不造伪英文入口（标注式 fallback 见规约）
- `docs/index.html`：移除 `/.*/_sidebar.md` 通配 alias（会把 /en/ 页面静默改写回根侧边栏）与 `subMaxLevel`/`maxLevel`（页内标题注入 sidebar 渲染），改由 docsify 原生按页面目录解析侧边栏

不删任何首页/文档内容，不改 runtime code，不发 release。验收：`docsite.py navcheck` ✅（本仓已跑通）。