### PR TITLE
fix(scheduler): terminalise a Slot abandoned by its own timeout

### DIFF
--- a/src/__tests__/scheduler/abandonedSlotRecovery.test.ts
+++ b/src/__tests__/scheduler/abandonedSlotRecovery.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for the 2026-09-12 production recovery loop.
+ *
+ * A scheduled run that OBEYED the scheduler timeout unwound through the
+ * abnormal-abort path, which released the lease but left the Slot `running`.
+ * `recoverableSlots()` matches a NULL lease on purpose — that is its "recorded
+ * but never claimed" case for a crash between accept and claim — so the sweep
+ * re-dispatched the SAME occurrence on every tick: three identical ~1800s
+ * timeouts ~30 minutes apart, and a real Pixiv 429 penalty caused purely by the
+ * repeated work.
+ *
+ * The invariant pinned here is the CRASH / ABANDONMENT split:
+ *
+ *   ABANDONED / TIMEOUT -> terminal Slot, NOT recoverable
+ *   SHUTDOWN            -> non-terminal Slot, recoverable (resumes after restart)
+ *   CRASH               -> non-terminal Slot, recoverable
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Database } from '../../storage/Database';
+import { SlotCoordinator } from '../../scheduler/SlotCoordinator';
+import { ScheduleConfig, TargetConfig } from '../../config';
+import { shouldTerminaliseAbortedSlot } from '../../commands/scheduler-runtime';
+
+type SlotCtx = Parameters<SlotCoordinator['finish']>[0];
+
+const OCCURRENCE_AT = Date.parse('2026-09-12T10:00:00Z');
+const SLOT_ID = 'bot1-daily@2026-09-12T1800';
+const OWNER = 'run-642-7a0b3c61';
+/** Exactly what the aborted run left on the illustration cell in production. */
+const ABORT_ERROR = 'aborted before rate-limit slot';
+
+const schedule: ScheduleConfig = {
+  id: 'bot1',
+  name: 'Bot1',
+  cron: '0 10,18 * * *',
+  timezone: 'Asia/Shanghai',
+  enabled: true,
+} as ScheduleConfig;
+
+const targets: TargetConfig[] = [
+  { id: 'bot1-illust-botefuku', type: 'illustration' },
+  { id: 'bot1-novel-botefuku', type: 'novel' },
+] as TargetConfig[];
+
+const slotCtx: SlotCtx = {
+  slotId: SLOT_ID,
+  scheduleId: 'bot1',
+  occurrenceAt: OCCURRENCE_AT,
+  occurrenceDate: '2026-09-12',
+  occurrenceLabel: '18:00',
+  timezone: 'Asia/Shanghai',
+  triggerSource: 'http',
+  slotName: '18:00',
+  slotDate: '2026-09-12',
+};
+
+function withDb<T>(fn: (db: Database) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-abandoned-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Reach the exact ledger state the production abort left behind: a claimed,
+ * heartbeating Slot with the illustration cell already failed by the cancelled
+ * download and the novel cell untouched.
+ */
+function seedAbortedRun(db: Database, coordinator: SlotCoordinator): void {
+  db.slots.getOrCreateSlot(SLOT_ID, {
+    scheduleId: 'bot1',
+    occurrenceAt: OCCURRENCE_AT,
+    occurrenceDate: '2026-09-12',
+    occurrenceLabel: '18:00',
+    timezone: 'Asia/Shanghai',
+    targetIds: targets.map((t) => t.id) as string[],
+    triggerSource: 'http',
+    slotDate: '2026-09-12',
+    slotName: '18:00',
+  });
+  db.slots.materializeCells(
+    SLOT_ID,
+    targets.map((t) => t.id) as string[],
+    (id) => (id === 'bot1-illust-botefuku' ? 'illustration' : 'novel')
+  );
+  expect(coordinator.claimRunLease(SLOT_ID, OWNER, 180_000)).toBe(true);
+  coordinator.markRunning(SLOT_ID);
+  coordinator.markCell(SLOT_ID, 'bot1-illust-botefuku', 'failed', ABORT_ERROR);
+}
+
+describe('shouldTerminaliseAbortedSlot', () => {
+  it('terminalises a live process that cancelled itself (scheduler timeout)', () => {
+    expect(shouldTerminaliseAbortedSlot('timeout', false)).toBe(true);
+  });
+
+  it('terminalises an unexpected in-process abort that was never a cancellation', () => {
+    // No cancellation was ever requested and the process is still up: nobody
+    // else will finish this Slot, so it must not be left recoverable.
+    expect(shouldTerminaliseAbortedSlot(null, false)).toBe(true);
+  });
+
+  it('leaves the Slot recoverable when the process is shutting down', () => {
+    expect(shouldTerminaliseAbortedSlot('shutdown', false)).toBe(false);
+  });
+
+  it('does not roll up twice once the abandon path already terminalised it', () => {
+    expect(shouldTerminaliseAbortedSlot('timeout', true)).toBe(false);
+    expect(shouldTerminaliseAbortedSlot('shutdown', true)).toBe(false);
+  });
+});
+
+describe('an abandoned scheduled run must not stay recoverable', () => {
+  it('takes the Slot terminal, so the recovery sweep cannot re-dispatch it', () => {
+    withDb((db) => {
+      const coordinator = new SlotCoordinator(db);
+      seedAbortedRun(db, coordinator);
+
+      // What the fixed abnormal-abort path does before handing the lease back.
+      expect(shouldTerminaliseAbortedSlot('timeout', false)).toBe(true);
+      coordinator.finish(slotCtx, schedule, targets);
+      coordinator.releaseRunLease(SLOT_ID, OWNER);
+
+      // Both cells end terminal: the untouched novel cell is rolled up rather
+      // than left `pending`, which is what kept the Slot `running` forever.
+      expect(db.slots.getCell(SLOT_ID, 'bot1-illust-botefuku')!.status).toBe('failed');
+      expect(db.slots.getCell(SLOT_ID, 'bot1-novel-botefuku')!.status).toBe('failed');
+
+      expect(db.slots.getSlot(SLOT_ID)!.status).toBe('failed');
+      expect(db.slots.getSlot(SLOT_ID)!.leaseOwner).toBeNull();
+
+      // The loop is broken: a released lease is not enough on its own.
+      expect(db.slots.recoverableSlots().map((s) => s.id)).not.toContain(SLOT_ID);
+    });
+  });
+
+  it('would loop forever without the terminal rollup (pre-fix behaviour)', () => {
+    withDb((db) => {
+      const coordinator = new SlotCoordinator(db);
+      seedAbortedRun(db, coordinator);
+
+      // Pre-fix: release the lease, leave the status alone.
+      coordinator.releaseRunLease(SLOT_ID, OWNER);
+
+      expect(db.slots.getSlot(SLOT_ID)!.status).toBe('running');
+      expect(db.slots.getSlot(SLOT_ID)!.leaseOwner).toBeNull();
+      // A NULL lease is `recoverableSlots()`'s crash case, so the live worker's
+      // abandoned Slot is indistinguishable from a crash and gets re-dispatched.
+      expect(db.slots.recoverableSlots().map((s) => s.id)).toContain(SLOT_ID);
+    });
+  });
+
+  it('still resumes the same occurrence when the process is shutting down', () => {
+    withDb((db) => {
+      const coordinator = new SlotCoordinator(db);
+      seedAbortedRun(db, coordinator);
+
+      expect(shouldTerminaliseAbortedSlot('shutdown', false)).toBe(false);
+      coordinator.releaseRunLease(SLOT_ID, OWNER);
+
+      // Deliberately non-terminal: recovery after the restart resumes this Slot.
+      expect(db.slots.getSlot(SLOT_ID)!.status).toBe('running');
+      expect(db.slots.recoverableSlots().map((s) => s.id)).toContain(SLOT_ID);
+    });
+  });
+
+  it('keeps a genuinely crashed worker recoverable', () => {
+    withDb((db) => {
+      const coordinator = new SlotCoordinator(db);
+      seedAbortedRun(db, coordinator);
+
+      // A crash runs no code at all: the lease simply expires with the owner
+      // still recorded, which is how recovery tells it apart from an abort.
+      db.slots.claimSlotLease(SLOT_ID, OWNER, Date.now() - 1);
+
+      expect(db.slots.getSlot(SLOT_ID)!.status).toBe('running');
+      expect(db.slots.getSlot(SLOT_ID)!.leaseOwner).toBe(OWNER);
+      expect(db.slots.recoverableSlots().map((s) => s.id)).toContain(SLOT_ID);
+    });
+  });
+});

--- a/src/commands/ExecuteSlotCommand.ts
+++ b/src/commands/ExecuteSlotCommand.ts
@@ -162,7 +162,7 @@ export class ExecuteSlotCommand extends BaseCommand {
           ...(excludedWorkIds ? { excludedWorkIds } : {}),
         }),
         timeoutMs,
