### PR TITLE
chore(governance): install the production-operation branch contract

### DIFF
--- a/.github/workflows/branch-contract.yml
+++ b/.github/workflows/branch-contract.yml
@@ -1,0 +1,16 @@
+name: Branch contract
+# Production-operation branch contract gate (see redtidev1918/releasegraph
+# docs/branch-contract.md). Feature PRs are skipped; a violating
+# cutover/release/hotfix/ops PR hard-fails with a diff proof.
+#
+# Pinned to the immutable ReleaseGraph v1.4.11 commit. v1.4.10 enforces engine
+# provenance (the gate builds and asserts its engine from job.workflow_sha, so
+# caller pin == engine version end to end); v1.4.11 evaluates the real PR head
+# commit (github.event.pull_request.head.sha) instead of the merge ref, whose
+# ancestry against the base is trivially clean.
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  branch-contract:
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-branch-contract.yml@0b0c28990abac59aa5ae1d2c50bf95ce06d26a8d # ReleaseGraph v1.4.11

--- a/.release-policy.yml
+++ b/.release-policy.yml
@@ -38,5 +38,32 @@
     "failed_draft": 2
   },
   "checksums": true,
-  "sbom": true
+  "sbom": true,
+  "repository": {
+    "git": {
+      "productionOperations": {
+        "base": "default",
+        "branches": [
+          "chore/cutover-*",
+          "ops/*",
+          "release/*",
+          "hotfix/*"
+        ],
+        "requireLatestBase": true,
+        "operations": {
+          "cutover": {
+            "branches": [
+              "chore/cutover-*"
+            ],
+            "allowedPaths": [
+              "Dockerfile",
+              "Dockerfile.scheduler",
+              "docker-compose.yml",
+              "docker-compose.apprise.example.yml"
+            ]
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What this installs

The **Production-Operation Branch Contract** as declared governance, plus the canonical thin caller for the reusable ReleaseGraph gate:

```yaml
on: [pull_request]
permissions:
  contents: read
jobs:
  branch-contract:
    uses: redtidev1918/releasegraph/.github/workflows/reusable-branch-contract.yml@0b0c28990abac59aa5ae1d2c50bf95ce06d26a8d # ReleaseGraph v1.4.11
```

Every consumer pin is a full 40-character commit SHA. `@v1`, `@v1.4.11`, `@main`, `@master`, `@latest` are never used as a formal pin — the tag in the trailing comment is human annotation only.

## The invariant

Feature branches may stack freely. A branch matching a production-operation pattern (`chore/cutover-*`, `ops/*`, `release/*`, `hotfix/*`) must:

1. target the configured production base directly,
2. descend from that base's **current** HEAD,
3. stay inside the declared `allowedPaths`,
4. never depend on unmerged feature branches.

Judgement is pure git topology (`merge-base` / `rev-parse`) — never commit messages, PR titles, patch-id or content similarity. Feature PRs are skipped at zero cost, so ordinary development is unaffected.

## Scope declared for this repository

| field | value |
|---|---|
| `base` | `default` → **`master`** (non-`main` default branch) |
| `branches` | `chore/cutover-*`, `ops/*`, `release/*`, `hotfix/*` |
| `operations.cutover.branches` | `chore/cutover-*` |
| `operations.cutover.allowedPaths` | `Dockerfile`, `Dockerfile.scheduler`, `docker-compose.yml`, `docker-compose.apprise.example.yml` |

PixivFlow publishes to npm and ghcr, so its production surface is container build/compose configuration rather than a runtime host config.

This repository additionally verifies that `base: default` resolves to the repository's **actual** default branch — here `master`, not `main`.

## Blast radius

Governance only. No runtime behaviour, published value, secret or artifact-producing workflow is modified. The gate is read-only: it never rebases, force-pushes or mutates the production branch. Reversible by reverting this single commit.

## Expected behaviour on this PR

`feat/branch-contract-governance` is not a production-operation branch, so the gate must report:

```text
SKIP not a production-operation branch
```

If it reports `POLICY_ERROR`, the declaration is wrong and this PR must not merge.
