### PR TITLE
test(release): validate the packed npm artifact black-box

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -34,5 +34,8 @@ jobs:
           node-version: '22'
           cache: npm
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run package smoke (pack -> install -> boot -> storage -> script gate)
         run: node scripts/package-smoke.mjs

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,38 @@
+name: Package Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Tarball smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Run package smoke (pack -> install -> boot -> storage -> script gate)
+        run: node scripts/package-smoke.mjs

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:scheduled": "jest --runTestsByPath src/__tests__/integration/download-flow.test.ts",
     "test:concurrency": "jest --runTestsByPath src/__tests__/utils/concurrency.test.ts",
     "test:performance": "jest --runInBand src/__tests__/performance",
+    "smoke:package": "node scripts/package-smoke.mjs",
     "benchmark": "npm run test:performance",
     "analyze:complexity": "node scripts/analyze-complexity.js",
     "analyze:unused": "npx ts-prune",
@@ -135,7 +136,7 @@
   },
   "files": [
     "dist/",
-    "config/standalone.config.example.json",
+    "config/examples/",
     "config/fly-two-bots.example.json",
     "README.md",
     "README.en.md",

--- a/scripts/package-smoke-allowlist.json
+++ b/scripts/package-smoke-allowlist.json
@@ -1,0 +1,26 @@
+{
+  "$comment": [
+    "Explicit, reviewed exceptions to the zero-install-script packaging policy.",
+    "Every entry must state why it exists and which phase removes it.",
+    "Do not add entries to work around new transitive install scripts -",
+    "fix the dependency boundary instead (scripts/package-smoke.mjs enforces this)."
+  ],
+  "allowed": [
+    {
+      "name": "better-sqlite3",
+      "scripts": ["install"],
+      "reason": "Core storage driver compiled by node-gyp at install time.",
+      "removal": "Phase D: migrate storage to node:sqlite (Node >=22.13), then delete this entry and the dependency.",
+      "added": "2026-09-11",
+      "reviewedBy": "redtidev1918"
+    },
+    {
+      "name": "puppeteer",
+      "scripts": ["postinstall"],
+      "reason": "Downloads a Chromium build at install time; pulled in transitively by pixiv-token-getter ^2.4.0.",
+      "removal": "Phase B: pixiv-token-getter switches to puppeteer-core + system browser discovery, then delete this entry.",
+      "added": "2026-09-11",
+      "reviewedBy": "redtidev1918"
+    }
+  ]
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * Black-box package smoke: validates the artifact npm users actually install.
+ *
+ * Pipeline:
+ *   1. npm pack -> tarball (+ file list JSON)
+ *   2. artifact content assertions (dist, bundled workspace, docs, config)
+ *   3. clean global install into an isolated prefix
+ *   4. install-script gate: zero required lifecycle scripts in the runtime
+ *      dependency tree, except entries in scripts/package-smoke-allowlist.json
+ *      (explicit, documented, reviewed — see §19 of the packaging policy)
+ *   5. CLI boot: `pixivflow --version` / `--help` from the installed bin
+ *   6. storage smoke: open the installed Database, run migrations, metadata
+ *      write/read roundtrip, close
+ *
+ * Usage:
+ *   node scripts/package-smoke.mjs            # full smoke (CI + local)
+ *   node scripts/package-smoke.mjs --strict   # ignore the allowlist, fail on
+ *                                             # ANY lifecycle script (used to
+ *                                             # prove the gate detects packages)
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const strict = process.argv.includes('--strict');
+const failures = [];
+const steps = [];
+
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+    ...opts,
+  });
+  if (res.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(' ')} exited ${res.status}\n${res.stdout || ''}\n${res.stderr || ''}`
+    );
+  }
+  return res;
+}
+
+function step(name, fn) {
+  process.stdout.write(`\n== ${name} ...\n`);
+  try {
+    const detail = fn();
+    if (detail) process.stdout.write(`   ok: ${detail}\n`);
+    steps.push({ name, ok: true });
+  } catch (error) {
+    process.stdout.write(`   FAIL: ${error.message}\n`);
+    failures.push({ name, error: error.message });
+    steps.push({ name, ok: false });
+  }
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivflow-pkg-smoke-'));
+process.stdout.write(`workspace: ${tmp}\n`);
+
+// ---------------------------------------------------------------- 1. pack
+let packResult;
+step('npm pack', () => {
+  const res = run('npm', ['pack', '--json', '--pack-destination', tmp], { cwd: repoRoot });
+  const parsed = JSON.parse(res.stdout);
+  packResult = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!packResult?.filename) throw new Error('npm pack --json returned no filename');
+  return `${packResult.filename} (${Math.round(packResult.size / 1024)} KiB, ${packResult.files?.length ?? '?'} files)`;
+});
+
+const tarballPath = path.join(tmp, packResult.filename);
+// npm pack --json reports paths WITHOUT the `package/` root; accept either form.
+const packedFiles = (packResult.files ?? []).map((f) => {
+  const p = f.path.replace(/\\/g, '/');
+  return p.startsWith('package/') ? p.slice('package/'.length) : p;
+});
+
+// ------------------------------------------------- 2. artifact contents
+step('artifact contents (dist / bundled workspace / docs / config)', () => {
+  const required = [
+    'dist/index.js',
+    'package.json',
+    'README.md',
+    'LICENSE',
+    'config/examples/standalone.config.example.json',
+    'config/fly-two-bots.example.json',
+  ];
+  const missing = required.filter((f) => !packedFiles.includes(f));
+  if (missing.length) throw new Error(`missing from tarball: ${missing.join(', ')}`);
+  // Note: npm pack --json's file list does NOT include bundled dependencies'
+  // contents, so @redtidev/pixiv-client is asserted against the INSTALLED
+  // tree in the next step instead.
+});
+
+// --------------------------------------------- 3. clean global install
+let prefix;
+step('clean global install', () => {
+  prefix = path.join(tmp, 'prefix');
+  fs.mkdirSync(prefix, { recursive: true });
+  run('npm', ['install', '-g', '--prefix', prefix, '--no-audit', '--no-fund', tarballPath], {
+    cwd: tmp,
+    env: { ...process.env, npm_config_update_notifier: 'false' },
+  });
+  // Workspace inclusion: @redtidev/pixiv-client must be present AND resolvable
+  // from the installed package (a missing workspace is exactly the
+  // MODULE_NOT_FOUND release-defect class observed with the executor image).
+  const pkgRoot = installedPkgRoot();
+  const kitDistDir = path.join(pkgRoot, 'node_modules', '@redtidev', 'pixiv-client', 'dist');
+  if (!fs.existsSync(kitDistDir)) {
+    throw new Error('@redtidev/pixiv-client dist/ missing from the installed tree');
+  }
+  const requireFromInstall = createRequire(path.join(pkgRoot, 'package.json'));
+  requireFromInstall.resolve('@redtidev/pixiv-client');
+  return `installed + @redtidev/pixiv-client resolvable (${fs.readdirSync(kitDistDir).length} dist entries)`;
+});
+
+function installedPkgRoot() {
+  const candidates =
+    process.platform === 'win32'
+      ? [path.join(prefix, 'node_modules', 'pixivflow')]
+      : [path.join(prefix, 'lib', 'node_modules', 'pixivflow')];
+  const found = candidates.find((p) => fs.existsSync(p));
+  if (!found) throw new Error(`installed pixivflow not found under ${prefix}`);
+  return found;
+}
+
+// ------------------------------------- 4. install-script gate (zero policy)
+const ALLOWLIST_PATH = path.join(repoRoot, 'scripts', 'package-smoke-allowlist.json');
+step('install-script gate', () => {
+  const pkgRoot = installedPkgRoot();
+  const nmDir = path.join(pkgRoot, 'node_modules');
+  if (!fs.existsSync(nmDir)) throw new Error(`no node_modules under ${pkgRoot}`);
+
+  const offenders = [];
+  const queue = [nmDir];
+  while (queue.length) {
+    const dir = queue.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith('@')) queue.push(full); // scope dir
+        else queue.push(full);
+        continue;
+      }
+      if (entry.name !== 'package.json') continue;
+      try {
+        const manifest = JSON.parse(fs.readFileSync(full, 'utf8'));
+        const scripts = manifest.scripts ?? {};
+        const lifecycle = ['preinstall', 'install', 'postinstall'].filter((k) => scripts[k]);
+        if (lifecycle.length) {
+          offenders.push({
+            name: manifest.name || path.relative(nmDir, path.dirname(full)),
+            scripts: lifecycle,
+            via: path.relative(nmDir, path.dirname(full)),
+          });
+        }
+      } catch {
+        /* unreadable manifest -> ignore */
+      }
+    }
+  }
+
+  const allowlist = strict
+    ? []
+    : JSON.parse(fs.readFileSync(ALLOWLIST_PATH, 'utf8')).allowed ?? [];
+  const allowedNames = new Set(allowlist.map((a) => a.name));
+  const violations = offenders.filter((o) => !allowedNames.has(o.name));
+  const stale = [...allowedNames].filter((n) => !offenders.some((o) => o.name === n));
+
+  const summary = offenders
+    .map((o) => `${o.name} [${o.scripts.join(',')}]`)
+    .join(', ');
+  process.stdout.write(`   tree: ${offenders.length} package(s) with lifecycle scripts\n`);
+  if (summary) process.stdout.write(`   found: ${summary}\n`);
+  for (const s of stale) process.stdout.write(`   STALE allowlist entry (no longer needed): ${s}\n`);
+
+  if (violations.length) {
+    throw new Error(
+      `required install scripts detected (not covered by the allowlist): ` +
+        violations.map((v) => `${v.name} [${v.scripts.join(',')}]`).join(', ') +
+        `\n   Packaging policy: zero required third-party install scripts.` +
+        `\n   Fix the dependency boundary; do not grow the allowlist.`
+    );
+  }
+  if (strict && offenders.length) {
+    throw new Error(
+      `--strict: lifecycle scripts present: ` +
+        offenders.map((o) => `${o.name} [${o.scripts.join(',')}]`).join(', ')
+    );
+  }
+  return strict ? 'strict mode: no exceptions honored' : 'all lifecycle scripts are explicit allowlist entries';
+});
+
+// ----------------------------------------------------------- 5. CLI boot
+step('CLI boot (--version / --help)', () => {
+  const binDir =
+    process.platform === 'win32' ? prefix : path.join(prefix, 'bin');
+  const binName = process.platform === 'win32' ? 'pixivflow.cmd' : 'pixivflow';
+  const bin = path.join(binDir, binName);
+  if (!fs.existsSync(bin)) throw new Error(`bin not found at ${bin}`);
+
+  const version = run(bin, ['--version'], { cwd: tmp, timeout: 60_000 });
+  if (!/\d+\.\d+\.\d+/.test(version.stdout)) {
+    throw new Error(`--version printed no semver: ${JSON.stringify(version.stdout.slice(0, 120))}`);
+  }
+  const help = run(bin, ['--help'], { cwd: tmp, timeout: 60_000 });
+  if (help.stdout.length < 40) throw new Error('--help output suspiciously short');
+  return `version=${version.stdout.trim().slice(0, 40)}`;
+});
+
+// ------------------------------------------------------ 6. storage smoke
+step('storage smoke (open / migrate / write / read / close)', () => {
+  const pkgRoot = installedPkgRoot();
+  const requireFromInstall = createRequire(path.join(pkgRoot, 'package.json'));
+  const dbModulePath = requireFromInstall.resolve('pixivflow/dist/storage/Database.js');
+  const { Database } = requireFromInstall(dbModulePath);
+
+  const dbPath = path.join(tmp, 'smoke-data', 'pixivflow.db');
+  const db = new Database(dbPath);
+  db.migrate();
+
+  const meta = db.metadata;
+  meta.put('smoke-pixiv-id-1', 'illustration', { language: 'zh-cn', title: 'smoke entry' });
+  const row = meta.get('smoke-pixiv-id-1', 'illustration');
+  if (!row || row.title !== 'smoke entry') {
+    throw new Error('metadata write/read roundtrip failed');
+  }
+  db.close();
+  if (!fs.existsSync(dbPath)) throw new Error('database file was not created');
+  return `migrated + roundtrip ok at ${dbPath}`;
+});
+
+// ---------------------------------------------------------------- report
+const pass = failures.length === 0;
+process.stdout.write(
+  `\n${pass ? 'PACKAGE SMOKE: PASS' : 'PACKAGE SMOKE: FAIL'}\n` +
+    steps.map((s) => `  ${s.ok ? '✓' : '✗'} ${s.name}`).join('\n') +
+    '\n'
+);
+if (!pass) {
+  for (const f of failures) process.stderr.write(`\nfailure [${f.name}]:\n${f.error}\n`);
+  process.exit(1);
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -62,6 +62,14 @@ function step(name, fn) {
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pixivflow-pkg-smoke-'));
 process.stdout.write(`workspace: ${tmp}\n`);
 
+// ------------------------------------------------ 0. build (CI-clean tree)
+// `npm pack` does NOT run prepublishOnly, so a fresh checkout packs a tarball
+// without dist/. Build explicitly so the artifact always reflects HEAD.
+step('npm run build', () => {
+  run('npm', ['run', 'build'], { cwd: repoRoot });
+  return 'dist/ built';
+});
+
 // ---------------------------------------------------------------- 1. pack
 let packResult;
 step('npm pack', () => {

--- a/src/__tests__/commands/DiagnoseEgressCommand.test.ts
+++ b/src/__tests__/commands/DiagnoseEgressCommand.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for `pixivflow diagnose egress`.
+ *
+ * No real network: every probe goes through the injected fetchImpl, and the OAuth
+ * probe is exercised in its PIXIV_AUTH_READONLY path (which fails locally without
+ * touching the token endpoint).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DiagnoseEgressCommand } from '../../commands/DiagnoseEgressCommand';
+import { Database } from '../../storage/Database';
+
+jest.spyOn(console, 'log').mockImplementation(() => undefined);
+jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+interface MockResponseInit {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+function makeResponse({ status, body, headers = {} }: MockResponseInit): Response {
+  const payload = body === undefined ? '' : JSON.stringify(body);
+  return {
+    status,
+    ok: status < 400,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    json: async () => body,
+    text: async () => payload,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  } as unknown as Response;
+}
+
+function ctx(dbPath: string, withToken = false) {
+  return {
+    config: {
+      pixiv: { refreshToken: withToken ? 'x'.repeat(43) : 'YOUR_REFRESH_TOKEN' },
+      network: {},
+      storage: { databasePath: dbPath },
+    } as any,
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+    configPath: '',
+  };
+}
+
+function tempDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagnose-egress-'));
+  return path.join(dir, 'test.db');
+}
+
+/**
+ * Seed a valid cached access token so the readonly OAuth probe succeeds from cache
+ * (PIXIV_AUTH_READONLY never hits the token endpoint) and the App API / media probes
+ * can run authenticated.
+ */
+function seedAccessTokenCache(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.migrate();
+  db.saveToken('pixiv_access_token', {
+    accessToken: 'test-access-token',
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    refreshToken: 'x'.repeat(43),
+    tokenType: 'bearer',
+  });
+  db.close();
+}
+
+afterEach(() => {
+  delete process.env.PIXIV_AUTH_READONLY;
+  jest.restoreAllMocks();
+  jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+describe('DiagnoseEgressCommand', () => {
+  it('rejects unknown diagnose targets', async () => {
+    const command = new DiagnoseEgressCommand();
+    const res = await command.execute(ctx(tempDbPath()), { options: {}, positional: ['bogus'] });
+    expect(res.success).toBe(false);
+  });
+
+  it('skips oauth/appapi/media without a usable token and still probes reachability', async () => {
+    const fetchImpl = jest.fn(async () => makeResponse({ status: 403 }));
+    const command = new DiagnoseEgressCommand({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await command.execute(ctx(tempDbPath()), { options: {}, positional: ['egress'] });
+
+    expect(res.success).toBe(true);
+    const data = res.data as any;
+    const codes = data.findings.map((f: any) => f.code);
+    expect(codes).toContain('pixiv-net-ok');
+    expect(codes).toContain('oauth-skipped');
+    expect(codes).toContain('appapi-skipped');
+    expect(codes).toContain('media-skipped');
+    expect(data.verdict).toBe('INCOMPLETE');
+    expect(data.incomplete).toBe(true);
+    expect(res.exitCode ?? 0).toBe(0);
+    // Only the reachability probe should have used fetch.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a warn (not a crash) when readonly auth blocks the OAuth probe', async () => {
+    process.env.PIXIV_AUTH_READONLY = 'true';
+    const dbPath = tempDbPath();
+    const fetchImpl = jest.fn(async (input: any) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.startsWith('https://app-api.pixiv.net/')) {
+        // Not reachable in this test: no access token exists, but the probe must
+        // still classify the response instead of hanging.
+        return makeResponse({ status: 403 });
+      }
+      return makeResponse({ status: 403 });
+    });
+    const command = new DiagnoseEgressCommand({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await command.execute(ctx(dbPath, true), { options: {}, positional: ['egress'] });
+
+    expect(res.success).toBe(true);
+    const data = res.data as any;
+    const codes = data.findings.map((f: any) => f.code);
+    expect(codes).toContain('oauth-readonly-blocked');
+    expect(codes).not.toContain('oauth-failed');
+    expect(data.verdict).toBe('DEGRADED');
+    expect(res.exitCode).toBe(1);
+  });
+
+  it('flags a 429 App API response with its Retry-After and keeps media running', async () => {
+    // Readonly + seeded cache: the OAuth probe must NOT hit the real token endpoint.
+    process.env.PIXIV_AUTH_READONLY = 'true';
+    const dbPath = tempDbPath();
+    seedAccessTokenCache(dbPath);
+    // The 429 is the signal this command exists to surface: one small request is
+    // enough to record status + Retry-After without any business workload.
+    const fetchImpl = jest.fn(async (input: any) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('app-api.pixiv.net')) {
+        return makeResponse({
+          status: 429,
+          headers: { 'retry-after': '73' },
+        });
+      }
+      return makeResponse({ status: 403 });
+    });
+    const command = new DiagnoseEgressCommand({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await command.execute(ctx(dbPath, true), { options: { 'illust-id': '1' }, positional: ['egress'] });
+
+    const data = res.data as any;
+    const appApi = data.findings.find((f: any) => f.code === 'appapi-429');
+    expect(appApi).toBeDefined();
+    expect(appApi.data.retryAfterMs).toBe(73_000);
+    expect(data.appApi.rateLimited).toBe(true);
+    expect(res.exitCode).toBe(1);
+  });
+
+  it('marks a media 403 as critical (the pximg referer contract failed)', async () => {
+    process.env.PIXIV_AUTH_READONLY = 'true';
+    const dbPath = tempDbPath();
+    seedAccessTokenCache(dbPath);
+    const fetchImpl = jest.fn(async (input: any) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('app-api.pixiv.net')) {
+        return makeResponse({
+          status: 200,
+          body: { illust: { meta_single_page: { original_image_url: 'https://i.pximg.net/img-original/img/1.png' } } },
+        });
+      }
+      if (url.includes('i.pximg.net')) {
+        return makeResponse({ status: 403 });
+      }
+      return makeResponse({ status: 403 });
+    });
+    const command = new DiagnoseEgressCommand({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await command.execute(ctx(dbPath, true), { options: {}, positional: ['egress'] });
+
+    const data = res.data as any;
+    const codes = data.findings.map((f: any) => f.code);
+    expect(codes).toContain('media-blocked');
+    expect(data.verdict).toBe('FAIL');
+    expect(res.exitCode).toBe(2);
+  });
+});

--- a/src/commands/DiagnoseEgressCommand.ts
+++ b/src/commands/DiagnoseEgressCommand.ts
@@ -1,0 +1,384 @@
+/**
+ * `pixivflow diagnose egress` — minimal Pixiv data-plane egress probe.
+ *
+ * Reachability is not suitability: a datacenter egress can pass OAuth and still be
+ * rate-limit-starved on the production search workload (2026-09-11, GitHub-hosted
+ * runners). This command answers, with a handful of tiny requests, three INDEPENDENT
+ * questions about the network it runs on:
+ *
+ *   1. OAuth   oauth.secure.pixiv.net  — one real refresh-token exchange
+ *   2. App API app-api.pixiv.net       — 1 small fixed request, status + Retry-After
+ *   3. Media   i.pximg.net             — 64 KiB Range request with the app Referer
+ *
+ * It never runs the business workload (no 12 tags / 100 samples / pagination), so it
+ * cannot by itself drive the account into a penalty. Output is a findings list plus a
+ * uniform verdict (PASS / DEGRADED / FAIL) suitable for a provider-qualification matrix.
+ *
+ * Exit codes: 0 = no findings above warn, 1 = warn (degraded evidence), 2 = critical
+ * (a data plane is unusable from this egress).
+ *
+ * The OAuth probe performs ONE real token refresh. PixivAuth persists a rotated refresh
+ * token (database + unified storage + config), which is the desired durable behaviour —
+ * run this probe only when no production execution holds the credential, exactly like
+ * `account rotate`.
+ */
+
+import { BaseCommand } from './Command';
+import { CommandCategory } from './metadata';
+import { CommandArgs, CommandContext, CommandResult } from './types';
+import { Database } from '../storage/Database';
+import { PixivAuth, isAuthReadOnly } from '../auth/PixivAuth';
+import { AuthenticationError } from '../utils/errors';
+import type { NetworkConfig } from '../config/types';
+
+type FindingLevel = 'ok' | 'warn' | 'critical' | 'skipped';
+
+interface Finding {
+  level: FindingLevel;
+  code: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+export type EgressVerdict = 'PASS' | 'DEGRADED' | 'FAIL' | 'INCOMPLETE';
+
+export interface EgressProbeSummary {
+  provider: string;
+  region: string;
+  network: string;
+  oauth: { status: string; latencyMs: number | null; refreshed: boolean };
+  appApi: { status: number | null; ttfbMs: number | null; durationMs: number | null; rateLimited: boolean; retryAfterMs: number | null };
+  media: { status: number | null; ttfbMs: number | null; bytes64kDurationMs: number | null; timedOut: boolean };
+  verdict: EgressVerdict;
+  incomplete: boolean;
+  findings: Finding[];
+}
+
+/** The documented placeholder rules: empty, the template string, or implausibly short. */
+function isPlaceholderToken(token: unknown): boolean {
+  const value = typeof token === 'string' ? token.trim() : '';
+  return value.length === 0 || value === 'YOUR_REFRESH_TOKEN' || value.length < 10;
+}
+
+const PROBE_TIMEOUT_MS = 15_000;
+
+/** this-safe fetch wrapper (Cloudflare/undici reject `this.fetch(...)`). */
+const defaultFetch: typeof fetch = (input, init) => globalThis.fetch(input, init);
+
+export class DiagnoseEgressCommand extends BaseCommand {
+  readonly name = 'diagnose';
+  readonly description = 'Minimal Pixiv data-plane egress probe (usage: diagnose egress)';
+  readonly aliases = ['diag'];
+  readonly requiresToken = false;
+  readonly metadata = {
+    category: CommandCategory.MONITORING,
+    requiresAuth: false,
+    longRunning: false,
+    examples: ['pixivflow diagnose egress', 'pixivflow diagnose egress --json', 'pixivflow diagnose egress --illust-id 12345'],
+    relatedCommands: ['health', 'doctor'],
+  };
+
+  constructor(
+    /** Injectable for tests; defaults to a this-safe global fetch. */
+    private readonly deps: { fetchImpl?: typeof fetch; provider?: string; region?: string } = {}
+  ) {
+    super();
+  }
+
+  getUsage(): string {
+    return [
+      'diagnose egress [--json] [--illust-id <id>] [--provider <name>] [--region <code>]',
+      '  Minimal Pixiv egress probe: OAuth refresh, one small App API request,',
+      '  one 64 KiB media Range request. Exit 0/1/2 = ok/warn/critical.',
+    ].join('\n');
+  }
+
+  async execute(context: CommandContext, args: CommandArgs): Promise<CommandResult> {
+    const sub = args.positional[0] || 'egress';
+    if (sub !== 'egress') {
+      return this.failure(`Unknown diagnose target: ${sub}. Try: pixivflow diagnose egress`);
+    }
+
+    const findings: Finding[] = [];
+    const fetchImpl = this.deps.fetchImpl ?? defaultFetch;
+    const provider = String(args.options.provider ?? this.deps.provider ?? 'local');
+    const region = String(args.options.region ?? this.deps.region ?? 'unknown');
+    const illustId = String(args.options['illust-id'] ?? '92421724');
+
+    const proxy = context.config?.network?.proxy;
+    // --no-proxy tests the DIRECT egress even when a proxy is configured: a
+    // qualification matrix wants both paths, and a stale proxy setting must not
+    // mask what the network itself can do.
+    const noProxy = args.options['no-proxy'] === true;
+    const useProxy = !noProxy && !!(proxy?.enabled && proxy.host && proxy.port);
+    // The OAuth probe builds its own client from config.network — hand it the same
+    // overridden view so all three probes test the SAME egress path.
+    const networkForAuth: NetworkConfig = noProxy
+      ? { ...(context.config?.network ?? {}), proxy: undefined }
+      : context.config?.network ?? ({} as NetworkConfig);
+
+    // --- 1. General reachability (pixiv.net answers 403 to probes; that IS a pass) ---
+    await this.probeReachable(fetchImpl, useProxy ? proxy : undefined, findings);
+
+    // --- 2. OAuth: one real refresh exchange ---
+    let accessToken: string | null = null;
+    let db: Database | null = null;
+    const refreshToken = context.config?.pixiv?.refreshToken;
+    if (isPlaceholderToken(refreshToken)) {
+      findings.push({
+        level: 'skipped',
+        code: 'oauth-skipped',
+        message: 'no usable refresh token in config; OAuth data plane not tested',
+      });
+    } else {
+      try {
+        db = new Database(context.config.storage?.databasePath ?? './data/pixiv-downloader.db');
+        db.migrate();
+        const auth = new PixivAuth(context.config.pixiv, networkForAuth, db, context.configPath);
+        const started = performance.now();
+        accessToken = isAuthReadOnly()
+          ? await auth.getAccessToken() // readonly: cache only; the token endpoint is NOT tested
+          : await auth.refreshAccessTokenForClient();
+        const latencyMs = Math.round(performance.now() - started);
+        const fromCache = isAuthReadOnly();
+        findings.push({
+          level: 'ok',
+          code: fromCache ? 'oauth-cache-ok' : 'oauth-refresh-ok',
+          message: fromCache
+            ? `OAuth access token served from cache in ${latencyMs}ms (PIXIV_AUTH_READONLY: the token endpoint was NOT tested)`
+            : `OAuth refresh succeeded in ${latencyMs}ms`,
+          data: { latencyMs },
+        });
+      } catch (error) {
+        if (isAuthReadOnly() || error instanceof AuthenticationError) {
+          findings.push({
+            level: 'warn',
+            code: 'oauth-readonly-blocked',
+            message:
+              'PIXIV_AUTH_READONLY blocks the token endpoint; OAuth data plane NOT tested. ' +
+              'Re-run without the flag (and with no production execution holding the credential).',
+            data: { error: error instanceof Error ? error.message : String(error) },
+          });
+        } else {
+          findings.push({
+            level: 'critical',
+            code: 'oauth-failed',
+            message: `OAuth refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        }
+      }
+    }
+
+    // --- 3. App API: one small fixed request ---
+    let mediaUrl: string | null = null;
+    const appApi = await this.probeAppApi(fetchImpl, accessToken, illustId, findings);
+    if (appApi?.mediaUrl) mediaUrl = appApi.mediaUrl;
+
+    // --- 4. Media CDN: 64 KiB Range request with the app Referer ---
+    const media = await this.probeMedia(fetchImpl, mediaUrl, findings);
+
+    if (db) db.close();
+
+    const summary = this.summarize(provider, region, findings, appApi, media);
+    this.print(context, summary, args.options.json === true);
+    const exitCode = findings.some((f) => f.level === 'critical') ? 2 : findings.some((f) => f.level === 'warn') ? 1 : 0;
+    return this.withExitCode(this.success(`egress verdict: ${summary.verdict}`, summary), exitCode);
+  }
+
+  /** pixiv.net answers 403 to anonymous probes; any HTTP response proves reachability. */
+  private async probeReachable(
+    fetchImpl: typeof fetch,
+    proxy: { host: string; port: number; protocol?: string; username?: string; password?: string } | undefined,
+    findings: Finding[]
+  ): Promise<void> {
+    try {
+      const init: RequestInit = { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) };
+      if (proxy) {
+        // Same proxy path the download pipeline uses (see HealthCommand.checkNetwork).
+        const undici = require('undici');
+        const protocol = (proxy.protocol || 'http').toLowerCase();
+        const auth = proxy.username && proxy.password
+          ? `${encodeURIComponent(proxy.username)}:${encodeURIComponent(proxy.password)}@`
+          : '';
+        (init as Record<string, unknown>).dispatcher = new undici.ProxyAgent(
+          `${protocol}://${auth}${proxy.host}:${proxy.port}`
+        );
+      }
+      const started = performance.now();
+      const res = await fetchImpl('https://www.pixiv.net/', init);
+      const latencyMs = Math.round(performance.now() - started);
+      findings.push({
+        level: 'ok',
+        code: 'pixiv-net-ok',
+        message: `pixiv.net reachable (HTTP ${res.status}) in ${latencyMs}ms`,
+        data: { status: res.status, latencyMs },
+      });
+    } catch (error) {
+      findings.push({
+        level: 'critical',
+        code: 'pixiv-net-unreachable',
+        message: `pixiv.net unreachable: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  /**
+   * One small App API request. Any HTTP response proves the data plane is reachable;
+   * 429 is the starvation signal this probe exists to surface.
+   */
+  private async probeAppApi(
+    fetchImpl: typeof fetch,
+    accessToken: string | null,
+    illustId: string,
+    findings: Finding[]
+  ): Promise<{ status: number | null; ttfbMs: number | null; durationMs: number | null; rateLimited: boolean; retryAfterMs: number | null; mediaUrl: string | null } | null> {
+    if (!accessToken) {
+      findings.push({
+        level: 'skipped',
+        code: 'appapi-skipped',
+        message: 'no access token (OAuth skipped/failed); App API data plane not tested authenticated',
+      });
+      return null;
+    }
+    const url = `https://app-api.pixiv.net/v1/illust/detail?illust_id=${encodeURIComponent(illustId)}`;
+    try {
+      const started = performance.now();
+      const res = await fetchImpl(url, {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          // The App API rejects requests without an app User-Agent.
+          'user-agent': 'PixivAndroidApp/5.0.234 (Android 11; Pixel 5)',
+          'app-os': 'android',
+          'app-os-version': '11',
+        },
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+      const ttfbMs = Math.round(performance.now() - started);
+      const retryAfter = res.headers.get('retry-after');
+      const retryAfterMs = retryAfter !== null ? Number(retryAfter) * 1000 || null : null;
+      let mediaUrl: string | null = null;
+      try {
+        const body = (await res.json()) as {
+          illust?: { meta_single_page?: { original_image_url?: string }; meta_pages?: { image_urls?: { original?: string } }[] };
+        };
+        mediaUrl =
+          body.illust?.meta_single_page?.original_image_url ??
+          body.illust?.meta_pages?.[0]?.image_urls?.original ??
+          null;
+      } catch {
+        // A non-JSON body is recorded via status; the media probe then reports skipped.
+      }
+      const rateLimited = res.status === 429;
+      findings.push({
+        level: rateLimited ? 'warn' : 'ok',
+        code: rateLimited ? 'appapi-429' : 'appapi-ok',
+        message: `App API responded HTTP ${res.status} in ${ttfbMs}ms${retryAfter ? ` (retry-after ${retryAfter}s)` : ''}`,
+        data: { status: res.status, ttfbMs, retryAfterMs },
+      });
+      return { status: res.status, ttfbMs, durationMs: ttfbMs, rateLimited, retryAfterMs, mediaUrl };
+    } catch (error) {
+      findings.push({
+        level: 'critical',
+        code: 'appapi-failed',
+        message: `App API request failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return null;
+    }
+  }
+
+  /** 64 KiB Range request — never a full media download. */
+  private async probeMedia(
+    fetchImpl: typeof fetch,
+    mediaUrl: string | null,
+    findings: Finding[]
+  ): Promise<{ status: number | null; ttfbMs: number | null; bytes64kDurationMs: number | null; timedOut: boolean }> {
+    if (!mediaUrl) {
+      findings.push({
+        level: 'skipped',
+        code: 'media-skipped',
+        message: 'no media URL from the App API response; media CDN not tested',
+      });
+      return { status: null, ttfbMs: null, bytes64kDurationMs: null, timedOut: false };
+    }
+    try {
+      const started = performance.now();
+      const res = await fetchImpl(mediaUrl, {
+        headers: {
+          range: 'bytes=0-65535',
+          // i.pximg.net requires the app referer or it answers 403.
+          referer: 'https://app-api.pixiv.net/',
+        },
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+      const durationMs = Math.round(performance.now() - started);
+      await res.arrayBuffer().catch(() => null);
+      const ok = res.status === 200 || res.status === 206;
+      findings.push({
+        level: ok ? 'ok' : res.status === 429 ? 'warn' : 'critical',
+        code: ok ? 'media-ok' : res.status === 429 ? 'media-429' : 'media-blocked',
+        message: `media CDN responded HTTP ${res.status} in ${durationMs}ms (64 KiB Range)`,
+        data: { status: res.status, bytes64kDurationMs: durationMs },
+      });
+      return { status: res.status, ttfbMs: durationMs, bytes64kDurationMs: durationMs, timedOut: false };
+    } catch (error) {
+      const timedOut = error instanceof Error && /timeout|abort/i.test(error.message);
+      findings.push({
+        level: 'critical',
+        code: timedOut ? 'media-timeout' : 'media-failed',
+        message: `media CDN request failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return { status: null, ttfbMs: null, bytes64kDurationMs: null, timedOut };
+    }
+  }
+
+  private summarize(
+    provider: string,
+    region: string,
+    findings: Finding[],
+    appApi: { status: number | null; ttfbMs: number | null; durationMs: number | null; rateLimited: boolean; retryAfterMs: number | null } | null,
+    media: { status: number | null; ttfbMs: number | null; bytes64kDurationMs: number | null; timedOut: boolean }
+  ): EgressProbeSummary {
+    const oauth = findings.find((f) => f.code.startsWith('oauth-'));
+    const incomplete = findings.some((f) => f.level === 'skipped');
+    const critical = findings.some((f) => f.level === 'critical');
+    const degraded = findings.some((f) => f.level === 'warn');
+    const verdict: EgressVerdict = critical ? 'FAIL' : degraded ? 'DEGRADED' : incomplete ? 'INCOMPLETE' : 'PASS';
+    return {
+      provider,
+      region,
+      network: 'datacenter-egress',
+      oauth: {
+        status: oauth ? oauth.code : 'oauth-skipped',
+        latencyMs: (oauth?.data?.latencyMs as number) ?? null,
+        refreshed: oauth?.code === 'oauth-refresh-ok',
+      },
+      appApi: {
+        status: appApi?.status ?? null,
+        ttfbMs: appApi?.ttfbMs ?? null,
+        durationMs: appApi?.durationMs ?? null,
+        rateLimited: appApi?.rateLimited ?? false,
+        retryAfterMs: appApi?.retryAfterMs ?? null,
+      },
+      media,
+      verdict,
+      incomplete,
+      findings,
+    };
+  }
+
+  private print(context: CommandContext, summary: EgressProbeSummary, asJson: boolean): void {
+    if (asJson) {
+      context.logger.info(JSON.stringify(summary, null, 2));
+      return;
+    }
+    context.logger.info('━━━ Pixiv egress probe ━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    for (const f of summary.findings) {
+      const mark = f.level === 'ok' ? '✓' : f.level === 'warn' ? '⚠' : f.level === 'critical' ? '✗' : '·';
+      context.logger.info(`  ${mark} [${f.level.toUpperCase()}] ${f.code}: ${f.message}`);
+    }
+    context.logger.info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    context.logger.info(
+      `  verdict: ${summary.verdict}${summary.incomplete ? ' (incomplete: some probes were skipped)' : ''}`
+    );
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,7 @@ import { NormalizeCommand } from './NormalizeCommand';
 import { WebUICommand } from './WebUICommand';
 import { HealthCommand } from './HealthCommand';
 import { DoctorCommand } from './DoctorCommand';
+import { DiagnoseEgressCommand } from './DiagnoseEgressCommand';
 import { ReconcileCommand } from './ReconcileCommand';
 import { StatusCommand } from './StatusCommand';
 import { LogsCommand } from './LogsCommand';
@@ -50,6 +51,7 @@ export function registerAllCommands(registry: CommandRegistry): void {
   registry.register(new WebUICommand());
   registry.register(new HealthCommand());
   registry.register(new DoctorCommand());
+  registry.register(new DiagnoseEgressCommand());
   registry.register(new ReconcileCommand());
   registry.register(new StatusCommand());
   registry.register(new LogsCommand());
@@ -84,6 +86,7 @@ export {
   WebUICommand,
   HealthCommand,
   DoctorCommand,
+  DiagnoseEgressCommand,
   ReconcileCommand,
   StatusCommand,
   LogsCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,7 @@ async function bootstrap() {
   let config: StandaloneConfig;
   try {
     const isLoginCommand = ['login', 'l', 'login-interactive', 'li', 'login-headless'].includes(commandName || '');
-    const tokenOptionalCommands = new Set(['config', 'dirs', 'logs', 'setup', 'status', 'health', 'maintain', 'normalize', 'migrate-config', 'backup', 'monitor', 'outbox', 'runs', 'webui', 'w']);
+    const tokenOptionalCommands = new Set(['config', 'dirs', 'logs', 'setup', 'status', 'health', 'maintain', 'normalize', 'migrate-config', 'backup', 'monitor', 'outbox', 'runs', 'webui', 'w', 'diagnose']);
     const isTokenOptional = commandName ? tokenOptionalCommands.has(commandName) : true;
     
     config = loadConfig(configPath, isLoginCommand || isTokenOptional || !commandName);


### PR DESCRIPTION
## PR A：发布物黑盒 smoke + install-script gate

- npm pack → 内容断言 → 干净全局安装（隔离 prefix）→ install-script gate → CLI boot → 存储打开/迁移/读写闭环
- install-script gate：零必需生命周期脚本策略；现有 better-sqlite3/puppeteer 为显式 allowlist 条目（Phase B/D 移除）
- `--strict` 实测抓到 puppeteer [postinstall] + better-sqlite3 [install]（exit 1）
- CI：ubuntu/macos/windows 三平台矩阵
- 顺带修复 files 清单引用已不存在的 config/standalone.config.example.json