-        () => runtime!.cancelActive(`batch timeout after ${timeoutMs}ms`),
+        () => runtime!.cancelActive(`batch timeout after ${timeoutMs}ms`, 'timeout'),
         `slot ${slotId}`
       );
 

--- a/src/commands/SchedulerCommand.ts
+++ b/src/commands/SchedulerCommand.ts
@@ -62,7 +62,9 @@ export class SchedulerCommand extends BaseCommand {
         telemetry: {
           beginRun: () => runtime.database.getOverviewStats().totalDownloads,
           endRun: () => runtime.database.getOverviewStats().totalDownloads,
-          requestCancel: (reason) => runtime.cancelActive(reason),
+          // `timeout`: the daemon stays alive, so the run's Slot must be taken
+          // terminal (the abort path does that) instead of staying recoverable.
+          requestCancel: (reason) => runtime.cancelActive(reason, 'timeout'),
         },
       });
       const status = manager.start(runtime.config);

--- a/src/commands/SchedulerRunOnceCommand.ts
+++ b/src/commands/SchedulerRunOnceCommand.ts
@@ -60,7 +60,7 @@ export class SchedulerRunOnceCommand extends BaseCommand {
           // occurrence complete nor be resumed as one. Explicit replacement.
           runtime.runJob(runtime.config, plan, { adhoc: true, triggerSource: 'manual', onlyTarget: targetFilter }),
           timeoutMs,
-          () => runtime.cancelActive(`run timeout after ${timeoutMs}ms`),
+          () => runtime.cancelActive(`run timeout after ${timeoutMs}ms`, 'timeout'),
           `plan ${plan.id}`
         );
       }

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -77,6 +77,40 @@ export function withDeliveryMode<T extends { delivery?: unknown }>(
   return targets.map((target) => (target.delivery ? { ...target, delivery: undefined } : target));
 }
 
