### PR TITLE
feat(scheduler): 外部时钟下的跑完即退出生命周期

### DIFF
--- a/src/__tests__/scheduler/IdleLifecycle.test.ts
+++ b/src/__tests__/scheduler/IdleLifecycle.test.ts
@@ -1,0 +1,184 @@
+/**
+ * External-worker run-to-completion lifecycle tests.
+ *
+ * The contract under test is narrow on purpose: the lifecycle must never exit
+ * while the worker's own durable ledger still holds work, must exit once the
+ * ledger is empty and the grace window has elapsed, and must never let a broken
+ * probe or a wedged run hold the machine open past the hard backstop.
+ */
+import {
+  DEFAULT_IDLE_GRACE_MS,
+  DEFAULT_MAX_LIFETIME_MS,
+  IdleSnapshot,
+  SchedulerIdleLifecycle,
+  isIdle,
+} from '../../commands/SchedulerIdleLifecycle';
+
+const IDLE: IdleSnapshot = { activeSlots: 0, processingOutbox: 0, pendingOutbox: 0 };
+
+const POLL_MS = 15_000;
+const GRACE_MS = 60_000;
+
+describe('isIdle', () => {
+  it('requires every counter to be zero', () => {
+    expect(isIdle(IDLE)).toBe(true);
+    expect(isIdle({ ...IDLE, activeSlots: 1 })).toBe(false);
+    expect(isIdle({ ...IDLE, processingOutbox: 1 })).toBe(false);
+    expect(isIdle({ ...IDLE, pendingOutbox: 1 })).toBe(false);
+  });
+
+  it('exposes safe defaults', () => {
+    expect(DEFAULT_IDLE_GRACE_MS).toBe(10 * 60 * 1000);
+    expect(DEFAULT_MAX_LIFETIME_MS).toBe(3 * 60 * 60 * 1000);
+  });
+});
+
+describe('SchedulerIdleLifecycle', () => {
+  let snapshot: IdleSnapshot;
+  let onExit: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    snapshot = { ...IDLE };
+    onExit = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const build = (overrides: Partial<{ idleGraceMs: number; maxLifetimeMs: number; pollMs: number }> = {}) =>
+    new SchedulerIdleLifecycle({
+      snapshot: () => snapshot,
+      onExit,
+      idleGraceMs: GRACE_MS,
+      maxLifetimeMs: DEFAULT_MAX_LIFETIME_MS,
+      pollMs: POLL_MS,
+      ...overrides,
+    });
+
+  it('exits with reason "idle" only after the full grace window elapses', () => {
+    const lifecycle = build();
+    lifecycle.start();
+
+    // Grace starts at the first idle observation (t=15s), so the exit is due at
+    // t=75s — not at t=60s.
+    jest.advanceTimersByTime(60_000);
+    expect(onExit).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(15_000);
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith('idle');
+  });
+
+  it('stays awake while a non-terminal Slot is still owned by the ledger', () => {
+    snapshot = { activeSlots: 1, processingOutbox: 0, pendingOutbox: 0 };
+    const lifecycle = build();
+    lifecycle.start();
+
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('stays awake while an outbox row is in flight or waiting on backoff', () => {
+    const processing = build();
+    snapshot = { activeSlots: 0, processingOutbox: 1, pendingOutbox: 0 };
+    processing.start();
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(onExit).not.toHaveBeenCalled();
+
+    onExit.mockClear();
+    const retrying = build();
+    snapshot = { activeSlots: 0, processingOutbox: 0, pendingOutbox: 1 };
+    retrying.start();
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('restarts the grace window when new work appears mid-grace', () => {
+    const lifecycle = build();
+    lifecycle.start();
+
+    // Idle from t=15s, so the original window would close at t=75s.
+    jest.advanceTimersByTime(45_000);
+    snapshot = { activeSlots: 1, processingOutbox: 0, pendingOutbox: 0 };
+    jest.advanceTimersByTime(15_000); // t=60s: busy cancels the window
+    expect(onExit).not.toHaveBeenCalled();
+
+    snapshot = { ...IDLE };
+    jest.advanceTimersByTime(15_000); // t=75s: idle again, window restarts here
+    jest.advanceTimersByTime(55_000); // t=130s: only 55s into the new window
+    expect(onExit).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(5_000); // t=135s: new window complete
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith('idle');
+  });
+
+  it('exits on the maxLifetimeMs backstop even with work outstanding', () => {
+    snapshot = { activeSlots: 1, processingOutbox: 1, pendingOutbox: 2 };
+    const lifecycle = build({ maxLifetimeMs: 120_000 });
+    lifecycle.start();
+
+    jest.advanceTimersByTime(119_000);
+    expect(onExit).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1_000);
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith('max-lifetime');
+
+    // A backstop fires once; the poller must not resurrect the exit.
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a failed probe as "still awake" rather than as idleness', () => {
+    let calls = 0;
+    const lifecycle = new SchedulerIdleLifecycle({
+      snapshot: () => {
+        calls += 1;
+        if (calls <= 2) throw new Error('database is locked');
+        return { ...IDLE };
+      },
+      onExit,
+      idleGraceMs: GRACE_MS,
+      maxLifetimeMs: DEFAULT_MAX_LIFETIME_MS,
+      pollMs: POLL_MS,
+    });
+    lifecycle.start();
+
+    jest.advanceTimersByTime(45_000); // two throwing polls
+    expect(onExit).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(60_000); // recovery: idle from t=45s, due at t=105s
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith('idle');
+  });
+
+  it('exits on the first poll when the grace window is zero', () => {
+    const lifecycle = build({ idleGraceMs: 0 });
+    lifecycle.start();
+
+    jest.advanceTimersByTime(POLL_MS);
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith('idle');
+  });
+
+  it('disarms polling and the backstop on stop()', () => {
+    const lifecycle = build();
+    lifecycle.start();
+    lifecycle.stop();
+
+    jest.advanceTimersByTime(DEFAULT_MAX_LIFETIME_MS + GRACE_MS);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('start() is idempotent', () => {
+    const lifecycle = build();
+    lifecycle.start();
+    lifecycle.start();
+
+    jest.advanceTimersByTime(GRACE_MS + POLL_MS);
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/storage/SlotRepository.test.ts
+++ b/src/__tests__/storage/SlotRepository.test.ts
@@ -48,6 +48,31 @@ describe('Schedule Slot ledger', () => {
     });
   });
 
+  it('countActiveSlots counts non-terminal slots, including ones with a live lease', async () => {
+    await withDb(async (db) => {
+      db.slots.getOrCreateSlot('schedule-a@2026-09-08T1000', meta('schedule-a', ['t1']));
+      db.slots.getOrCreateSlot('schedule-a@2026-09-08T1800', meta('schedule-a', ['t1']));
+      db.slots.getOrCreateSlot('schedule-b@2026-09-08T1000', meta('schedule-b', ['t1']));
+      expect(db.slots.countActiveSlots()).toBe(3);
+
+      // A slot being executed RIGHT NOW holds a live lease. Recovery must ignore
+      // it (someone else owns it), but the external-worker idle probe must still
+      // count it as outstanding work — otherwise a daemon would exit mid-run.
+      const running = 'schedule-a@2026-09-08T1800';
+      db.slots.markSlotStatus(running, 'running');
+      db.slots.claimSlotLease(running, 'worker-1', Date.now() + 60_000);
+      expect(db.slots.recoverableSlots().map((slot) => slot.id)).not.toContain(running);
+      expect(db.slots.countActiveSlots()).toBe(3);
+
+      db.slots.markSlotStatus('schedule-a@2026-09-08T1000', 'success');
+      db.slots.markSlotStatus(running, 'success');
+      expect(db.slots.countActiveSlots()).toBe(1);
+
+      db.slots.markSlotStatus('schedule-b@2026-09-08T1000', 'failed');
+      expect(db.slots.countActiveSlots()).toBe(0);
+    });
+  });
+
   it('snapshots target membership at creation and ignores later config reload', async () => {
     await withDb(async (db) => {
       const id = 'schedule-a@2026-09-08T1000';

--- a/src/commands/SchedulerCommand.ts
+++ b/src/commands/SchedulerCommand.ts
@@ -11,6 +11,7 @@ import { ScheduleTriggerServer, TriggerRunResult } from '../scheduler/ScheduleTr
 import { SlotCoordinator } from '../scheduler/SlotCoordinator';
 import { selectScheduleTargets } from '../scheduler/schedules';
 import { createSchedulerRuntime } from './scheduler-runtime';
+import { SchedulerIdleLifecycle } from './SchedulerIdleLifecycle';
 
 /**
  * Decide whether the authenticated HTTP trigger server should be mounted. It is
@@ -74,8 +75,10 @@ export class SchedulerCommand extends BaseCommand {
       // Authenticated HTTP trigger. Mounted in external mode (the external clock
       // wakes the machine here) and, opt-in, in internal mode for manual/ops
       // triggers. Business logic lives in runJob/SlotCoordinator; this handler
-      // only authenticates, resolves the occurrence and delegates synchronously
-      // so the open request is the activity lease for the whole run.
+      // only authenticates, records the occurrence durably and hands it to the
+      // shared scheduler, then answers. It deliberately does not await the run:
+      // the open request is NOT an activity lease, and a 10-40 minute download
+      // would outlive the clock/proxy/client timeout carrying it.
       let triggerServer: ScheduleTriggerServer | null = null;
       if (triggerEnabled(runtime.config)) {
         const rt = runtime.config.schedulerRuntime!;
@@ -188,16 +191,53 @@ export class SchedulerCommand extends BaseCommand {
         );
       }
 
-      const cleanup = () => {
-        context.logger.info('Shutting down PixivFlow');
+      // Run-to-completion lifecycle for the external clock. The machine was woken
+      // by a trigger and has to return to `stopped` by itself. Platform-side
+      // auto-stop cannot decide that: the trigger answers long before the run
+      // finishes, so the proxy sees an idle socket while downloads are still in
+      // flight. The worker therefore reads its OWN durable ledger (see
+      // SchedulerIdleLifecycle). Wired after the trigger server so the port is
+      // already being served when the first idle probe runs.
+      let idleLifecycle: SchedulerIdleLifecycle | null = null;
+
+      const shutdown = (reason: string, code = 0) => {
+        context.logger.info('Shutting down PixivFlow', { reason });
+        idleLifecycle?.stop();
         triggerServer?.stop();
         manager.stop();
         runtime.close();
-        process.exit(0);
+        process.exit(code);
       };
 
-      process.on('SIGINT', cleanup);
-      process.on('SIGTERM', cleanup);
+      const scheduling = runtime.config.schedulerRuntime;
+      if (scheduling?.mode === 'external' && scheduling.exitWhenIdle) {
+        idleLifecycle = new SchedulerIdleLifecycle({
+          snapshot: () => {
+            const outbox = runtime.database.outbox.counts();
+            return {
+              activeSlots: runtime.database.slots.countActiveSlots(),
+              processingOutbox: outbox.processing,
+              // `pending` covers pending + retry_wait: a delivery still backing
+              // off is active work. Backoff is bounded (rows flip to `dead` once
+              // attempts are exhausted, which does not block exit), so this
+              // cannot hold the machine open indefinitely.
+              pendingOutbox: outbox.pending,
+            };
+          },
+          idleGraceMs: scheduling.idleGraceMs,
+          maxLifetimeMs: scheduling.maxLifetimeMs,
+          onExit: (reason) =>
+            shutdown(
+              reason === 'idle'
+                ? 'external worker idle: slot ledger and outbox are both empty'
+                : 'external worker exceeded the maxLifetimeMs backstop',
+            ),
+        });
+        idleLifecycle.start();
+      }
+
+      process.on('SIGINT', () => shutdown('SIGINT'));
+      process.on('SIGTERM', () => shutdown('SIGTERM'));
       process.on('SIGHUP', () => {
         context.logger.info('Received SIGHUP; reloading scheduler configuration');
         manager.reload();

--- a/src/commands/SchedulerIdleLifecycle.ts
+++ b/src/commands/SchedulerIdleLifecycle.ts
@@ -1,0 +1,166 @@
+/**
+ * Run-to-completion lifecycle for the external-clock (autosleep) deployment.
+ *
+ * A PixivFlow machine can be woken by an authenticated HTTP trigger, execute a
+ * schedule, deliver through the durable outbox, and must then return to
+ * `stopped` on its own. Two things make that non-trivial:
+ *
+ *  - Platform-side auto-stop cannot be used. The trigger endpoint answers as
+ *    soon as the occurrence is durable (deliberately — a 10-40 minute run cannot
+ *    survive a router/proxy/client timeout), so from the proxy's point of view
+ *    the machine goes idle while the run is still in progress. Auto-stop would
+ *    kill a download mid-flight.
+ *  - "The request returned" and "nobody connected recently" are both wrong
+ *    signals. HTTP activity says nothing about whether a download is still
+ *    running, a Slot is still open, or an outbox row is still retrying.
+ *
+ * So this reads the worker's OWN durable ledger instead, and exits only when
+ * that ledger says nothing is left: no non-terminal Slot, no in-flight outbox
+ * row, no undelivered outbox row. It is deliberately the only thing it does —
+ * no second business state machine, no scheduler of its own, no queue.
+ *
+ * The idle grace is a merge window, not a timeout: two schedules ten minutes
+ * apart are normally served by a single wake-up, and a delivery retry that lands
+ * just after the run is drained without paying for a second cold start.
+ *
+ * `maxLifetimeMs` is a backstop, never the normal path. It exists so a worker
+ * that somehow never reaches idle (a wedged run, a Slot that recovery cannot
+ * re-dispatch) cannot bill indefinitely. Reaching it deletes nothing: the
+ * process closes its database cleanly and the next wake resumes from the same
+ * Slot/outbox rows.
+ */
+
+import { logger } from '../logger';
+
+export type IdleExitReason = 'idle' | 'max-lifetime';
+
+/**
+ * A read-only view of the worker's own authoritative state. Every field must be
+ * derived from durable rows, never from in-memory scheduling or HTTP activity.
+ */
+export interface IdleSnapshot {
+  /** Non-terminal Slots (pending/running): work this ledger still owes. */
+  activeSlots: number;
+  /** Outbox rows currently claimed by this or another live worker. */
+  processingOutbox: number;
+  /** Undelivered outbox rows (pending, or waiting on a bounded retry backoff). */
+  pendingOutbox: number;
+}
+
+/** True only when the worker has no work of any kind left. */
+export function isIdle(snapshot: IdleSnapshot): boolean {
+  return (
+    snapshot.activeSlots === 0 &&
+    snapshot.processingOutbox === 0 &&
+    snapshot.pendingOutbox === 0
+  );
+}
+
+/** Default idle grace: long enough to merge two schedules ~10 minutes apart. */
+export const DEFAULT_IDLE_GRACE_MS = 10 * 60 * 1000;
+/** Default backstop on awake time; the idle detector is the normal exit path. */
+export const DEFAULT_MAX_LIFETIME_MS = 3 * 60 * 60 * 1000;
+/** How often the durable ledger is re-read. */
+export const DEFAULT_IDLE_POLL_MS = 15 * 1000;
+
+export interface IdleLifecycleOptions {
+  /** Reads the worker's authoritative state. Must not mutate anything. */
+  snapshot(): IdleSnapshot;
+  /**
+   * Invoked at most once, either on real idleness or on the hard backstop. The
+   * caller owns the shutdown itself (stop serving, flush, exit).
+   */
+  onExit(reason: IdleExitReason): void;
+  idleGraceMs?: number;
+  maxLifetimeMs?: number;
+  pollMs?: number;
+}
+
+export class SchedulerIdleLifecycle {
+  private readonly idleGraceMs: number;
+  private readonly maxLifetimeMs: number;
+  private readonly pollMs: number;
+  private pollTimer: NodeJS.Timeout | null = null;
+  private lifetimeTimer: NodeJS.Timeout | null = null;
+  private idleSince: number | null = null;
+  private exiting = false;
+
+  constructor(private readonly options: IdleLifecycleOptions) {
+    this.idleGraceMs = options.idleGraceMs ?? DEFAULT_IDLE_GRACE_MS;
+    this.maxLifetimeMs = options.maxLifetimeMs ?? DEFAULT_MAX_LIFETIME_MS;
+    this.pollMs = options.pollMs ?? DEFAULT_IDLE_POLL_MS;
+  }
+
+  /** Arm polling and the backstop. Idempotent. */
+  public start(): void {
+    if (this.pollTimer || this.lifetimeTimer) return;
+    logger.info('External worker lifecycle armed; will exit once real idleness is confirmed', {
+      idleGraceMs: this.idleGraceMs,
+      maxLifetimeMs: this.maxLifetimeMs,
+      pollMs: this.pollMs,
+    });
+    this.lifetimeTimer = setTimeout(() => this.exit('max-lifetime'), this.maxLifetimeMs);
+    this.pollTimer = setInterval(() => this.poll(), this.pollMs);
+  }
+
+  /** Disarm without exiting. Idempotent; used by the signal shutdown path. */
+  public stop(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.lifetimeTimer) {
+      clearTimeout(this.lifetimeTimer);
+      this.lifetimeTimer = null;
+    }
+  }
+
+  private poll(): void {
+    if (this.exiting) return;
+
+    let snapshot: IdleSnapshot;
+    try {
+      snapshot = this.options.snapshot();
+    } catch (error) {
+      // A failed read is NOT evidence of idleness. Stay awake and retry; the
+      // backstop still bounds how long a broken probe can hold the machine.
+      logger.warn('Idle probe failed; staying awake and will retry', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    if (!isIdle(snapshot)) {
+      if (this.idleSince !== null) {
+        logger.info('External worker picked up new work; idle grace window cancelled', { ...snapshot });
+      }
+      this.idleSince = null;
+      return;
+    }
+
+    if (this.idleGraceMs === 0) {
+      this.exit('idle');
+      return;
+    }
+
+    const now = Date.now();
+    if (this.idleSince === null) {
+      this.idleSince = now;
+      logger.info('External worker idle; starting exit grace window', {
+        idleGraceMs: this.idleGraceMs,
+        ...snapshot,
+      });
+      return;
+    }
+    if (now - this.idleSince >= this.idleGraceMs) {
+      this.exit('idle');
+    }
+  }
+
+  private exit(reason: IdleExitReason): void {
+    if (this.exiting) return;
+    this.exiting = true;
+    this.stop();
+    this.options.onExit(reason);
+  }
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -449,6 +449,39 @@ export interface SchedulerRuntimeConfig {
    */
   queueLimit?: number;
   /**
+   * External-mode run-to-completion lifecycle. When true, the daemon exits the
+   * process once its OWN durable ledger says there is nothing left to do, so a
+   * machine that was woken by an external clock returns to `stopped` by itself
+   * instead of idling on a fixed clock until the platform stops it.
+   *
+   * The platform's proxy-side auto-stop cannot make this call. The HTTP trigger
+   * answers as soon as the occurrence is durable (deliberately — a 10-40 minute
+   * run cannot survive a router/proxy/client timeout), so the proxy sees an idle
+   * socket while the real run is still going and would stop the machine
+   * mid-download. Only this process knows when its work is finished.
+   *
+   * Ignored in `internal` mode, where cron owns the process lifetime.
+   * Default: false.
+   */
+  exitWhenIdle?: boolean;
+  /**
+   * How long to stay awake after the last observed work, before exiting in
+   * `exitWhenIdle` mode. This is a merge window rather than a timeout: two
+   * schedules ten minutes apart are normally served by ONE wake-up, and a
+   * delivery retry that lands shortly after the run is drained without paying
+   * for a second cold start. Default: 600000ms (10 minutes).
+   */
+  idleGraceMs?: number;
+  /**
+   * Hard backstop on total awake time in `exitWhenIdle` mode. The native idle
+   * detector is the normal exit path and this should never fire; it exists so a
+   * worker that never reaches idle (a wedged run, a Slot recovery cannot
+   * re-dispatch) cannot bill indefinitely. On expiry the daemon logs the reason,
+   * closes its database cleanly and exits. Nothing is deleted — the next wake
+   * resumes from the same durable Slot/outbox rows. Default: 10800000ms (3h).
+   */
+  maxLifetimeMs?: number;
+  /**
    * External-mode HTTP trigger settings. Ignored in internal mode.
    */
   trigger?: SchedulerTriggerConfig;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -440,7 +440,7 @@ export function validateConfig(config: Partial<StandaloneConfig>, location: stri
 
   if (config.schedulerRuntime) {
     const rt = config.schedulerRuntime;
-    const { reloadDebounceMs, queueLimit, mode, trigger } = rt;
+    const { reloadDebounceMs, queueLimit, mode, trigger, idleGraceMs, maxLifetimeMs } = rt;
     if (mode !== undefined && mode !== 'internal' && mode !== 'external') {
       errors.push('schedulerRuntime.mode: Must be "internal" or "external"');
     }
@@ -452,6 +452,15 @@ export function validateConfig(config: Partial<StandaloneConfig>, location: stri
     }
     if (queueLimit !== undefined && (!Number.isInteger(queueLimit) || queueLimit < 0 || queueLimit > 100)) {
       errors.push('schedulerRuntime.queueLimit: Must be an integer between 0 and 100');
+    }
+    if (rt.exitWhenIdle !== undefined && typeof rt.exitWhenIdle !== 'boolean') {
+      errors.push('schedulerRuntime.exitWhenIdle: Must be a boolean');
+    }
+    if (idleGraceMs !== undefined && (!Number.isInteger(idleGraceMs) || idleGraceMs < 0)) {
+      errors.push('schedulerRuntime.idleGraceMs: Must be a non-negative integer (milliseconds)');
+    }
+    if (maxLifetimeMs !== undefined && (!Number.isInteger(maxLifetimeMs) || maxLifetimeMs <= 0)) {
+      errors.push('schedulerRuntime.maxLifetimeMs: Must be a positive integer (milliseconds)');
     }
     if (trigger) {
       if (trigger.port !== undefined && (!Number.isInteger(trigger.port) || trigger.port < 1 || trigger.port > 65535)) {

--- a/src/storage/repositories/SlotRepository.ts
+++ b/src/storage/repositories/SlotRepository.ts
@@ -342,6 +342,23 @@ export class SlotRepository extends BaseRepository {
     return rows.map((r) => this.toSlot(r));
   }
 
+  /**
+   * Non-terminal Slots (pending/running): work this ledger still owes, whether
+   * or not a live worker currently holds their lease.
+   *
+   * Deliberately NOT `recoverableSlots()`. That query excludes slots with a live
+   * lease — i.e. exactly the slots being executed right now — so using it as an
+   * "is anything still running?" probe reports idle in the middle of a run. The
+   * external-worker lifecycle needs to answer the opposite question, so it asks
+   * this one instead.
+   */
+  public countActiveSlots(): number {
+    const row = this.db
+      .prepare(`SELECT COUNT(*) n FROM schedule_slots WHERE status IN ('pending','running')`)
+      .get() as { n: number };
+    return row.n;
+  }
+
   /** Record an error without changing terminality (retryable failure keeps the cell resumable). */
   public setCellError(slotId: string, targetId: string, error: string): void {
     this.db


### PR DESCRIPTION
## 修改内容

让 scheduler 能在**外部时钟**（Cloudflare 薄触发器）下工作：平时停止，被唤醒后跑完自己的
账本就**自行退出**，不再依赖平台 auto-stop，也不再让 HTTP 连接时长决定一次运行的生命周期。

改动严格限定在通用 external-worker 生命周期，共 7 个文件、+482/−8：

| 文件 | 作用 |
| :-- | :-- |
| `src/commands/SchedulerIdleLifecycle.ts` | 新增。极薄生命周期：空闲探测 → 空闲宽限 → `exit(0)`；另有硬运行时长上限兜底。不含第二套槽位或投递状态机 |
| `src/commands/SchedulerCommand.ts` | 装配生命周期；修正「同步执行 / 连接即租约」的过时注释 |
| `src/config/types.ts` | `schedulerRuntime` 新增 `exitWhenIdle` / `idleGraceMs` / `maxLifetimeMs` |
| `src/config/validation.ts` | 新配置项校验 |
| `src/storage/repositories/SlotRepository.ts` | 新增只读的活动槽位计数（空闲判定用） |
| `src/__tests__/scheduler/IdleLifecycle.test.ts` | 新增。空闲退出、宽限合并、硬上限兜底 |
| `src/__tests__/storage/SlotRepository.test.ts` | 新增。活动槽位计数 |

**设计要点**

- 空闲判定只读**本进程自己的权威状态**：无进行中槽位、无被认领的 outbox、无待投递 outbox。
  worker 是唯一决定「我能否停机」的一方，平台侧不参与决策（平台看到的是「连接已空闲」，
  而下载往往还在跑）。
- 空闲宽限用于合并相邻调度（例如 10:00 与 10:10），避免刚退出又被唤醒。
- 退出是**干净退出**：先关库再 `exit(0)`，不删状态；下次唤醒从账本续跑。
- 硬运行时长上限只是**异常兜底**，不是正常退出路径。

## 验证

```
npm run typecheck   → 通过
npm test            → Test Suites: 65 passed, 65 total
                      Tests:       624 passed, 624 total
```

## 兼容性

- 默认行为不变：`exitWhenIdle` 未开启时，scheduler 仍按原有常驻方式运行
  （Compose / systemd 自托管路径不受影响）。
- 未改动调度域语义、槽位唯一约束、投递队列与投递契约。