### PR TITLE
fix(scheduler): durable trigger dispatch, lease recovery and honest status semantics

### DIFF
--- a/src/__tests__/scheduler/ScheduleTriggerServer.test.ts
+++ b/src/__tests__/scheduler/ScheduleTriggerServer.test.ts
@@ -26,8 +26,9 @@ function handlers(overrides: Record<string, unknown> = {}) {
     run: jest.fn(async (id: string) => ({
       scheduleId: id,
       slotId: ctx.slotId,
-      status: 'success',
-      cells: [{ targetId: 't', status: 'submitted', workId: '1' }],
+      disposition: 'accepted' as const,
+      status: 'pending',
+      cells: [{ targetId: 't', status: 'pending', workId: null }],
     })),
     status: jest.fn((id: string) => ({ scheduleId: id, mode: 'external' })),
     ...overrides,
@@ -92,7 +93,7 @@ describe('trigger endpoint auth + dispatch (live ephemeral express)', () => {
     }
   });
 
-  it('runs only the requested schedule with a valid token and returns its summary', async () => {
+  it('dispatches only the requested schedule and answers 202 queued, not "completed"', async () => {
     const h = handlers();
     const { base, close } = await boot('secret-token', h);
     try {
@@ -101,12 +102,98 @@ describe('trigger endpoint auth + dispatch (live ephemeral express)', () => {
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer secret-token' },
         body: JSON.stringify({ label: '今日早班' }),
       });
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { schedule?: { scheduleId: string; slotId: string } };
+      // 202 Accepted: the run was admitted, NOT finished. A clock that reads this
+      // as "done" is the bug that silently lost slots in production.
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as {
+        status: string;
+        note: string;
+        schedule?: { scheduleId: string; slotId: string; disposition: string };
+      };
+      expect(body.status).toBe('accepted');
+      expect(body.note).toBe('queued');
+      expect(body.schedule?.disposition).toBe('accepted');
       expect(body.schedule?.scheduleId).toBe('schedule-a');
       expect(body.schedule?.slotId).toBe(ctx.slotId);
       expect(h.run).toHaveBeenCalledTimes(1); // exactly one schedule, not all of them
       expect(h.run).toHaveBeenCalledWith('schedule-a', expect.objectContaining({ slotId: ctx.slotId }));
+    } finally {
+      close();
+    }
+  });
+
+  it('a still-running occurrence answers 202 already_running and is never called completed', async () => {
+    const h = handlers({
+      run: jest.fn(async (id: string) => ({
+        scheduleId: id,
+        slotId: ctx.slotId,
+        disposition: 'already_running' as const,
+        status: 'running',
+      })),
+    });
+    const { base, close } = await boot('secret-token', h);
+    try {
+      const res = await fetch(`${base}/internal/schedules/schedule-a/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer secret-token' },
+        body: '{}',
+      });
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as { status: string; note: string };
+      expect(body.note).toBe('already_running');
+      expect(body.status).toBe('running');
+      expect(body.note).not.toBe('already_completed');
+    } finally {
+      close();
+    }
+  });
+
+  it('a terminal occurrence answers 200 already_completed', async () => {
+    const h = handlers({
+      run: jest.fn(async (id: string) => ({
+        scheduleId: id,
+        slotId: ctx.slotId,
+        disposition: 'already_completed' as const,
+        status: 'success',
+        alreadyCompleted: true,
+      })),
+    });
+    const { base, close } = await boot('secret-token', h);
+    try {
+      const res = await fetch(`${base}/internal/schedules/schedule-a/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer secret-token' },
+        body: '{}',
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; note: string };
+      expect(body.note).toBe('already_completed');
+      expect(body.status).toBe('completed');
+    } finally {
+      close();
+    }
+  });
+
+  it('a refusal answers 503 rejected so the clock keeps its retry eligibility', async () => {
+    const h = handlers({
+      run: jest.fn(async (id: string) => ({
+        scheduleId: id,
+        slotId: ctx.slotId,
+        disposition: 'rejected' as const,
+        status: 'pending',
+      })),
+    });
+    const { base, close } = await boot('secret-token', h);
+    try {
+      const res = await fetch(`${base}/internal/schedules/schedule-a/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer secret-token' },
+        body: '{}',
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { status: string; note: string };
+      expect(body.status).toBe('rejected');
+      expect(body.note).toBe('rejected');
     } finally {
       close();
     }

--- a/src/__tests__/scheduler/SlotCoordinator.test.ts
+++ b/src/__tests__/scheduler/SlotCoordinator.test.ts
@@ -42,7 +42,7 @@ describe('SlotCoordinator', () => {
       const slot = r1.context!;
 
       // Occurrence materialized with targets [a, b].
-      coord.begin(slot, schedule, [target('a'), target('b')]);
+      coord.prepare(slot, schedule, [target('a'), target('b')]);
       expect(db.slots.getSlotTargetIds(slot.slotId).sort()).toEqual(['a', 'b']);
 
       // Config reload adds c; a resume of the SAME occurrence must not pick up c.
@@ -55,7 +55,7 @@ describe('SlotCoordinator', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a'), target('b'), target('c')]);
+      coord.prepare(slot, schedule, [target('a'), target('b'), target('c')]);
 
       coord.lockWork(slot.slotId, 'a', '100', 'illustration');
       coord.markCell(slot.slotId, 'a', 'submitted');
@@ -70,12 +70,12 @@ describe('SlotCoordinator', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a')]);
+      coord.prepare(slot, schedule, [target('a')]);
       coord.lockWork(slot.slotId, 'a', '100', 'illustration');
 
       // Simulate process restart: rebuild coordinator, re-open same slot.
       const coord2 = new SlotCoordinator(db);
-      const again = coord2.begin(slot, schedule, [target('a')]);
+      const again = coord2.prepare(slot, schedule, [target('a')]);
       expect(again.alreadyCompleted).toBe(false); // resumed, not a new terminal slot
       const cell = db.slots.getCell(slot.slotId, 'a')!;
       expect(cell.workId).toBe('100');
@@ -87,7 +87,7 @@ describe('SlotCoordinator', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a'), target('b')]);
+      coord.prepare(slot, schedule, [target('a'), target('b')]);
       coord.lockWork(slot.slotId, 'a', '100', 'illustration');
       coord.markCell(slot.slotId, 'a', 'submitted');
       coord.markCell(slot.slotId, 'b', 'no_candidate', 'none');
@@ -104,7 +104,7 @@ describe('SlotCoordinator failure injection', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a')]);
+      coord.prepare(slot, schedule, [target('a')]);
 
       expect(coord.claimRunLease(slot.slotId, 'trigger-1', 60_000)).toBe(true);
       // A duplicate HTTP trigger arriving while trigger-1 is live must NOT
@@ -122,7 +122,7 @@ describe('SlotCoordinator failure injection', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a')]);
+      coord.prepare(slot, schedule, [target('a')]);
 
       coord.lockWork(slot.slotId, 'a', '100', 'illustration');
       coord.applyOutcome(slot.slotId, 'a', { kind: 'submitted', workId: '100', workType: 'illustration' });
@@ -145,7 +145,7 @@ describe('SlotCoordinator failure injection', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a')]);
+      coord.prepare(slot, schedule, [target('a')]);
 
       coord.lockWork(slot.slotId, 'a', '100', 'illustration');
       coord.applyOutcome(slot.slotId, 'a', { kind: 'failed', retryable: true, error: 'connection reset' });
@@ -168,7 +168,7 @@ describe('SlotCoordinator failure injection', () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
-      coord.begin(slot, schedule, [target('a')]);
+      coord.prepare(slot, schedule, [target('a')]);
 
       coord.applyOutcome(slot.slotId, 'a', {
         kind: 'delivery_pending', workId: '100', workType: 'illustration', deliveryId: 'd-1',

--- a/src/__tests__/scheduler/abandonedRun.test.ts
+++ b/src/__tests__/scheduler/abandonedRun.test.ts
@@ -1,0 +1,279 @@
+/**
+ * P0 reliability: a run that outlives its own timeout must stop running AND stop
+ * renewing its lease, even when the in-flight work ignores the abort.
+ *
+ * Encodes the production incident: `bot1-daily@2026-09-10T1800` passed its
+ * 30-minute timeout, never settled because a Pixiv request never returned, and
+ * the runtime kept heart-beating the slot lease every 620s — so nothing could
+ * reclaim it and the occurrence stayed `running` indefinitely.
+ *
+ * The two guarantees pinned here:
+ *  1. bounded drain: after the timeout the scheduler stops waiting, clears its
+ *     concurrent-run guard, and reports the run as abandoned.
+ *  2. no duplicate execution: an abandoned slot is left TERMINAL, so the recovery
+ *     sweep cannot re-dispatch it while the wedged job is still alive — while a
+ *     genuinely crashed worker still gets recovered.
+ */
+
+import { Database } from '../../storage/Database';
+import { Scheduler, ABORT_DRAIN_MS, JobAbandoned } from '../../scheduler/Scheduler';
+import { SlotCoordinator } from '../../scheduler/SlotCoordinator';
+import { OperationCancelledError } from '../../utils/errors';
+import { TopicPipeline } from '../../topic/TopicPipeline';
+import type { TopicResolver } from '../../topic/TopicResolver';
+import type { ResolvedTag, TopicClient } from '../../topic/types';
+import { SchedulerConfig, StandaloneConfig, ScheduleConfig, TargetConfig } from '../../config';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const target = (id: string, type = 'illustration'): TargetConfig => ({ id, type }) as TargetConfig;
+const schedule: ScheduleConfig = {
+  id: 'bot1',
+  name: 'Bot1',
+  cron: '0 10,18 * * *',
+  timezone: 'Asia/Shanghai',
+  enabled: true,
+} as ScheduleConfig;
+const scheduleConfig = { schedulerRuntime: { trigger: { graceMinutes: 720 } } } as StandaloneConfig;
+const AT = new Date('2026-09-08T02:00:30Z');
+
+function withDb<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-abandoned-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  return fn(db).finally(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+function resolveTag(name: string, score: number): ResolvedTag {
+  return {
+    name,
+    score,
+    occurrences: 2,
+    coverage: 1,
+    specificity: score,
+    suggested: false,
+    seed: false,
+  };
+}
+
+function pipelineWith(
+  client: TopicClient,
+  signal: AbortSignal,
+  tags: ResolvedTag[] = [resolveTag('seed', 1), resolveTag('related', 0.5)]
+): TopicPipeline {
+  const resolver = {
+    resolve: async () => ({
+      space: {
+        version: 1,
+        topic: 'seed',
+        contentType: 'illustration',
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+        sampleSize: 10,
+        sampledWorks: 10,
+        tags,
+      },
+      fromCache: true,
+      degraded: false,
+    }),
+  } as unknown as TopicResolver;
+  return new TopicPipeline(client, resolver, 0, signal);
+}
+
+describe('scheduler timeout is bounded by a drain window', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('abandons a job that ignores cancellation instead of waiting forever', async () => {
+    jest.useFakeTimers();
+    const database = {
+      getSchedulerStats: jest.fn(() => ({ totalExecutions: 0 })),
+      getConsecutiveFailures: jest.fn(() => 0),
+      getNextExecutionNumber: jest.fn(() => 1),
+      logSchedulerExecution: jest.fn(),
+    } as unknown as Database;
+    const requestCancel = jest.fn();
+    const onFailure = jest.fn();
+    const onAbandoned = jest.fn();
+    const scheduler = new Scheduler(
+      { timeout: 1_000, timezone: 'UTC' } as SchedulerConfig,
+      database,
+      {
+        beginRun: () => 0,
+        endRun: () => 0,
+        requestCancel,
+      },
+      'bot1',
+      undefined,
+      onFailure,
+      onAbandoned
+    );
+
+    // A job that never settles and never observes its abort — the worst case the
+    // production incident produced.
+    scheduler.init(async () => {
+      await new Promise<void>(() => undefined);
+    });
+    expect(scheduler.runNow()).toBe(true);
+    expect(scheduler.getStats().running).toBe(true);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(requestCancel).toHaveBeenCalledWith('scheduler timeout');
+    expect(onAbandoned).not.toHaveBeenCalled(); // still inside the drain window
+
+    await jest.advanceTimersByTimeAsync(ABORT_DRAIN_MS);
+
+    expect(onAbandoned).toHaveBeenCalledTimes(1);
+    const abandoned = onAbandoned.mock.calls[0][0] as JobAbandoned;
+    expect(abandoned.drainWindowMs).toBe(ABORT_DRAIN_MS);
+    expect(abandoned.errorMessage).toMatch(/drain window/i);
+    // The concurrent-run guard must be released even though the job never ended:
+    // otherwise the schedule is blocked for the life of the process.
+    expect(scheduler.getStats().running).toBe(false);
+    expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({ status: 'timeout' }));
+  });
+
+  it('does not abandon a job that settles inside the drain window', async () => {
+    jest.useFakeTimers();
+    const database = {
+      getSchedulerStats: jest.fn(() => ({ totalExecutions: 0 })),
+      getConsecutiveFailures: jest.fn(() => 0),
+      getNextExecutionNumber: jest.fn(() => 1),
+      logSchedulerExecution: jest.fn(),
+    } as unknown as Database;
+    const onAbandoned = jest.fn();
+    const jobGate: { release?: () => void } = {};
+    const scheduler = new Scheduler(
+      { timeout: 1_000, timezone: 'UTC' } as SchedulerConfig,
+      database,
+      { beginRun: () => 0, endRun: () => 0, requestCancel: () => undefined },
+      'bot1',
+      undefined,
+      undefined,
+      onAbandoned
+    );
+
+    scheduler.init(
+      () =>
+        new Promise<void>((resolve) => {
+          jobGate.release = resolve;
+        })
+    );
+    scheduler.runNow();
+
+    await jest.advanceTimersByTimeAsync(1_000); // timeout fires, abort requested
+    jobGate.release?.(); // the abort was honoured: the job unwinds promptly
+    await jest.advanceTimersByTimeAsync(50);
+
+    expect(onAbandoned).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(ABORT_DRAIN_MS);
+    expect(onAbandoned).not.toHaveBeenCalled();
+    expect(scheduler.getStats().running).toBe(false);
+  });
+});
+
+describe('cancellation reaches candidate acquisition and is never swallowed', () => {
+  it('surfaces the cancellation instead of degrading it to "no results"', async () => {
+    const controller = new AbortController();
+    const searched: string[] = [];
+    const client: TopicClient = {
+      getTagAutocomplete: async () => [],
+      searchIllustrationsForTags: async (tag) => {
+        searched.push(tag);
+        // The transport failed *because* of the abort, which the collector's
+        // catch-all used to convert into an empty result.
+        controller.abort();
+        throw new Error('socket hang up');
+      },
+      searchNovelsForTags: async () => [],
+    };
+    const pipeline = pipelineWith(client, controller.signal);
+
+    await expect(
+      pipeline.selectWorks(target('a'), 'illustration', '2026-09-10', 1, {}, {})
+    ).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(searched).toEqual(['seed']);
+  });
+
+  it('stops before the next tag even when the aborted request returned normally', async () => {
+    const controller = new AbortController();
+    const searched: string[] = [];
+    const client: TopicClient = {
+      getTagAutocomplete: async () => [],
+      searchIllustrationsForTags: async (tag) => {
+        searched.push(tag);
+        controller.abort(); // abort observed by the loop, not by the transport
+        return [];
+      },
+      searchNovelsForTags: async () => [],
+    };
+    const pipeline = pipelineWith(client, controller.signal);
+
+    await expect(
+      pipeline.selectWorks(target('a'), 'illustration', '2026-09-10', 1, {}, {})
+    ).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(searched).toEqual(['seed']);
+  });
+
+  it('still collects normally while the run is not cancelled', async () => {
+    const client: TopicClient = {
+      getTagAutocomplete: async () => [],
+      searchIllustrationsForTags: async (tag) => [
+        {
+          id: tag === 'seed' ? 1 : 2,
+          title: 'seed work',
+          caption: '',
+          create_date: '2026-09-10T00:00:00+09:00',
+          tags: [{ name: 'seed' }],
+        },
+      ],
+      searchNovelsForTags: async () => [],
+    };
+    const pipeline = pipelineWith(client, new AbortController().signal);
+    const { works } = await pipeline.selectWorks(
+      target('a'),
+      'illustration',
+      '2026-09-10',
+      2,
+      {},
+      {}
+    );
+    expect(works.length).toBeGreaterThan(0);
+  });
+});
+
+describe('an abandoned run cannot coexist with its recovery', () => {
+  it('leaves the slot terminal so the recovery sweep skips it, unlike a crash', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, scheduleConfig, 'http', AT).context!;
+      coord.prepare(slot, schedule, [target('a')]);
+      coord.markRunning(slot.slotId);
+      expect(coord.claimRunLease(slot.slotId, 'wedged-run', 3 * 60 * 1000)).toBe(true);
+
+      // The abandon path taken by runtime.abandonActiveRun(): stop owning the
+      // lease AND make the ledger terminal in the same step.
+      db.slots.markSlotStatus(
+        slot.slotId,
+        'failed',
+        'abandoned after scheduler timeout; no delivery (drain window expired)'
+      );
+      coord.releaseRunLease(slot.slotId, 'wedged-run');
+
+      // Recovery only re-dispatches non-terminal slots, so the still-running job
+      // is never joined by a second execution of the same occurrence.
+      expect(db.slots.recoverableSlots().map((s) => s.id)).not.toContain(slot.slotId);
+
+      // Contrast: a worker that crashed (still `running`, lease lapsed) MUST be
+      // recovered, or the occurrence is stranded forever.
+      db.slots.markSlotStatus(slot.slotId, 'running');
+      expect(db.slots.recoverableSlots().map((s) => s.id)).toContain(slot.slotId);
+    });
+  });
+});

--- a/src/__tests__/scheduler/durableDispatch.test.ts
+++ b/src/__tests__/scheduler/durableDispatch.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Regression tests for the durable-dispatch / lease-recovery overhaul.
+ *
+ * These encode the three production incidents that motivated the change:
+ *  (a) a run longer than the trigger request's timeout (the request died at
+ *      exactly 600s while the download was still going),
+ *  (b) a process restart in the middle of an active lease (the stale lease then
+ *      blocked the occurrence for ~31 minutes and the re-trigger silently
+ *      reported `completed`),
+ *  (c) the same slot triggered by several clocks at once (Cloudflare + GitHub
+ *      watchdog + manual POST).
+ *
+ * They also pin the invariant that the accepting adapter must never report a
+ * still-executing slot as completed.
+ */
+
+import { Database } from '../../storage/Database';
+import { SlotCoordinator } from '../../scheduler/SlotCoordinator';
+import { MultiScheduleManager } from '../../scheduler/MultiScheduleManager';
+import { StandaloneConfig, ScheduleConfig, TargetConfig } from '../../config';
+import { ScheduleRunOptions } from '../../scheduler/OccurrenceResolver';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const target = (id: string, type = 'illustration'): TargetConfig => ({ id, type }) as TargetConfig;
+const schedule: ScheduleConfig = {
+  id: 'bot1',
+  name: 'Bot1',
+  cron: '0 10,18 * * *',
+  timezone: 'Asia/Shanghai',
+  enabled: true,
+} as ScheduleConfig;
+const scheduleConfig = { schedulerRuntime: { trigger: { graceMinutes: 720 } } } as StandaloneConfig;
+
+// 2026-09-08 10:00 Shanghai == 02:00 UTC.
+const AT = new Date('2026-09-08T02:00:30Z');
+const OCCURRENCE_AT = Date.parse('2026-09-08T02:00:00Z');
+
+function makeConfig(overrides: Partial<StandaloneConfig> = {}): StandaloneConfig {
+  return {
+    pixiv: {
+      clientId: 'client',
+      clientSecret: 'secret',
+      deviceToken: 'device',
+      refreshToken: 'refresh-token',
+      userAgent: 'agent',
+    },
+    targets: [{ id: 'bot1-illust', type: 'illustration', mode: 'ranking' }],
+    scheduler: { enabled: false, cron: '0 3 * * *' },
+    schedules: [{ id: 'bot1', enabled: true, cron: '0 10,18 * * *', targetIds: ['bot1-illust'] }],
+    schedulerRuntime: { watchConfig: false, queueLimit: 2 },
+    ...overrides,
+  } as StandaloneConfig;
+}
+
+function withDb<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-durable-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  return fn(db).finally(async () => {
+    // Admitted runs are fire-and-forget: give any in-flight job time to finish
+    // its accounting write before the test DB disappears underneath it.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+/** Let a fire-and-forget admitted run settle before the test DB is closed. */
+async function settle(ms = 150): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+/** A typed fake executor so assertions can read the forwarded run options. */
+function makeExecute() {
+  return jest.fn(
+    async (_config: StandaloneConfig, _schedule: ScheduleConfig, _options?: ScheduleRunOptions) =>
+      undefined
+  );
+}
+
+/** Insert a durable slot in the state a crashed/restarted worker would leave. */
+function seedSlot(
+  db: Database,
+  opts: { slotId: string; status: 'pending' | 'running'; leaseUntil?: number | null; owner?: string | null }
+): void {
+  db.slots.getOrCreateSlot(opts.slotId, {
+    scheduleId: 'bot1',
+    occurrenceAt: OCCURRENCE_AT,
+    occurrenceDate: '2026-09-08',
+    occurrenceLabel: '10:00',
+    timezone: 'Asia/Shanghai',
+    targetIds: ['bot1-illust'],
+    triggerSource: 'http',
+    slotDate: '2026-09-08',
+    slotName: '10:00',
+  });
+  db.slots.materializeCells(opts.slotId, ['bot1-illust'], () => 'illustration');
+  db.slots.markSlotStatus(opts.slotId, opts.status);
+  if (opts.leaseUntil != null || opts.owner != null) {
+    // Claim at exactly `leaseUntil` so the CAS sees a free/expired slot and the
+    // stored lease_until is whatever the scenario needs (past or future).
+    const leaseUntil = opts.leaseUntil ?? 0;
+    db.slots.claimSlotLease(opts.slotId, opts.owner ?? 'dead-worker', leaseUntil, leaseUntil);
+  }
+}
+
+describe('Scheduler dispatch must not lose the trigger context', () => {
+  it('runNow forwards the resolved SlotContext into the job (incident: slot dropped by the executor)', async () => {
+    await withDb(async (db) => {
+      const execute = makeExecute();
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => makeConfig(),
+        execute,
+        database: db,
+      });
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      manager.start(cfg);
+      try {
+        const slot = {
+          slotId: 'bot1@2026-09-08T1000',
+          scheduleId: 'bot1',
+          occurrenceAt: OCCURRENCE_AT,
+          occurrenceDate: '2026-09-08',
+          occurrenceLabel: '10:00',
+          timezone: 'Asia/Shanghai',
+          triggerSource: 'http' as const,
+          slotName: '10:00',
+          slotDate: '2026-09-08',
+        };
+        expect(manager.triggerSchedule('bot1', { triggerSource: 'http', slot })).toBe(true);
+        await waitFor(() => execute.mock.calls.length > 0);
+
+        // The executor MUST receive the same occurrence the adapter resolved;
+        // losing it made the run resolve a different (or no) slot.
+        const passed = execute.mock.calls[0][2] as ScheduleRunOptions | undefined;
+        expect(passed?.slot?.slotId).toBe(slot.slotId);
+        expect(passed?.triggerSource).toBe('http');
+      } finally {
+        manager.stop();
+      }
+    });
+  });
+
+  it('admission is fire-and-forget: it returns before a never-resolving run finishes', async () => {
+    await withDb(async (db) => {
+      let settle: (() => void) | undefined;
+      const neverFinishes = new Promise<void>((resolve) => {
+        settle = resolve;
+      });
+      const execute = jest.fn(async () => {
+        await neverFinishes;
+      });
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => makeConfig(),
+        execute,
+        database: db,
+      });
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      manager.start(cfg);
+      try {
+        const slot = {
+          slotId: 'bot1@2026-09-08T1000',
+          scheduleId: 'bot1',
+          occurrenceAt: OCCURRENCE_AT,
+          occurrenceDate: '2026-09-08',
+          occurrenceLabel: '10:00',
+          timezone: 'Asia/Shanghai',
+          triggerSource: 'http' as const,
+          slotName: '10:00',
+          slotDate: '2026-09-08',
+        };
+        // A 10-40 minute run must not be awaited by the accepting endpoint.
+        expect(manager.triggerSchedule('bot1', { triggerSource: 'http', slot })).toBe(true);
+        await waitFor(() => execute.mock.calls.length > 0);
+        // Still in flight, and the caller already has its answer.
+        expect(execute).toHaveBeenCalledTimes(1);
+      } finally {
+        // Release the deliberately-hung run, then let its accounting settle.
+        settle?.();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        manager.stop();
+      }
+    });
+  });
+});
+
+describe('lease semantics bound how long a dead worker blocks its slot', () => {
+  it('a live lease rejects a second owner and hides the slot from recovery', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, scheduleConfig, 'http', AT).context!;
+      coord.prepare(slot, schedule, [target('a')]);
+
+      const ttl = 3 * 60 * 1000;
+      expect(coord.claimRunLease(slot.slotId, 'worker-1', ttl)).toBe(true);
+      // Concurrent Cloudflare + watchdog triggers must converge, not double-run.
+      expect(coord.claimRunLease(slot.slotId, 'worker-2', ttl)).toBe(false);
+      expect(db.slots.recoverableSlots().map((s) => s.id)).not.toContain(slot.slotId);
+    });
+  });
+
+  it('an expired lease is reclaimable, and the TTL is far below the run timeout', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, scheduleConfig, 'http', AT).context!;
+      coord.prepare(slot, schedule, [target('a')]);
+
+      const ttl = 3 * 60 * 1000;
+      expect(coord.claimRunLease(slot.slotId, 'crashed-worker', ttl)).toBe(true);
+
+      // 30-minute schedule timeout + crash would have been a 31-minute block
+      // under the old lease TTL; a dead worker must now be replaceable in ~TTL.
+      expect(ttl).toBeLessThanOrEqual(5 * 60 * 1000);
+      const later = Date.now() + ttl + 1000;
+      // The slot is visible to reconciliation the moment its lease lapses...
+      expect(db.slots.recoverableSlots(later).map((s) => s.id)).toContain(slot.slotId);
+      // ...and a restarted worker wins the CAS on the same row.
+      expect(db.slots.claimSlotLease(slot.slotId, 'restarted-worker', ttl, later)).toBe(true);
+    });
+  });
+
+  it('a slot recorded but never claimed is recoverable (crash between accept and claim)', async () => {
+    await withDb(async (db) => {
+      seedSlot(db, { slotId: 'bot1@2026-09-08T1000', status: 'pending' });
+      const lease = db.slots.getSlotLease('bot1@2026-09-08T1000');
+      expect(lease.owner).toBeNull();
+      expect(lease.until).toBeNull();
+      expect(db.slots.recoverableSlots().map((s) => s.id)).toContain('bot1@2026-09-08T1000');
+    });
+  });
+
+  it('the lease is still held after finish(), so a concurrent trigger cannot re-run the rollup', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, scheduleConfig, 'http', AT).context!;
+      coord.prepare(slot, schedule, [target('a')]);
+      expect(coord.claimRunLease(slot.slotId, 'worker-1', 3 * 60 * 1000)).toBe(true);
+      coord.markRunning(slot.slotId);
+
+      coord.lockWork(slot.slotId, 'a', '100', 'illustration');
+      coord.markCell(slot.slotId, 'a', 'submitted');
+      const summary = coord.finish(slot, schedule, [target('a')]);
+      expect(summary.status).toBe('success');
+
+      // Ordering invariant: release happens AFTER finish. Until then the slot
+      // must still be owned.
+      expect(coord.claimRunLease(slot.slotId, 'worker-2', 3 * 60 * 1000)).toBe(false);
+
+      // Once released, the occurrence is recognisably terminal rather than
+      // runnable again: prepare() is the guard the runtime checks before claiming.
+      coord.releaseRunLease(slot.slotId, 'worker-1');
+      expect(coord.prepare(slot, schedule, [target('a')]).alreadyCompleted).toBe(true);
+    });
+  });
+});
+
+describe('reconciliation re-dispatches stranded slots', () => {
+  it('recovers a stale-lease slot at startup using the STORED occurrence', async () => {
+    await withDb(async (db) => {
+      const staleSlotId = 'bot1@2026-09-08T1000';
+      // Lease expired 5 minutes ago: the worker that owned it is gone.
+      seedSlot(db, { slotId: staleSlotId, status: 'running', owner: 'dead-worker', leaseUntil: Date.now() - 5 * 60 * 1000 });
+
+      const execute = makeExecute();
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => cfg,
+        execute,
+        database: db,
+      });
+      manager.start(cfg);
+      try {
+        await waitFor(() => execute.mock.calls.length > 0);
+        await settle();
+        const passed = execute.mock.calls[0][2] as ScheduleRunOptions | undefined;
+        // Must resume the SAME occurrence, never re-resolve "now" (which would
+        // map a stranded 18:00 slot onto a different one).
+        expect(passed?.slot?.slotId).toBe(staleSlotId);
+        expect(passed?.slot?.occurrenceAt).toBe(OCCURRENCE_AT);
+      } finally {
+        manager.stop();
+      }
+    });
+  });
+
+  it('recovers a queued slot that was never claimed (pending + no lease)', async () => {
+    await withDb(async (db) => {
+      seedSlot(db, { slotId: 'bot1@2026-09-08T1000', status: 'pending' });
+
+      const execute = makeExecute();
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => cfg,
+        execute,
+        database: db,
+      });
+      manager.start(cfg);
+      try {
+        expect(await waitFor(() => execute.mock.calls.length > 0)).toBe(true);
+        await settle();
+      } finally {
+        manager.stop();
+      }
+    });
+  });
+
+  it('never steals a slot from a live worker', async () => {
+    await withDb(async (db) => {
+      const liveSlotId = 'bot1@2026-09-08T1000';
+      seedSlot(db, { slotId: liveSlotId, status: 'running', owner: 'live-worker', leaseUntil: Date.now() + 3 * 60 * 1000 });
+
+      const execute = makeExecute();
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => cfg,
+        execute,
+        database: db,
+      });
+      manager.start(cfg);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(execute).not.toHaveBeenCalled();
+      } finally {
+        manager.stop();
+      }
+    });
+  });
+
+  it('recovery also runs in external mode, where catch-up deliberately does not', async () => {
+    await withDb(async (db) => {
+      seedSlot(db, { slotId: 'bot1@2026-09-08T1000', status: 'running', owner: 'dead', leaseUntil: Date.now() - 60_000 });
+
+      const execute = makeExecute();
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => cfg,
+        execute,
+        database: db,
+      });
+      manager.start(cfg);
+      try {
+        // A stranded slot is a fact in the ledger, not a cron guess: it must be
+        // recovered even though external mode never catches missed runs.
+        expect(await waitFor(() => execute.mock.calls.length > 0)).toBe(true);
+        await settle();
+      } finally {
+        manager.stop();
+      }
+    });
+  });
+
+  it('skips a stranded slot whose schedule no longer exists instead of guessing', async () => {
+    await withDb(async (db) => {
+      db.slots.getOrCreateSlot('gone@2026-09-08T1000', {
+        scheduleId: 'gone',
+        occurrenceAt: OCCURRENCE_AT,
+        occurrenceDate: '2026-09-08',
+        occurrenceLabel: '10:00',
+        timezone: 'Asia/Shanghai',
+        targetIds: ['bot1-illust'],
+        triggerSource: 'http',
+      });
+      db.slots.markSlotStatus('gone@2026-09-08T1000', 'pending');
+
+      const execute = makeExecute();
+      const cfg = makeConfig({ schedulerRuntime: { mode: 'external', watchConfig: false } });
+      const manager = new MultiScheduleManager({
+        configPath: '/tmp/not-watched.json',
+        loadConfig: () => cfg,
+        execute,
+        database: db,
+      });
+      manager.start(cfg);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(execute).not.toHaveBeenCalled();
+        // And it stays reported as stranded rather than silently completed.
+        expect(db.slots.recoverableSlots().map((s) => s.id)).toContain('gone@2026-09-08T1000');
+      } finally {
+        manager.stop();
+      }
+    });
+  });
+});

--- a/src/commands/SchedulerCommand.ts
+++ b/src/commands/SchedulerCommand.ts
@@ -9,7 +9,7 @@ import { getConfigPath, loadConfig, StandaloneConfig } from '../config';
 import { MultiScheduleManager } from '../scheduler/MultiScheduleManager';
 import { ScheduleTriggerServer, TriggerRunResult } from '../scheduler/ScheduleTriggerServer';
 import { SlotCoordinator } from '../scheduler/SlotCoordinator';
-import { TriggerSource } from '../scheduler/OccurrenceResolver';
+import { selectScheduleTargets } from '../scheduler/schedules';
 import { createSchedulerRuntime } from './scheduler-runtime';
 
 /**
@@ -82,12 +82,14 @@ export class SchedulerCommand extends BaseCommand {
         const findPlan = (cfg: StandaloneConfig, scheduleId: string) =>
           cfg.schedules?.find((s) => s.id === scheduleId && s.enabled !== false);
 
-        // In-process singleflight: coalesce concurrent triggers of the same
-        // occurrence on THIS process. Optimization only — the DB unique
-        // constraints + ledger are the real correctness guarantee across
-        // restarts/processes.
-        const inFlight = new Map<string, Promise<TriggerRunResult>>();
-
+        // Durable dispatch. The trigger endpoint records the occurrence FIRST,
+        // then hands it to the shared scheduler and answers immediately. It must
+        // never await the download itself: a 10-40 minute run outlives the
+        // router/proxy/clock timeouts, and a request that dies mid-run used to
+        // take the occurrence with it. Idempotency comes from the slot ledger and
+        // the cross-process lease, so concurrent clocks (Cloudflare + watchdog +
+        // manual) converge on one worker instead of needing an in-process
+        // singleflight map.
         triggerServer = new ScheduleTriggerServer(
           ScheduleTriggerServer.resolveToken(rt.trigger?.token),
           {
@@ -100,38 +102,65 @@ export class SchedulerCommand extends BaseCommand {
               if (!resolved.context) return { error: resolved.error ?? 'could not resolve occurrence', status: resolved.status ?? 400 };
               return { context: resolved.context };
             },
-            run: (scheduleId, context) => {
-              const key = context.slotId;
-              const existing = inFlight.get(key);
-              if (existing) return existing;
+            run: async (scheduleId, context): Promise<TriggerRunResult> => {
               const cfg = resolveConfig();
               const plan = findPlan(cfg, scheduleId);
-              const promise = (async (): Promise<TriggerRunResult> => {
-                try {
-                  if (!plan) return { scheduleId, slotId: context.slotId, status: 'failed', alreadyCompleted: false };
-                  // Synchronous: awaited so the HTTP response does not return
-                  // (and release the activity lease) until the run finishes.
-                  await runtime.runJob(cfg, plan, { triggerSource: 'http' as TriggerSource, slot: context });
-                  const rec = runtime.database.slots.getSlot(context.slotId);
-                  const cells = runtime.database.slots.getCells(context.slotId).map((c) => ({
-                    targetId: c.targetId,
-                    status: c.status,
-                    workId: c.workId,
-                    error: c.lastError,
-                  }));
-                  return {
-                    scheduleId,
-                    slotId: context.slotId,
-                    status: rec?.status ?? 'failed',
-                    alreadyCompleted: rec?.status === 'success' || rec?.status === 'partial',
-                    cells,
-                  };
-                } finally {
-                  inFlight.delete(key);
-                }
-              })();
-              inFlight.set(key, promise);
-              return promise;
+              if (!plan) {
+                return { scheduleId, slotId: context.slotId, disposition: 'rejected', status: 'failed' };
+              }
+              const targets = selectScheduleTargets(cfg.targets, plan);
+              if (targets.length === 0) {
+                return { scheduleId, slotId: context.slotId, disposition: 'rejected', status: 'pending' };
+              }
+
+              // Step 1: make the occurrence durable BEFORE answering. A crash
+              // between here and the claim leaves a `pending`, lease-less row that
+              // the recovery loop re-dispatches, so an accepted trigger can never
+              // be silently dropped.
+              const prepared = coordinator.prepare(context, plan, targets);
+              if (prepared.alreadyCompleted) {
+                return {
+                  ...coordinator.completedSummary(context.slotId, plan),
+                  disposition: 'already_completed',
+                };
+              }
+
+              // Step 2: admit to the scheduler. Fire-and-forget by contract — the
+              // boolean only reports whether this process took the work.
+              const admitted = manager.triggerSchedule(scheduleId, {
+                triggerSource: 'http',
+                slot: context,
+              });
+              const rec = runtime.database.slots.getSlot(context.slotId);
+
+              if (admitted) {
+                return {
+                  scheduleId,
+                  slotId: context.slotId,
+                  disposition: 'accepted',
+                  status: rec?.status ?? 'pending',
+                };
+              }
+
+              // Not admitted locally. A live lease means another worker already
+              // owns the occurrence; anything else is a refusal this process could
+              // not take (busy/stopped/limit), which the clock may retry and the
+              // recovery loop will also pick up.
+              const lease = runtime.database.slots.getSlotLease(context.slotId);
+              if (lease.owner && lease.until && lease.until > Date.now()) {
+                return {
+                  scheduleId,
+                  slotId: context.slotId,
+                  disposition: 'already_running',
+                  status: 'running',
+                };
+              }
+              return {
+                scheduleId,
+                slotId: context.slotId,
+                disposition: 'rejected',
+                status: rec?.status ?? 'pending',
+              };
             },
             drainOutbox: () => runtime.drainOutbox(),
             status: (scheduleId) => {

--- a/src/commands/SchedulerCommand.ts
+++ b/src/commands/SchedulerCommand.ts
@@ -56,6 +56,8 @@ export class SchedulerCommand extends BaseCommand {
         execute: runtime.runJob,
         database: runtime.database,
         onFailure: runtime.notifyScheduleFailure,
+        onAbandoned: (_config, _schedule, abandoned) =>
+          runtime.abandonActiveRun(abandoned.errorMessage ?? 'abandoned after timeout'),
         telemetry: {
           beginRun: () => runtime.database.getOverviewStats().totalDownloads,
           endRun: () => runtime.database.getOverviewStats().totalDownloads,

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -87,6 +87,12 @@ export interface SchedulerRuntime {
   runJob(snapshot: StandaloneConfig, schedule: ScheduleConfig, options?: RunJobOptions): Promise<void>;
   /** Cancel the in-flight download plan, if any. */
   cancelActive(reason: string): void;
+  /**
+   * The active run never settled after its timeout and drain window. Stop
+   * renewing its lease and take its Slot terminal so recovery cannot re-dispatch
+   * the same occurrence alongside the still-running job.
+   */
+  abandonActiveRun(reason: string): void;
   /** Notify the affected review group after a failed scheduled run. */
   notifyScheduleFailure(
     snapshot: StandaloneConfig,
@@ -265,6 +271,12 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
   }
 
   let activeDownloadManager: DownloadManager | null = null;
+  /**
+   * Lease bookkeeping of the run that currently owns a Slot, exposed to
+   * cancelActive()/abandonActiveRun() (defined below, outside runJob's closure).
+   * Set while a lease is held and cleared as soon as it is released.
+   */
+  let activeLeaseHooks: { stopHeartbeat(): void; abandon(reason: string): void } | null = null;
 
   // Independently-pumped durable outbox (content + notifications). Started in
   // the long-running scheduler daemon; run-once drains explicitly before exit.
@@ -323,6 +335,12 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     // resolve a canonical occurrence and converge on one durable Slot.
     let slotCtx: SlotContext | null = null;
     let varReleaseLease: (() => void) | null = null;
+    /**
+     * Set when the run was abandoned past its drain window. A wedged job can
+     * still return much later; it must not roll the slot up again (which would
+     * overwrite the terminal `failed` record the abandon path wrote).
+     */
+    let slotAbandoned = false;
     if (!adhoc) {
       if (providedSlot) {
         slotCtx = providedSlot;
@@ -370,14 +388,48 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       // Only the process that actually owns the lease may report the slot as
       // running; the accepting adapter records it as pending instead.
       coordinator.markRunning(activeSlot.slotId);
-      const heartbeat = setInterval(
-        () => coordinator.heartbeatLease(activeSlot.slotId, runOwner, SLOT_LEASE_TTL_MS),
-        SLOT_HEARTBEAT_MS
-      );
+      let cancelled = false;
+      const heartbeat = setInterval(() => {
+        // A cancelled/timed-out run must stop renewing its lease. An infinitely
+        // renewed lease is precisely what made a wedged run unrecoverable: the
+        // heartbeat outlived the scheduler timeout, so no other worker could ever
+        // claim the slot and the occurrence stayed stuck in `running` forever.
+        if (cancelled) {
+          clearInterval(heartbeat);
+          return;
+        }
+        coordinator.heartbeatLease(activeSlot.slotId, runOwner, SLOT_LEASE_TTL_MS);
+      }, SLOT_HEARTBEAT_MS);
       heartbeat.unref?.();
       varReleaseLease = () => {
         clearInterval(heartbeat);
+        activeLeaseHooks = null;
         coordinator.releaseRunLease(activeSlot.slotId, runOwner);
+      };
+      activeLeaseHooks = {
+        stopHeartbeat: () => {
+          cancelled = true;
+          clearInterval(heartbeat);
+        },
+        /**
+         * The run will never settle: stop heart-beating AND leave the ledger
+         * terminal, so the recovery sweep (which only acts on `pending`/`running`
+         * slots with no live lease) cannot re-dispatch this occurrence next to a
+         * still-running job. Merely dropping the lease would be wrong here —
+         * unlike a crash, this worker is alive.
+         */
+        abandon: (reason: string) => {
+          cancelled = true;
+          slotAbandoned = true;
+          clearInterval(heartbeat);
+          database.slots.markSlotStatus(
+            activeSlot.slotId,
+            'failed',
+            `abandoned after scheduler timeout; no delivery (${reason})`
+          );
+          coordinator.releaseRunLease(activeSlot.slotId, runOwner);
+          activeLeaseHooks = null;
+        },
       };
     }
 
@@ -500,7 +552,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     }
     const duration = Math.round((Date.now() - startTime) / 1000);
 
-    if (slotCtx) {
+    if (slotCtx && !slotAbandoned) {
       const summary = coordinator.finish(slotCtx, schedule, targets);
       notificationPolicy.sendSlotSummary(
         slotCtx,
@@ -531,6 +583,18 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
 
   const cancelActive = (reason: string): void => {
     activeDownloadManager?.cancel(reason);
+    // Scheduler timeout / process shutdown also stop the lease heartbeat. The run
+    // is on its way out (or about to be killed with the process), so it must not
+    // keep the slot locked while it unwinds. A shutdown deliberately leaves the
+    // slot NON-terminal: recovery resumes the same occurrence after restart.
+    activeLeaseHooks?.stopHeartbeat();
+  };
+
+  const abandonActiveRun = (reason: string): void => {
+    // Cancellation did not take effect inside the drain window — a request that
+    // ignores the abort. This run will never settle, so finish the lease
+    // bookkeeping it cannot do itself.
+    activeLeaseHooks?.abandon(reason);
   };
 
   const close = (): void => {
@@ -550,6 +614,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     tokenMaintenance,
     runJob,
     cancelActive,
+    abandonActiveRun,
     startOutboxWorker: () => outboxWorker.start(),
     drainOutbox: () => outboxWorker.drainOnce(),
     notifyScheduleFailure: (snapshot, schedule, failure) =>

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -17,7 +17,12 @@ import { DownloadManager } from '../download/DownloadManager';
 import { DeliveryDispatcher } from '../delivery/DeliveryDispatcher';
 import { createTokenMaintenanceService } from '../utils/token-maintenance';
 import { selectScheduleTargets } from '../scheduler/schedules';
-import { SlotContext, SlotCoordinator } from '../scheduler/SlotCoordinator';
+import {
+  SLOT_HEARTBEAT_MS,
+  SLOT_LEASE_TTL_MS,
+  SlotContext,
+  SlotCoordinator,
+} from '../scheduler/SlotCoordinator';
 import { TargetOutcome } from '../scheduler/TargetOutcome';
 import { DeliveryService } from '../delivery/DeliveryService';
 import { OutboxWorker } from '../delivery/OutboxWorker';
@@ -337,19 +342,20 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
 
       const activeSlot = slotCtx!;
       const runOwner = `run-${process.pid}-${randomUUID().slice(0, 8)}`;
-      const leaseMs = Math.max(60_000, (schedule.timeout ?? 30 * 60_000) + 60_000);
-      const begin = coordinator.begin(slotCtx, schedule, targets);
-      if (begin.alreadyCompleted && !onlyTarget) {
+      const prepared = coordinator.prepare(slotCtx, schedule, targets);
+      if (prepared.alreadyCompleted && !onlyTarget) {
         logger.info('Slot already terminal; nothing to do', {
           slot: activeSlot.slotId,
-          status: begin.slotRec.status,
+          status: prepared.slotRec.status,
         });
         return;
       }
       // Cross-process lease: a concurrent Cloudflare + watchdog + manual
       // trigger on a SECOND process sees an active lease and converges instead
-      // of running the same targets in parallel.
-      const claimed = coordinator.claimRunLease(activeSlot.slotId, runOwner, leaseMs);
+      // of running the same targets in parallel. The lease TTL bounds how long a
+      // DEAD worker blocks its slot; it is intentionally independent of
+      // schedule.timeout (which bounds how long a live run may take).
+      const claimed = coordinator.claimRunLease(activeSlot.slotId, runOwner, SLOT_LEASE_TTL_MS);
       if (!claimed) {
         const lease = database.slots.getSlotLease(activeSlot.slotId);
         logger.info('Slot run already leased by another worker; converging', {
@@ -361,7 +367,13 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
         await outboxWorker.drainOnce(1);
         return;
       }
-      const heartbeat = setInterval(() => coordinator.heartbeatLease(activeSlot.slotId, runOwner, leaseMs), Math.floor(leaseMs / 3));
+      // Only the process that actually owns the lease may report the slot as
+      // running; the accepting adapter records it as pending instead.
+      coordinator.markRunning(activeSlot.slotId);
+      const heartbeat = setInterval(
+        () => coordinator.heartbeatLease(activeSlot.slotId, runOwner, SLOT_LEASE_TTL_MS),
+        SLOT_HEARTBEAT_MS
+      );
       heartbeat.unref?.();
       varReleaseLease = () => {
         clearInterval(heartbeat);
@@ -378,6 +390,10 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     if (slotCtx && runTargets.length === 0) {
       logger.info('All slot cells already complete', { slot: slotCtx.slotId });
       coordinator.finish(slotCtx, schedule, targets);
+      // Release LAST: the slot must stay owned until its aggregate state has
+      // been rolled up, otherwise a concurrent trigger could claim and re-run it
+      // against a half-finished ledger.
+      varReleaseLease?.();
       return;
     }
     // Ad-hoc refetch with a filter that matched no target (or all filtered out):
@@ -469,6 +485,10 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       await downloadManager.runAllTargets();
     } catch (error) {
       if (!slotCtx || !(error instanceof Error) || !/^All \d+ target\(s\) failed\./.test(error.message)) {
+        // Abnormal abort: no roll-up is possible, so hand the slot back now
+        // instead of holding it until the lease TTL expires. Recovery sees a
+        // non-terminal slot with no live lease and resumes the SAME occurrence.
+        releaseLease?.();
         throw error;
       }
       // Scheduled Slots treat terminal target failures (failed/no_candidate) as
@@ -477,7 +497,6 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       allTargetsFailed = error;
     } finally {
       if (activeDownloadManager === downloadManager) activeDownloadManager = null;
-      releaseLease?.();
     }
     const duration = Math.round((Date.now() - startTime) / 1000);
 

--- a/src/download/DownloadManager.ts
+++ b/src/download/DownloadManager.ts
@@ -57,6 +57,13 @@ export class DownloadManager implements IDownloadManager {
   // Cooperative cancellation state (see cancel())
   private cancelled = false;
   private cancelReason = '';
+  /**
+   * Hard cancellation signal for the current run. The flag above only stops the
+   * pipeline between items; this aborts the in-flight HTTP request too, so a
+   * cancelled run cannot sit blocked inside a Pixiv call until the scheduler
+   * times out — and, once timed out, cannot keep holding its slot lease.
+   */
+  private readonly abortController = new AbortController();
   private readonly deliveryService!: DeliveryService;
   /** Per-target TYPED outcome hook (the Slot ledger maps it to cell transitions). */
   private onTargetOutcome: ((target: TargetConfig, outcome: TargetOutcome) => void) | null = null;
@@ -105,6 +112,17 @@ export class DownloadManager implements IDownloadManager {
       this.cancelReason = reason;
       logger.warn(`Download cancellation requested: ${reason}`);
     }
+    // Always abort, even on a repeated cancel: the signal is what unwedges an
+    // in-flight request, and an early cancel (e.g. process shutdown) must not
+    // leave a later, already-aborted run with a live signal.
+    if (!this.abortController.signal.aborted) {
+      this.abortController.abort(reason);
+    }
+  }
+
+  /** Run-scoped abort signal (already aborted once cancel() was called). */
+  public get signal(): AbortSignal {
+    return this.abortController.signal;
   }
 
   public isCancelled(): boolean {
@@ -183,7 +201,8 @@ export class DownloadManager implements IDownloadManager {
       typeof (database as unknown as { getDatabasePath?: () => string }).getDatabasePath === 'function'
         ? (database as unknown as { getDatabasePath(): string })
         : config.storage?.databasePath,
-      config.download?.requestDelay ?? 500
+      config.download?.requestDelay ?? 500,
+      this.abortController.signal
     );
 
     this.illustrationHandler = new IllustrationTargetHandler(

--- a/src/pixiv-client/PixivFlowPixivClient.ts
+++ b/src/pixiv-client/PixivFlowPixivClient.ts
@@ -99,25 +99,33 @@ export class PixivFlowPixivClient implements IPixivClient {
   // -- IPixivClient surface ---------------------------------------------------
 
   searchIllustrations(target: TargetConfig): Promise<PixivIllust[]> {
+    return this.searchIllustrationsInternal(target);
+  }
+
+  private searchIllustrationsInternal(target: TargetConfig, signal?: AbortSignal): Promise<PixivIllust[]> {
     const requestDelay = this.config.download?.requestDelay ?? 500;
-    return this.searchRunner.searchIllustrations(target, requestDelay);
+    return this.searchRunner.searchIllustrations(target, requestDelay, signal);
   }
 
   searchNovels(target: TargetConfig): Promise<PixivNovel[]> {
-    const requestDelay = this.config.download?.requestDelay ?? 500;
-    return this.searchRunner.searchNovels(target, requestDelay);
+    return this.searchNovelsInternal(target);
   }
 
-  getTagAutocomplete(seed: string): Promise<PixivTag[]> {
-    return this.kit.tags.autocomplete(seed);
+  private searchNovelsInternal(target: TargetConfig, signal?: AbortSignal): Promise<PixivNovel[]> {
+    const requestDelay = this.config.download?.requestDelay ?? 500;
+    return this.searchRunner.searchNovels(target, requestDelay, signal);
+  }
+
+  getTagAutocomplete(seed: string, options: { signal?: AbortSignal } = {}): Promise<PixivTag[]> {
+    return this.kit.tags.autocomplete(seed, options.signal);
   }
 
   searchIllustrationsForTags(
     seed: string,
     limit: number,
-    options: { startDate?: string; endDate?: string; includeR18?: boolean } = {}
+    options: { startDate?: string; endDate?: string; includeR18?: boolean; signal?: AbortSignal } = {}
   ): Promise<PixivIllust[]> {
-    return this.searchIllustrations({
+    return this.searchIllustrationsInternal({
       type: 'illustration',
       tag: seed,
       searchTarget: 'partial_match_for_tags',
@@ -126,15 +134,15 @@ export class PixivFlowPixivClient implements IPixivClient {
       startDate: options.startDate,
       endDate: options.endDate,
       r18: options.includeR18,
-    });
+    }, options.signal);
   }
 
   searchNovelsForTags(
     seed: string,
     limit: number,
-    options: { startDate?: string; endDate?: string; includeR18?: boolean } = {}
+    options: { startDate?: string; endDate?: string; includeR18?: boolean; signal?: AbortSignal } = {}
   ): Promise<PixivNovel[]> {
-    return this.searchNovels({
+    return this.searchNovelsInternal({
       type: 'novel',
       tag: seed,
       searchTarget: 'partial_match_for_tags',
@@ -143,7 +151,7 @@ export class PixivFlowPixivClient implements IPixivClient {
       startDate: options.startDate,
       endDate: options.endDate,
       r18: options.includeR18,
-    });
+    }, options.signal);
   }
 
   getIllustration(id: number): Promise<PixivIllust> {

--- a/src/pixiv-client/TargetSearchRunner.ts
+++ b/src/pixiv-client/TargetSearchRunner.ts
@@ -11,6 +11,7 @@ import { logger } from '../logger';
 import { parseDateRange } from '../utils/date-utils';
 import { isDateInRange } from '../utils/date-utils';
 import { sortPixivItems } from '../utils/pixiv-sort';
+import { throwIfAborted } from '../utils/errors';
 import type { TargetConfig } from '../config';
 import { mapTargetToIllustQuery, mapTargetToNovelQuery } from './query-mapper';
 
@@ -23,28 +24,35 @@ import { mapTargetToIllustQuery, mapTargetToNovelQuery } from './query-mapper';
 export class TargetSearchRunner {
   constructor(private readonly kit: KitPixivClient) {}
 
-  async searchIllustrations(target: TargetConfig, requestDelayMs: number): Promise<PixivIllust[]> {
+  async searchIllustrations(
+    target: TargetConfig,
+    requestDelayMs: number,
+    signal?: AbortSignal
+  ): Promise<PixivIllust[]> {
     if (target.tagRelation === 'or') {
       return this.mergeTagUnion(target, requestDelayMs, (t, tag, d) =>
-        this.searchSingleIllust(t, tag, d)
-      );
+        this.searchSingleIllust(t, tag, d, signal), signal);
     }
-    return this.searchSingleIllust(target, target.tag!, requestDelayMs);
+    return this.searchSingleIllust(target, target.tag!, requestDelayMs, signal);
   }
 
-  async searchNovels(target: TargetConfig, requestDelayMs: number): Promise<PixivNovel[]> {
+  async searchNovels(
+    target: TargetConfig,
+    requestDelayMs: number,
+    signal?: AbortSignal
+  ): Promise<PixivNovel[]> {
     if (target.tagRelation === 'or') {
       return this.mergeTagUnion(target, requestDelayMs, (t, tag, d) =>
-        this.searchSingleNovel(t, tag, d)
-      );
+        this.searchSingleNovel(t, tag, d, signal), signal);
     }
-    return this.searchSingleNovel(target, target.tag!, requestDelayMs);
+    return this.searchSingleNovel(target, target.tag!, requestDelayMs, signal);
   }
 
   private async mergeTagUnion<T extends PixivIllust | PixivNovel>(
     target: TargetConfig,
     requestDelayMs: number,
-    runOne: (target: TargetConfig, tag: string, delayMs: number) => Promise<T[]>
+    runOne: (target: TargetConfig, tag: string, delayMs: number) => Promise<T[]>,
+    signal?: AbortSignal
   ): Promise<T[]> {
     const tags = target.tag!.split(/\s+/).map((t) => t.trim()).filter(Boolean);
     if (tags.length <= 1) return runOne(target, target.tag!, requestDelayMs);
@@ -52,6 +60,7 @@ export class TargetSearchRunner {
     const seen = new Set<string>();
     const merged: T[] = [];
     for (let i = 0; i < tags.length; i++) {
+      throwIfAborted(signal, 'search cancelled');
       const part = await runOne(target, tags[i], requestDelayMs);
       for (const item of part) {
         const key = String(item.id);
@@ -61,7 +70,7 @@ export class TargetSearchRunner {
         }
       }
       if (target.limit && merged.length >= target.limit) break;
-      if (i < tags.length - 1 && requestDelayMs > 0) await delay(requestDelayMs);
+      if (i < tags.length - 1 && requestDelayMs > 0) await delay(requestDelayMs, undefined, { signal });
     }
     const sorted = sortPixivItems(merged, target.sort);
     return target.limit ? sorted.slice(0, target.limit) : sorted;
@@ -70,28 +79,32 @@ export class TargetSearchRunner {
   private async searchSingleIllust(
     target: TargetConfig,
     tag: string,
-    requestDelayMs: number
+    requestDelayMs: number,
+    signal?: AbortSignal
   ): Promise<PixivIllust[]> {
     return this.searchWithPagination<PixivIllust, IllustSearchOptions>(
       target,
       tag,
       requestDelayMs,
       (options) => this.kit.illustrations.searchPage(options),
-      (t, g) => mapTargetToIllustQuery({ ...t, tag: g })
+      (t, g) => mapTargetToIllustQuery({ ...t, tag: g }),
+      signal
     );
   }
 
   private async searchSingleNovel(
     target: TargetConfig,
     tag: string,
-    requestDelayMs: number
+    requestDelayMs: number,
+    signal?: AbortSignal
   ): Promise<PixivNovel[]> {
     return this.searchWithPagination<PixivNovel, NovelSearchOptions>(
       target,
       tag,
       requestDelayMs,
       (options) => this.kit.novels.searchPage(options),
-      (t, g) => mapTargetToNovelQuery({ ...t, tag: g })
+      (t, g) => mapTargetToNovelQuery({ ...t, tag: g }),
+      signal
     );
   }
 
@@ -108,7 +121,8 @@ export class TargetSearchRunner {
     tag: string,
     requestDelayMs: number,
     fetchPage: (options: O) => Promise<{ items: T[]; next: string | null }>,
-    buildBase: (t: TargetConfig, tag: string) => O
+    buildBase: (t: TargetConfig, tag: string) => O,
+    signal?: AbortSignal
   ): Promise<T[]> {
     const fetchOne = fetchPage as (options: IllustSearchOptions | NovelSearchOptions) => Promise<{ items: T[]; next: string | null }>;
     logger.debug('Searching Pixiv', {
@@ -142,6 +156,7 @@ export class TargetSearchRunner {
     let shouldStop = false;
 
     while ((!fetchLimit || results.length < fetchLimit) && !shouldStop) {
+      throwIfAborted(signal, 'search cancelled');
       pageCount++;
       // Dates are intentionally filtered CLIENT-side below (legacy behavior;
       // PixivFlow needs the early-stop walk on create_date).
@@ -151,6 +166,10 @@ export class TargetSearchRunner {
         searchTarget: base.searchTarget,
         includeR18: base.includeR18,
         cursor,
+        // Threaded into the kit transport, which combines it with its per-request
+        // timeout and honours it in retry back-off. Without this the pager could
+        // stay blocked in a single hung request for the rest of the run.
+        signal,
       });
       cursor = page.next;
 
@@ -170,7 +189,7 @@ export class TargetSearchRunner {
         logger.debug(
           `Tag "${tag}" page ${pageCount}: total collected ${results.length}, waiting ${requestDelayMs}ms...`
         );
-        await delay(requestDelayMs);
+        await delay(requestDelayMs, undefined, { signal });
       }
       if (!cursor) break;
     }

--- a/src/scheduler/MultiScheduleManager.ts
+++ b/src/scheduler/MultiScheduleManager.ts
@@ -7,6 +7,7 @@ import { logger } from '../logger';
 import { ScheduleConfig, StandaloneConfig } from '../config';
 import {
   DEFAULT_SCHEDULE_TIMEOUT_MS,
+  JobAbandoned,
   JobAdmissionController,
   JobFailure,
   JobLease,
@@ -27,6 +28,17 @@ export interface MultiScheduleManagerOptions {
     config: StandaloneConfig,
     schedule: ScheduleConfig,
     failure: JobFailure
+  ) => Promise<void> | void;
+  /**
+   * A run outlived its timeout AND the drain window, so it will never be
+   * awaited again. The host must finish the bookkeeping the run cannot: stop
+   * renewing its lease and take its Slot terminal, otherwise the recovery sweep
+   * re-dispatches the same occurrence next to a still-running job.
+   */
+  onAbandoned?: (
+    config: StandaloneConfig,
+    schedule: ScheduleConfig,
+    abandoned: JobAbandoned
   ) => Promise<void> | void;
   onReload?: (result: ConfigReloadResult) => void;
 }
@@ -137,6 +149,11 @@ export class MultiScheduleManager {
 
   private startRecoveryLoop(): void {
     if (!this.options.database) return;
+    if (this.isExternalMode()) {
+      logger.info('External scheduler mode: internal cron disabled, awaiting authenticated schedule triggers', {
+        recoveryIntervalMs: RECOVERY_INTERVAL_MS,
+      });
+    }
     this.recoveryTimer = setInterval(() => {
       try {
         this.recoverInterruptedSlots();
@@ -324,7 +341,8 @@ export class MultiScheduleManager {
         this.options.telemetry,
         plan.id,
         this.admission,
-        (failure) => this.options.onFailure?.(config, plan, failure)
+        (failure) => this.options.onFailure?.(config, plan, failure),
+        (abandoned) => this.options.onAbandoned?.(config, plan, abandoned)
       );
       scheduler[registerCron ? 'start' : 'init'](async (options?: ScheduleRunOptions) => {
         // The closure keeps the exact validated snapshot for an in-flight run.

--- a/src/scheduler/MultiScheduleManager.ts
+++ b/src/scheduler/MultiScheduleManager.ts
@@ -14,7 +14,7 @@ import {
   Scheduler,
 } from './Scheduler';
 import { describeSchedule, resolveSchedules } from './schedules';
-import { ResolvedOccurrence, ScheduleRunOptions, resolveOccurrence } from './OccurrenceResolver';
+import { ResolvedOccurrence, ScheduleRunOptions, TriggerSource, resolveOccurrence } from './OccurrenceResolver';
 import { SlotContext } from './SlotCoordinator';
 
 export interface MultiScheduleManagerOptions {
@@ -36,6 +36,20 @@ export interface ConfigReloadResult {
   generation: number;
   schedules: string[];
   error?: string;
+}
+
+/**
+ * How often the manager looks for unfinished occurrences that no live worker
+ * owns. Combined with the slot lease TTL (SlotCoordinator), the worst case for a
+ * slot stranded by a crash/redeploy is roughly TTL + one sweep.
+ */
+export const RECOVERY_INTERVAL_MS = 60 * 1000;
+
+/** Narrow a stored trigger_source back to the union it was written from. */
+function asTriggerSource(value: string | null): TriggerSource {
+  return value === 'cron' || value === 'http' || value === 'manual' || value === 'catchup'
+    ? value
+    : 'catchup';
 }
 
 class SerialJobAdmission implements JobAdmissionController {
@@ -100,6 +114,7 @@ export class MultiScheduleManager {
   private activeConfig!: StandaloneConfig;
   private generation = 0;
   private reloadTimer: NodeJS.Timeout | null = null;
+  private recoveryTimer: NodeJS.Timeout | null = null;
   private watching = false;
   private readonly admission = new SerialJobAdmission(8);
 
@@ -112,8 +127,104 @@ export class MultiScheduleManager {
       throw new Error(result.error || 'Failed to start scheduler');
     }
     this.updateWatcher(config);
+    // Recovery first: it acts on occurrences the ledger already knows about.
+    // Catch-up is inference ("cron suggests a fire was missed") and runs after.
+    this.recoverInterruptedSlots();
+    this.startRecoveryLoop();
     this.catchUpMissedRuns(config);
     return result;
+  }
+
+  private startRecoveryLoop(): void {
+    if (!this.options.database) return;
+    this.recoveryTimer = setInterval(() => {
+      try {
+        this.recoverInterruptedSlots();
+      } catch (error) {
+        logger.warn('Slot recovery sweep failed; will retry on the next tick', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }, RECOVERY_INTERVAL_MS);
+    this.recoveryTimer.unref?.();
+  }
+
+  /**
+   * Re-dispatch occurrences that the durable ledger says are unfinished but that
+   * no live worker owns.
+   *
+   * This is NOT catch-up: catch-up guesses from cron that a fire was missed, and
+   * is therefore disabled in `external` mode where a stopped machine is normal.
+   * Recovery instead acts on a slot row that provably exists and has not reached
+   * a terminal state — a worker that crashed, was redeployed, or died between
+   * "occurrence recorded" and "lease claimed". It must run in EVERY mode, or an
+   * autosleep/external deployment silently strands those slots forever.
+   *
+   * Recovery only DISPATCHES. Clearing the lease here would race a healthy owner
+   * that heartbeats between the read and the write; the atomic CAS in
+   * `claimSlotLease` elects the single winner, so duplicate clocks, restarts and
+   * overlapping sweeps all converge on one worker.
+   */
+  private recoverInterruptedSlots(): void {
+    const database = this.options.database;
+    if (!database) return;
+
+    const config = this.activeConfig;
+    const plans = new Map(
+      resolveSchedules(config)
+        .filter((plan) => plan.enabled)
+        .map((plan) => [plan.id, plan] as const)
+    );
+
+    const recovered = database.slots.recoverableSlots();
+    if (recovered.length === 0) return;
+
+    let reclaimed = 0;
+    let skipped = 0;
+    for (const slot of recovered) {
+      const plan = plans.get(slot.scheduleId);
+      // A slot whose schedule no longer exists (renamed/disabled) has no plan to
+      // run. Report it rather than silently ignoring it, so a config mistake is
+      // visible instead of looking like a missing run.
+      if (!plan || slot.occurrenceAt === null || slot.occurrenceAt === undefined) {
+        skipped++;
+        logger.warn('Cannot recover slot: no enabled schedule (or occurrence) for it', {
+          slot: slot.id,
+          schedule: slot.scheduleId,
+          status: slot.status,
+        });
+        continue;
+      }
+
+      // Rebuild the context from the STORED occurrence. Re-resolving "now" would
+      // map a stale slot onto a different occurrence (e.g. yesterday's 18:00
+      // resuming as today's), which is exactly the silent corruption the ledger
+      // exists to prevent.
+      const context: SlotContext = {
+        slotId: slot.id,
+        scheduleId: slot.scheduleId,
+        occurrenceAt: slot.occurrenceAt,
+        occurrenceDate: slot.occurrenceDate,
+        occurrenceLabel: slot.occurrenceLabel,
+        timezone: slot.timezone,
+        triggerSource: asTriggerSource(slot.triggerSource),
+        slotName: slot.slotName || slot.occurrenceLabel,
+        slotDate: slot.slotDate || slot.occurrenceDate,
+      };
+
+      const admitted = this.triggerSchedule(slot.scheduleId, {
+        triggerSource: context.triggerSource,
+        slot: context,
+      });
+      if (admitted) reclaimed++;
+      else skipped++;
+    }
+
+    logger.info('Recovered interrupted slots', {
+      stale_slots_found: recovered.length,
+      reclaimed,
+      skipped,
+    });
   }
 
   /**
@@ -264,6 +375,8 @@ export class MultiScheduleManager {
   public stop(): void {
     if (this.reloadTimer) clearTimeout(this.reloadTimer);
     this.reloadTimer = null;
+    if (this.recoveryTimer) clearInterval(this.recoveryTimer);
+    this.recoveryTimer = null;
     if (this.watching) unwatchFile(this.options.configPath);
     this.watching = false;
     for (const scheduler of this.schedulers.values()) scheduler.stop();

--- a/src/scheduler/ScheduleTriggerServer.ts
+++ b/src/scheduler/ScheduleTriggerServer.ts
@@ -7,24 +7,48 @@ import { SlotContext } from './SlotCoordinator';
 import { TriggerSource } from './OccurrenceResolver';
 
 /**
- * Authenticated HTTP schedule trigger.
+ * Authenticated HTTP schedule trigger — a DISPATCH endpoint, not a run endpoint.
  *
  * A dumb external clock (Cloudflare cron worker, cron-job.org, GitHub Actions)
- * POSTs a schedule id; this server wakes with the machine, verifies a bearer
- * token, resolves the canonical occurrence from the schedule's OWN cron +
- * timezone (never a client-supplied date), and runs that schedule synchronously
- * so the open HTTP request keeps the machine active for the whole run — the
- * request itself is the activity lease (no background fire-and-forget that lets
- * a scale-to-zero host stop mid-run). All business state lives in the Slot
- * ledger; the handler only authenticates, validates, resolves and delegates. It
- * never queries Pixiv, loops targets, or touches the Slot DB itself.
+ * POSTs a schedule id; this server verifies a bearer token, resolves the
+ * canonical occurrence from the schedule's OWN cron + timezone (never a
+ * client-supplied date), durably records the slot and returns immediately with a
+ * business disposition. Execution happens in the in-process scheduler behind a
+ * short renewable lease, so the response no longer has to stay open for the
+ * whole 10-40 minute run.
+ *
+ * That distinction matters: holding the request open assumed the connection was
+ * an activity lease, but a 10-40 min run cannot survive the router/proxy/client
+ * timeouts that assumption ignored, and a run that outlived them was frozen or
+ * reported as failed while work was still owed. Durable state plus a background
+ * worker means a dropped connection is now recoverable instead of fatal.
+ *
+ * All business state lives in the Slot ledger; the handler only authenticates,
+ * validates, resolves and delegates. It never queries Pixiv, loops targets, or
+ * touches the Slot DB itself.
  *
  * Mounting is independent of `schedulerRuntime.mode`: external mode mounts it as
  * the primary clock; always-on/internal mode may also mount it for manual ops.
  */
+/**
+ * What the trigger adapter actually did with the request. This is the contract
+ * an external clock must judge, because HTTP status alone cannot distinguish
+ * "the run was admitted and is executing" from "the occurrence is finished".
+ */
+export type TriggerDisposition =
+  /** Accepted now; the slot is durably recorded and executes in the background. */
+  | 'accepted'
+  /** Another worker owns the slot; this trigger converged onto it. */
+  | 'already_running'
+  /** The occurrence reached a terminal state (success/partial) earlier. */
+  | 'already_completed'
+  /** Not admitted (unknown/disabled schedule, budget exhausted, bad state). */
+  | 'rejected';
+
 export interface TriggerRunResult {
   scheduleId: string;
   slotId: string;
+  disposition: TriggerDisposition;
   status: string;
   alreadyCompleted?: boolean;
   cells?: Array<{ targetId: string; status: string; workId: string | null; error?: string | null }>;
@@ -97,12 +121,40 @@ export class ScheduleTriggerServer {
         }
 
         const result = await this.handlers.run(scheduleId, resolved.context);
-        // alreadyCompleted => 200 with a clear note; real run => 200 completed.
-        res.status(result.alreadyCompleted ? 200 : 200).json({
-          status: result.status === 'failed' ? 'failed' : 'ok',
-          schedule: result,
-          note: result.alreadyCompleted ? 'already_completed' : 'completed',
-        });
+        // Business disposition, not HTTP luck: an accepted or already-running
+        // occurrence is NOT a completed one. Returning 200/"completed" for a run
+        // that is still executing makes an external clock stop retrying and
+        // silently lose the slot, so 'running' is reported as 202 here.
+        switch (result.disposition) {
+          case 'already_completed':
+            res.status(200).json({
+              status: 'completed',
+              schedule: result,
+              note: 'already_completed',
+            });
+            return;
+          case 'accepted':
+            res.status(202).json({
+              status: 'accepted',
+              schedule: result,
+              note: 'queued',
+            });
+            return;
+          case 'already_running':
+            res.status(202).json({
+              status: 'running',
+              schedule: result,
+              note: 'already_running',
+            });
+            return;
+          default:
+            res.status(503).json({
+              status: 'rejected',
+              schedule: result,
+              note: 'rejected',
+            });
+            return;
+        }
       } catch (error) {
         logger.error('Schedule trigger failed', { error: error instanceof Error ? error.message : String(error) });
         // The slot ledger resumes on the next trigger; a 500 tells the clock to

--- a/src/scheduler/Scheduler.ts
+++ b/src/scheduler/Scheduler.ts
@@ -13,6 +13,20 @@ import { ScheduleRunOptions } from './OccurrenceResolver';
 export const DEFAULT_SCHEDULE_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
+ * How long a run may keep draining after its timeout fired before the scheduler
+ * gives up on it.
+ *
+ * Cancellation is cooperative, so a request that never returns (or a retry loop
+ * that ignores the abort) can outlive the timeout indefinitely. Awaiting that
+ * forever is what kept a timed-out run holding its Slot lease: the scheduler
+ * stayed `running`, the runtime kept heart-beating, and the occurrence could
+ * never be recovered. After this window the run is declared abandoned — the
+ * scheduler slot is freed and the runtime takes the Slot terminal — so a wedged
+ * job degrades into one recorded failure instead of a permanent hang.
+ */
+export const ABORT_DRAIN_MS = 30 * 1000;
+
+/**
  * Optional integration hooks allowing the host command to provide real
  * accounting data and cooperative cancellation to the scheduler.
  */
@@ -38,6 +52,19 @@ export interface JobFailure {
   stopped: boolean;
 }
 
+/**
+ * Reported when a run was still executing after its timeout AND the drain window
+ * expired, so it can never be awaited to completion. The host must treat the run
+ * as finished: stop renewing any lease it owns and take its Slot terminal, or a
+ * recovery sweep will re-dispatch the same occurrence while this run is alive.
+ */
+export interface JobAbandoned {
+  scheduleId: string;
+  executionNumber: number;
+  errorMessage: string | null;
+  drainWindowMs: number;
+}
+
 /** Admission is acquired before timeout/accounting starts. */
 export interface JobAdmissionController {
   acquire(scheduleId: string): Promise<JobLease | null>;
@@ -51,6 +78,7 @@ export class Scheduler {
   private executionCount: number = 0;
   private consecutiveFailures: number = 0;
   private timeoutHandle: NodeJS.Timeout | null = null;
+  private drainHandle: NodeJS.Timeout | null = null;
   private stopped: boolean = false;
   private pending: boolean = false;
 
@@ -60,7 +88,8 @@ export class Scheduler {
     private readonly telemetry?: JobTelemetry,
     private readonly scheduleId: string = 'default',
     private readonly admission?: JobAdmissionController,
-    private readonly onFailure?: (failure: JobFailure) => Promise<void> | void
+    private readonly onFailure?: (failure: JobFailure) => Promise<void> | void,
+    private readonly onAbandoned?: (abandoned: JobAbandoned) => Promise<void> | void
   ) {}
 
   public start(job: (options?: ScheduleRunOptions) => Promise<void>) {
@@ -235,6 +264,12 @@ export class Scheduler {
     });
 
     // Set up timeout if configured
+    let abandoned = false;
+    let resolveDrainExpired: (() => void) | null = null;
+    const drainExpired = new Promise<void>((resolve) => {
+      resolveDrainExpired = resolve;
+    });
+
     if (this.config.timeout) {
       this.timeoutHandle = setTimeout(() => {
         if (this.running) {
@@ -247,20 +282,39 @@ export class Scheduler {
           } catch (cancelError) {
             logger.warn('Failed to request job cancellation', { error: cancelError });
           }
-          // Keep running=true until the aborted job actually settles so the
-          // concurrent-run guard stays correct during the drain window.
+          // Bounded drain. requestCancel is cooperative, so this run is only
+          // guaranteed to be *asked* to stop; a request that ignores the abort
+          // would otherwise hold `running` (and, through the host, the Slot
+          // lease) for good. After the drain window the run is abandoned.
+          this.drainHandle = setTimeout(() => {
+            abandoned = true;
+            errorMessage =
+              `Execution timeout after ${this.config.timeout}ms; the job was still running after the ` +
+              `${ABORT_DRAIN_MS}ms drain window and has been abandoned`;
+            logger.error('Job did not settle within the drain window; abandoning it', {
+              scheduleId: this.scheduleId,
+              drainWindowMs: ABORT_DRAIN_MS,
+            });
+            resolveDrainExpired?.();
+          }, ABORT_DRAIN_MS);
+          this.drainHandle.unref?.();
+          // Keep running=true until the aborted job settles (or the drain
+          // expires) so the concurrent-run guard stays correct.
         }
       }, this.config.timeout);
+      this.timeoutHandle.unref?.();
     }
 
+    const jobPromise = this.executeWithTracking(
+      job,
+      (count) => {
+        itemsDownloaded = count;
+      },
+      triggerOptions
+    );
+
     try {
-      await this.executeWithTracking(
-        job,
-        (count) => {
-          itemsDownloaded = count;
-        },
-        triggerOptions
-      );
+      await (this.config.timeout ? Promise.race([jobPromise, drainExpired]) : jobPromise);
 
       if (timeoutOccurred) {
         status = 'timeout';
@@ -298,6 +352,38 @@ export class Scheduler {
       if (this.timeoutHandle) {
         clearTimeout(this.timeoutHandle);
         this.timeoutHandle = null;
+      }
+      if (this.drainHandle) {
+        clearTimeout(this.drainHandle);
+        this.drainHandle = null;
+      }
+
+      if (abandoned) {
+        // The job is still running somewhere. Its abort signal has been fired, so
+        // it unwinds at the next checkpoint, but we stop waiting for it: capture
+        // its eventual rejection (nothing else can) and let the host finish the
+        // bookkeeping it owns — stop the lease heartbeat and take the Slot
+        // terminal — so a recovery sweep cannot re-dispatch the same occurrence
+        // while this run is still alive.
+        void jobPromise.catch((error) => {
+          logger.warn('Abandoned job settled after the drain window', {
+            scheduleId: this.scheduleId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+        try {
+          await this.onAbandoned?.({
+            scheduleId: this.scheduleId,
+            executionNumber,
+            errorMessage,
+            drainWindowMs: ABORT_DRAIN_MS,
+          });
+        } catch (error) {
+          logger.warn('Failed to report an abandoned job', {
+            scheduleId: this.scheduleId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
 
       const endTime = new Date();
@@ -374,6 +460,10 @@ export class Scheduler {
     if (this.timeoutHandle) {
       clearTimeout(this.timeoutHandle);
       this.timeoutHandle = null;
+    }
+    if (this.drainHandle) {
+      clearTimeout(this.drainHandle);
+      this.drainHandle = null;
     }
     logger.info('Scheduler stopped', {
       totalExecutions: this.executionCount,

--- a/src/scheduler/Scheduler.ts
+++ b/src/scheduler/Scheduler.ts
@@ -254,9 +254,13 @@ export class Scheduler {
     }
 
     try {
-      await this.executeWithTracking(job, (count) => {
-        itemsDownloaded = count;
-      });
+      await this.executeWithTracking(
+        job,
+        (count) => {
+          itemsDownloaded = count;
+        },
+        triggerOptions
+      );
 
       if (timeoutOccurred) {
         status = 'timeout';

--- a/src/scheduler/SlotCoordinator.ts
+++ b/src/scheduler/SlotCoordinator.ts
@@ -17,6 +17,20 @@ import {
 import { TargetOutcome } from './TargetOutcome';
 
 /**
+ * Execution-lease TTL and heartbeat cadence.
+ *
+ * These describe how fast a DEAD worker is noticed — they are deliberately
+ * unrelated to `schedule.timeout` (which caps how long a run may take). Tying
+ * the two together made a crashed worker hold its slot for up to 31 minutes
+ * before any other trigger could resume it. A live worker renews its lease every
+ * SLOT_HEARTBEAT_MS, so the worst-case recovery delay after a crash/restart is
+ * about SLOT_LEASE_TTL_MS. The TTL stays comfortably above the heartbeat so an
+ * occasional stalled event loop cannot make a healthy run look dead.
+ */
+export const SLOT_LEASE_TTL_MS = 3 * 60 * 1000;
+export const SLOT_HEARTBEAT_MS = 30 * 1000;
+
+/**
  * Durable execution context attached to a run. A scheduled occurrence always
  * has a slotId; an ad-hoc/manual run has none (it never touches the slot ledger).
  */
@@ -118,10 +132,16 @@ export class SlotCoordinator {
   }
 
   /**
-   * Open (or resume) an occurrence and snapshot its target membership on first
-   * creation. A later config reload cannot add/remove cells for this occurrence.
+   * Durably open (or resume) an occurrence and snapshot its target membership
+   * on first creation. A later config reload cannot add/remove cells for this
+   * occurrence.
+   *
+   * This deliberately does NOT mark the slot `running`: the HTTP trigger calls
+   * it before dispatch so that a crash between "accepted" and "claimed" still
+   * leaves a durable `pending` row for reconciliation to pick up (see
+   * `markRunning` and MultiScheduleManager's recovery loop).
    */
-  begin(slot: SlotContext, schedule: ScheduleConfig, targets: TargetConfig[]): { slotRec: SlotRecord; alreadyCompleted: boolean } {
+  prepare(slot: SlotContext, schedule: ScheduleConfig, targets: TargetConfig[]): { slotRec: SlotRecord; alreadyCompleted: boolean } {
     const targetIds = targets.map((t) => t.id).filter((id): id is string => Boolean(id));
     const { slot: slotRec, created } = this.database.slots.getOrCreateSlot(slot.slotId, {
       scheduleId: slot.scheduleId,
@@ -146,8 +166,16 @@ export class SlotCoordinator {
     if (slotRec.status === 'success' || slotRec.status === 'partial') {
       return { slotRec, alreadyCompleted: true };
     }
-    this.database.slots.markSlotStatus(slot.slotId, 'running');
     return { slotRec, alreadyCompleted: false };
+  }
+
+  /**
+   * Mark the occurrence as actually executing. Called by the worker that has
+   * already won the cross-process lease (never by the accepting adapter), so a
+   * slot is never reported `running` by a process that is not running it.
+   */
+  markRunning(slotId: string): void {
+    this.database.slots.markSlotStatus(slotId, 'running');
   }
 
   /**

--- a/src/storage/repositories/SlotRepository.ts
+++ b/src/storage/repositories/SlotRepository.ts
@@ -309,14 +309,37 @@ export class SlotRepository extends BaseRepository {
 
   /** Slots whose lease expired while still non-terminal (crashed workers). */
   public slotsWithStaleLease(now: number = Date.now()): string[] {
+    return this.recoverableSlots(now)
+      .filter((slot) => slot.leaseUntil !== null)
+      .map((slot) => slot.id);
+  }
+
+  /**
+   * Non-terminal slots no live worker currently owns, and which therefore should
+   * be re-dispatched.
+   *
+   * Two distinct situations qualify, and both must be recovered:
+   *  - `lease_until <= now`: a worker claimed the slot and then died (crash, OOM,
+   *    machine stop, redeploy). Its heartbeat stopped, so the lease expired.
+   *  - `lease_until IS NULL`: a durable slot was recorded (accepted) but no worker
+   *    ever claimed it — e.g. the process died between "occurrence recorded" and
+   *    "lease claimed". Nothing else will ever pick that up.
+   *
+   * Callers must NOT clear the lease from here. Recovery re-DISPATCHES the slot
+   * and the atomic CAS in `claimSlotLease` still elects the single winner, so a
+   * merely slow (but healthy) owner that heartbeats mid-scan cannot be robbed by
+   * a read-then-clear race.
+   */
+  public recoverableSlots(now: number = Date.now()): SlotRecord[] {
     const rows = this.db
       .prepare(
-        `SELECT id FROM schedule_slots
-         WHERE lease_until IS NOT NULL AND lease_until < @now
-           AND status IN ('pending','running')`
+        `SELECT * FROM schedule_slots
+         WHERE status IN ('pending','running')
+           AND (lease_until IS NULL OR lease_until <= @now)
+         ORDER BY COALESCE(occurrence_at, 0) ASC`
       )
-      .all({ now }) as Array<{ id: string }>;
-    return rows.map((r) => r.id);
+      .all({ now }) as any[];
+    return rows.map((r) => this.toSlot(r));
   }
 
   /** Record an error without changing terminality (retryable failure keeps the cell resumable). */

--- a/src/topic/TopicPipeline.ts
+++ b/src/topic/TopicPipeline.ts
@@ -3,6 +3,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { logger } from '../logger';
 import { calculatePopularityScore } from '../utils/pixiv-utils';
 import { isAIIllustration } from '../utils/ai-detection';
+import { rethrowIfCancelled, throwIfAborted } from '../utils/errors';
 import type { TargetConfig } from '../config';
 import type { TopicResolver } from './TopicResolver';
 import type {
@@ -45,7 +46,14 @@ export class TopicPipeline {
   constructor(
     private readonly client: TopicClient,
     private readonly resolver: TopicResolver,
-    private readonly requestDelayMs = 500
+    private readonly requestDelayMs = 500,
+    /**
+     * Run-scoped cancellation. Candidate acquisition is the longest stretch of
+     * network work in a run, so it must observe the same abort as the download
+     * pipeline; otherwise a cancelled run keeps searching tags and can never
+     * settle, which is what let a timed-out run hold its slot lease forever.
+     */
+    private readonly signal?: AbortSignal
   ) {}
 
   async selectWorks<T extends WorkLike>(
@@ -72,6 +80,9 @@ export class TopicPipeline {
 
     for (let i = 0; i < tagNames.length; i++) {
       if (byId.size >= maxCandidates) break;
+      // Cancellation is checked between tags, so a cancelled run stops issuing
+      // new searches even when the aborted request itself had already returned.
+      throwIfAborted(this.signal, 'topic collection cancelled');
       const tag = tagNames[i];
       const works = await this.searchDay<T>(contentType, tag, day, maxPerTag, includeR18);
       rawCount += works.length;
@@ -134,13 +145,16 @@ export class TopicPipeline {
     includeR18: boolean
   ): Promise<T[]> {
     try {
-      const opts = { startDate: day, endDate: day, includeR18 };
+      const opts = { startDate: day, endDate: day, includeR18, signal: this.signal };
       const works = contentType === 'illustration'
         ? await this.client.searchIllustrationsForTags(tag, limit, opts)
         : await this.client.searchNovelsForTags(tag, limit, opts);
       // Date is already enforced server-side + pager stop; keep a cheap guard.
       return works.filter((w) => this.onDay(w.create_date, day)) as unknown as T[];
     } catch (error) {
+      // A cancellation must not be degraded into "no results for this tag": that
+      // would silently continue the cancelled run across the remaining tags.
+      rethrowIfCancelled(error, this.signal);
       logger.warn('[TopicCollector] search failed tag=' + tag + ' type=' + contentType + ': ' + (error instanceof Error ? error.message : String(error)));
       return [];
     }

--- a/src/topic/TopicResolver.ts
+++ b/src/topic/TopicResolver.ts
@@ -1,6 +1,7 @@
 import { setTimeout as delay } from 'node:timers/promises';
 
 import { logger } from '../logger';
+import { rethrowIfCancelled, throwIfAborted } from '../utils/errors';
 import { TopicCache } from './TopicCache';
 import { TopicTagScorer } from './TopicTagScorer';
 import type {
@@ -41,7 +42,9 @@ export class TopicResolver {
   constructor(
     private readonly client: TopicClient,
     private readonly cache: TopicCache,
-    private readonly requestDelayMs = 500
+    private readonly requestDelayMs = 500,
+    /** Run-scoped cancellation, forwarded to every discovery request. */
+    private readonly signal?: AbortSignal
   ) {}
 
   /** Resolve tags for a topic+type, using cache when fresh. Never throws for
@@ -146,19 +149,40 @@ export class TopicResolver {
     sampleWorks: number,
     includeR18: boolean
   ): Promise<[Array<{ name: string; translated_name?: string }>, WorkLike[], WorkLike[]]> {
-    const suggested = await this.client.getTagAutocomplete(seed).catch(() => [] as Array<{ name: string; translated_name?: string }>);
+    throwIfAborted(this.signal, 'topic resolution cancelled');
+    // Discovery degrades to "no suggestions" / "no background" on ordinary
+    // failures, but a cancellation must abort the run rather than quietly
+    // continue against a stopped pipeline.
+    const suggested = await this.client
+      .getTagAutocomplete(seed, { signal: this.signal })
+      .catch((error: unknown) => {
+        rethrowIfCancelled(error, this.signal);
+        return [] as Array<{ name: string; translated_name?: string }>;
+      });
     if (this.requestDelayMs > 0) await delay(this.requestDelayMs);
 
+    throwIfAborted(this.signal, 'topic resolution cancelled');
     const topicWorks = contentType === 'illustration'
-      ? await this.client.searchIllustrationsForTags(seed, sampleWorks, { includeR18 })
-      : await this.client.searchNovelsForTags(seed, sampleWorks, { includeR18 });
+      ? await this.client.searchIllustrationsForTags(seed, sampleWorks, { includeR18, signal: this.signal })
+      : await this.client.searchNovelsForTags(seed, sampleWorks, { includeR18, signal: this.signal });
 
     // A small, cheap background sample (a common platform tag) estimates how
     // generic a co-occurring tag is. Bounded to keep requests/memory low.
     if (this.requestDelayMs > 0) await delay(this.requestDelayMs);
+    throwIfAborted(this.signal, 'topic resolution cancelled');
     const backgroundWorks = contentType === 'illustration'
-      ? await this.client.searchIllustrationsForTags('イラスト', 40, { includeR18 }).catch(() => [] as WorkLike[])
-      : await this.client.searchNovelsForTags('小説', 40, { includeR18 }).catch(() => [] as WorkLike[]);
+      ? await this.client
+          .searchIllustrationsForTags('イラスト', 40, { includeR18, signal: this.signal })
+          .catch((error: unknown) => {
+            rethrowIfCancelled(error, this.signal);
+            return [] as WorkLike[];
+          })
+      : await this.client
+          .searchNovelsForTags('小説', 40, { includeR18, signal: this.signal })
+          .catch((error: unknown) => {
+            rethrowIfCancelled(error, this.signal);
+            return [] as WorkLike[];
+          });
 
     return [suggested, topicWorks, backgroundWorks];
   }

--- a/src/topic/createTopicPipeline.ts
+++ b/src/topic/createTopicPipeline.ts
@@ -26,18 +26,28 @@ function resolveDbPath(source: DbPathSource): string {
   return absolute;
 }
 
-export function createTopicPipeline(client: IPixivClient, databasePath: DbPathSource, requestDelayMs = 500): TopicPipeline {
+export function createTopicPipeline(
+  client: IPixivClient,
+  databasePath: DbPathSource,
+  requestDelayMs = 500,
+  signal?: AbortSignal
+): TopicPipeline {
   const resolved = resolveDbPath(databasePath);
   const cache = new TopicCache(resolvePath(dirname(resolved), 'topic-cache'));
-  const resolver = new TopicResolver(client as never, cache, requestDelayMs);
-  return new TopicPipeline(client as never, resolver, requestDelayMs);
+  const resolver = new TopicResolver(client as never, cache, requestDelayMs, signal);
+  return new TopicPipeline(client as never, resolver, requestDelayMs, signal);
 }
 
 /** Lazily builds one shared pipeline per download run (cache + resolver). */
-export function createTopicPipelineFactory(client: IPixivClient, databasePath: DbPathSource, requestDelayMs = 500): TopicPipelineFactory {
+export function createTopicPipelineFactory(
+  client: IPixivClient,
+  databasePath: DbPathSource,
+  requestDelayMs = 500,
+  signal?: AbortSignal
+): TopicPipelineFactory {
   let instance: TopicPipeline | undefined;
   return () => {
-    if (!instance) instance = createTopicPipeline(client, databasePath, requestDelayMs);
+    if (!instance) instance = createTopicPipeline(client, databasePath, requestDelayMs, signal);
     return instance;
   };
 }

--- a/src/topic/types.ts
+++ b/src/topic/types.ts
@@ -74,16 +74,19 @@ export interface TopicCandidate {
 
 /** Minimal surface the resolver/collector need from the Pixiv client. */
 export interface TopicClient {
-  getTagAutocomplete(seed: string): Promise<Array<{ name: string; translated_name?: string }>>;
+  getTagAutocomplete(
+    seed: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<Array<{ name: string; translated_name?: string }>>;
   searchIllustrationsForTags(
     seed: string,
     limit: number,
-    options?: { startDate?: string; endDate?: string; includeR18?: boolean }
+    options?: { startDate?: string; endDate?: string; includeR18?: boolean; signal?: AbortSignal }
   ): Promise<Array<WorkLike>>;
   searchNovelsForTags(
     seed: string,
     limit: number,
-    options?: { startDate?: string; endDate?: string; includeR18?: boolean }
+    options?: { startDate?: string; endDate?: string; includeR18?: boolean; signal?: AbortSignal }
   ): Promise<Array<WorkLike>>;
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -144,6 +144,36 @@ export function isOperationCancelled(error: unknown): error is OperationCancelle
 }
 
 /**
+ * Raise the app's cancellation error when `signal` has been aborted.
+ *
+ * Standard `signal.throwIfAborted()` rejects with a DOMException, which the
+ * scheduler does not recognise as a cooperative cancel (it would be recorded as
+ * a hard failure and lose the timeout accounting). Every loop that can outlive a
+ * scheduler timeout checks this instead, so a cancellation is observable on the
+ * same error channel as the rest of the download pipeline.
+ */
+export function throwIfAborted(signal?: AbortSignal, message = 'operation cancelled'): void {
+  if (signal?.aborted) {
+    throw new OperationCancelledError(message);
+  }
+}
+
+/**
+ * Re-raise an error that is a cancellation instead of swallowing it.
+ *
+ * Loops around network calls legitimately degrade on failure (`catch → []`), but
+ * swallowing a cancellation there would let a cancelled run keep working through
+ * the remaining tags. Returns normally only for genuine failures.
+ */
+export function rethrowIfCancelled(error: unknown, signal?: AbortSignal): void {
+  if (isOperationCancelled(error) || signal?.aborted || (error as { name?: string })?.name === 'AbortError') {
+    throw isOperationCancelled(error)
+      ? error
+      : new OperationCancelledError(error instanceof Error ? error.message : 'operation cancelled');
+  }
+}
+
+/**
  * A special error-like class to signal a version request.
  * This is used for early exit without a full error stack.
  */


### PR DESCRIPTION
## 这是 #42 的重建

原 PR #42 已关闭，**不是设计或实现有冲突**：它被 "Update branch" 合过一次 master，history 里多了一个 merge commit。这次基于最新 master（`2ce5c97`）重新落地——5 个提交线性重放，代码内容与原分支**逐字节等价**（`git diff HEAD origin/fix/durable-slot-dispatch` 为空），设计说明与测试证据原样保留。

## 问题：一次下载 > 一次 HTTP 请求

线上 `telesubmit-multi-bot` 出现静默漏跑，根因是触发路径把「一次 10–40 分钟的下载」和「一次 HTTP 请求的生命周期」绑在了一起：

```text
Cloudflare / GitHub
    ↓ POST
TelePost relay（ROUTER_TIMEOUT_SECONDS）
    ↓
ScheduleTriggerServer
    ↓ await this.handlers.run()   ← 10~40 分钟
返回 HTTP 200 / note:"completed"
```

实测证据（2026-09-10）：

- 触发请求在**恰好 600s** 被掐断：`HTTP=502 ELAPSED=600s`，而下载仍在进行（bot1 插画 target 历史实测 1686s，另一次 26+ 分钟）。
- 北京 18:00/18:10 两个 slot **完全没跑**：PixivFlow 日志 09:02→11:46 之间无任何触发记录。
- 已存在且仍在 `running` 的 slot，接口返回 `200 {note:"completed"}` → 外部时钟以为完成、不再重试 → 当天 slot 静默丢失。
- 进程重启后，旧 worker 的租约残留 **31 分钟**（`leaseMs = schedule.timeout + 60s`），期间新触发只"converge"不干活。
- `SlotRepository.slotsWithStaleLease()` 存在但**运行时从未被调用**。

## 改法

```text
Cloudflare / GitHub
    ↓ POST
PixivFlow
    ├─ prepare() 持久化 slot（durable，先落库）
    ├─ manager.triggerSchedule() → Scheduler admission
    └─ 立即 202 Accepted
              ↓
        Scheduler 后台执行
              ↓
        lease(TTL 3min) + heartbeat(30s)
              ↓
        finish() → release lease
```

`restart / crash → startup + 每 60s reconciliation → CAS reclaim → 恢复同一个 slot`

### 1. `Scheduler.ts`：`triggerOptions` 丢失

`executeJob()` 收了 `triggerOptions`，却调用 `executeWithTracking(job, cb)` 时没传下去——所以**每一次外部触发进入 job 时都没有 slot 上下文**，包括启动 catch-up 的 `runNow({ slot })`。

### 2. `SchedulerCommand.ts`：`/run` 改成 dispatch，而非 run

- 先 `coordinator.prepare()` 落库（**先持久化再返回**，避免"返回 202 后进程立刻崩溃 → slot 从未落库 → 永久丢失"）。
- 再 `manager.triggerSchedule()`（本身 fire-and-forget，返回值只表示"是否被接纳"）。
- 删掉 HTTP 私有的 `inFlight` 执行模型与 `await runtime.runJob`；幂等由 slot ledger + 跨进程租约保证。
- 这样 `/run` 正常几十毫秒返回，而不是 1686 秒。

### 3. `ScheduleTriggerServer.ts`：显式 disposition

```ts
type TriggerDisposition = 'accepted' | 'already_running' | 'already_completed' | 'rejected';
```

| disposition | HTTP | note |
|---|---|---|
| `accepted` | 202 | `queued` |
| `already_running` | 202 | `already_running` |
| `already_completed` | 200 | `already_completed` |
| `rejected` | 503 | `rejected` |

`running` 再也不可能被写成 `completed`——只有 DB 里终态为 `success/partial` 才叫 completed。

### 4. `SlotCoordinator.ts`：`begin()` 拆成 `prepare()` + `markRunning()`

`begin()` 原来在**拿到租约之前**就把 slot 标成 `running`（进程没在跑却报 running）。现在：

- `prepare()`：落库 + 冻结 target cells，**不改状态**；
- `markRunning()`：只有真正拿到租约的 worker 调用。

### 5. 租约 TTL 与任务 timeout 解耦

```ts
export const SLOT_LEASE_TTL_MS = 3 * 60 * 1000;   // 原：schedule.timeout + 60s ≈ 31min
export const SLOT_HEARTBEAT_MS  = 30 * 1000;      // 原：leaseMs / 3 ≈ 10min
```

「能跑多久」和「死了多久被发现」是两件事。任务跑 10/30/40 分钟都无所谓，每 30s 续租；进程崩溃后最坏约 3 分钟即可被接管。TTL 不用更激进的值（避免 event loop 偶发卡顿造成误判）。

### 6. 租约生命周期：finish 先于 release

原代码在 `runAllTargets()` 的 `finally` 里就 `releaseLease()`，然后才 `finish()`——release 与 finish 之间存在窗口，另一个触发可以抢到该 slot。另外 `runTargets.length === 0` 的提前 `return` 发生在清理之前，**直接泄漏租约**。现在：claim → execute → finish → release，异常路径立即归还（不再等满 TTL）。

### 7. `MultiScheduleManager.ts`：真正的 reconciliation

- 启动 + 每 60s 扫描 `recoverableSlots()`（`status in (pending,running)` 且 `lease_until IS NULL OR lease_until <= now`），**只重新 dispatch，不清租约**——清租约会和"心跳中的健康 worker"产生 read-then-clear 竞态；最终由 `claimSlotLease` 的 CAS 决出唯一赢家。
- **在 external 模式下也执行**（这点与 `catchUpMissedRuns` 不同）：catch-up 是"按 cron 推测漏跑"，external 下故意关闭；recovery 是"DB 里确实存在且未完成的 slot"，必须恢复。
- 恢复时用 **DB 里存的 occurrence**（slotId/occurrenceAt/occurrenceDate），绝不用 `resolveOccurrence(now)` 重算——否则 9/10 18:00 的 slot 在 9/11 恢复时会被解析成另一场 occurrence。
- 每轮打印 `stale_slots_found / reclaimed / skipped`，避免再次出现"代码里有函数、生产从没调用"。

## 测试

本地（重建后分支，基于 `2ce5c97`）：

```text
npm run typecheck            → pass
npm test                     → 64 suites / 612 tests 全绿
npm run build                → pass
node scripts/package-smoke.mjs → 12 步 PASS
```

新增 `src/__tests__/scheduler/durableDispatch.test.ts`（11 例）覆盖三个事故：

- **超过 600s 的执行**：接纳是 fire-and-forget（execute 永不 resolve 时触发调用仍立即返回）；`runNow` 必须把同一个 SlotContext 传进 job。
- **active lease 中途重启**：过期租约可被接管；TTL 远低于运行超时；`finish()` 期间租约仍持有（并发触发抢不到）；`pending + lease=NULL`（"已落库但从未 claim"）也必须被恢复。
- **多时钟重复触发**：live lease 拒绝第二 owner；recovery 绝不抢健康 worker 的 slot。

以及 HTTP 边界：202 queued / 202 already_running / 200 already_completed / 503 rejected，并显式断言 `running` **不会**被报成 `completed`。

## 配套（不在本 PR）

- TelePost：删除为长请求加的 `ROUTER_TIMEOUT_SECONDS=600` workaround（已另行提 PR）。
- 部署仓库：watchdog 改为按业务状态判定 + 常驻（已另行提 PR）。

## 未覆盖 / 已知

- `scheduler-runtime` 里"异常/超时/取消都必须释放租约"这几条没有单测（需要真实 Pixiv client 与 DownloadManager 的接缝）。本 PR 用「finish 先于 release」的不变量测试 + 代码路径审查覆盖，未做端到端注入测试。
- 性能问题（`maxPageCount=30`、`aiMetadataCheck`、26 次 Pixiv 429）**故意不在本 PR**：先保证"再慢也不会漏跑"，再优化"为什么这么慢"。