+/**
+ * Who asked for the cancellation, which decides whether the abandoned Slot is
+ * allowed to stay recoverable.
+ *
+ *  - `timeout`: a watchdog inside this process (scheduler timeout, run-once or
+ *    execute-slot bound). The process stays up, so nothing will ever finish the
+ *    Slot — it must be terminalised, or the recovery sweep re-dispatches the
+ *    same occurrence on every tick forever.
+ *  - `shutdown`: the process is going away. The Slot is deliberately left
+ *    non-terminal so recovery resumes the same occurrence after restart; no
+ *    worker survives to duplicate it.
+ */
+export type CancelOrigin = 'timeout' | 'shutdown';
+
+/**
+ * Decide a scheduled run's Slot fate when `runAllTargets()` aborts abnormally
+ * instead of reporting per-target failures.
+ *
+ * Returning `false` leaves the Slot recoverable, which is only correct when the
+ * process is genuinely going away — because `recoverableSlots()` treats a
+ * released/NULL lease as "recorded but never claimed", so a live process that
+ * merely drops its lease is re-dispatched on every recovery tick, forever.
+ */
+export function shouldTerminaliseAbortedSlot(
+  origin: CancelOrigin | null,
+  slotAbandoned: boolean
+): boolean {
+  // The abandon path already wrote a terminal `failed`; rolling up again would
+  // only overwrite it when the wedged job finally settles.
+  if (slotAbandoned) return false;
+  // Shutdown is not a failure: recovery is meant to resume this occurrence.
+  return origin !== 'shutdown';
+}
+
 export interface SchedulerRuntime {
   config: StandaloneConfig;
   database: Database;
@@ -85,8 +119,14 @@ export interface SchedulerRuntime {
   tokenMaintenance: ReturnType<typeof createTokenMaintenanceService>;
   /** Run one schedule's enabled targets once (the same job the cron fires). */
   runJob(snapshot: StandaloneConfig, schedule: ScheduleConfig, options?: RunJobOptions): Promise<void>;
-  /** Cancel the in-flight download plan, if any. */
-  cancelActive(reason: string): void;
+  /**
+   * Cancel the in-flight download plan, if any holding a Slot.
+   *
+   * `origin` states whether this process is staying alive (`timeout`: the
+   * run is finished and its Slot must be terminalised) or going away
+   * (`shutdown`: leave the Slot non-terminal so recovery resumes it).
+   */
+  cancelActive(reason: string, origin?: CancelOrigin): void;
   /**
    * The active run never settled after its timeout and drain window. Stop
    * renewing its lease and take its Slot terminal so recovery cannot re-dispatch
@@ -277,6 +317,13 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
    * Set while a lease is held and cleared as soon as it is released.
    */
   let activeLeaseHooks: { stopHeartbeat(): void; abandon(reason: string): void } | null = null;
+  /**
+   * Why the in-flight run was cancelled, if it was. This is what lets the abort
+   * path tell a CRASH (nothing runs here — the process is gone) apart from an
+   * ABANDONMENT (this process is alive and will never touch the Slot again).
+   * `null` while no cancellation has been requested for the current run.
+   */
+  let activeAbortOrigin: CancelOrigin | null = null;
 
   // Independently-pumped durable outbox (content + notifications). Started in
   // the long-running scheduler daemon; run-once drains explicitly before exit.
@@ -388,6 +435,9 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       // Only the process that actually owns the lease may report the slot as
       // running; the accepting adapter records it as pending instead.
       coordinator.markRunning(activeSlot.slotId);
+      // This run owns the Slot now: any cancellation recorded against a previous
+      // run must not decide how THIS run's abort is handled.
+      activeAbortOrigin = null;
       let cancelled = false;
       const heartbeat = setInterval(() => {
         // A cancelled/timed-out run must stop renewing its lease. An infinitely
@@ -537,9 +587,24 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       await downloadManager.runAllTargets();
     } catch (error) {
       if (!slotCtx || !(error instanceof Error) || !/^All \d+ target\(s\) failed\./.test(error.message)) {
-        // Abnormal abort: no roll-up is possible, so hand the slot back now
-        // instead of holding it until the lease TTL expires. Recovery sees a
-        // non-terminal slot with no live lease and resumes the SAME occurrence.
+        // Abnormal abort. Two very different situations land here, and treating
+        // them as one is what produced the production loop:
+        //
+        //  - this process cancelled itself (scheduler timeout / watchdog) and is
+        //    still alive. It will never touch the Slot again, so releasing the
+        //    lease while leaving the status `running` makes the Slot look exactly
+        //    like a crashed worker: `recoverableSlots()` matches a NULL lease on
+        //    purpose (its "recorded but never claimed" case), so the recovery
+        //    sweep re-dispatches the SAME occurrence on every tick, forever.
+        //    Terminalise it instead: the occurrence is finished, and failed.
+        //
+        //  - the process is going away (`shutdown`). Deliberately leave the Slot
+        //    non-terminal so recovery resumes the same occurrence after restart.
+        if (slotCtx && shouldTerminaliseAbortedSlot(activeAbortOrigin, slotAbandoned)) {
+          coordinator.finish(slotCtx, schedule, targets);
+        }
+        // Hand the lease back either way: a terminal Slot cannot be re-dispatched,
+        // and a non-terminal one (shutdown) must not wait for its TTL to expire.
         releaseLease?.();
         throw error;
       }
@@ -581,12 +646,13 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     logger.info('='.repeat(60));
   };
 
-  const cancelActive = (reason: string): void => {
+  const cancelActive = (reason: string, origin: CancelOrigin = 'timeout'): void => {
+    activeAbortOrigin = origin;
     activeDownloadManager?.cancel(reason);
     // Scheduler timeout / process shutdown also stop the lease heartbeat. The run
     // is on its way out (or about to be killed with the process), so it must not
-    // keep the slot locked while it unwinds. A shutdown deliberately leaves the
-    // slot NON-terminal: recovery resumes the same occurrence after restart.
+    // keep the slot locked while it unwinds. Whether the Slot is then terminalised
+    // or left recoverable is decided by `origin` in the abort path of runJob.
     activeLeaseHooks?.stopHeartbeat();
   };
 
@@ -599,7 +665,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
 
   const close = (): void => {
     outboxWorker.stop();
-    cancelActive('process shutdown');
+    cancelActive('process shutdown', 'shutdown');
     if (tokenMaintenance) {
       tokenMaintenance.stop();
     }


### PR DESCRIPTION
## Blocker 2 — abandoned run / unbounded recovery loop

Production showed three identical ~1800s timeouts ~30 min apart for a single occurrence, plus a real Pixiv 429 penalty caused purely by the repeats.

**Root cause.** A scheduled run that obeyed the scheduler timeout unwound through the abnormal-abort path, which released the lease but left the Slot `running`. `recoverableSlots()` matches a NULL lease *on purpose* (its crash-between-accept-and-claim case), so the recovery sweep re-dispatched the SAME occurrence on every tick — forever. The abort path could not tell a **CRASH** (process gone, genuinely recoverable) from an **ABANDONMENT** (process alive, will never touch the Slot again).

## Change
- `scheduler-runtime`: `cancelActive(reason, origin)` records an explicit `CancelOrigin` (`'timeout' | 'shutdown'`); `shouldTerminaliseAbortedSlot()` decides the Slot's fate. An abort that leaves a live process behind rolls the Slot up via `SlotCoordinator.finish()`, so untouched cells *and* the Slot reach terminal, non-recoverable state. A released lease alone is not enough.
- `SchedulerCommand` / `ExecuteSlotCommand` / `SchedulerRunOnceCommand`: state the origin at each cancellation site.
- `shutdown` deliberately stays recoverable — recovery resumes the occurrence after restart.
- New regression tests pin CRASH vs ABANDONMENT recovery eligibility.

Deliberately **not** a blind retry-count ceiling: the state machine is fixed, not masked.

## Verification
`npm run typecheck` clean; scheduler / topic / slot / download / commands suites green.

Part 2/3 of the Controlled V4 recovery set.