### PR TITLE
fix(delivery): only notify endpoints that can receive notifications

### DIFF
--- a/src/__tests__/delivery/errorClass.test.ts
+++ b/src/__tests__/delivery/errorClass.test.ts
@@ -38,6 +38,17 @@ describe('classifyError', () => {
     });
   });
 
+  it('treats a local configuration error as terminal', () => {
+    // Production: a notification addressed at a submission target can never be
+    // delivered, so retrying only parked the row in retry_wait for hours.
+    expect(classifyError(new Error('Delivery target does not configure notificationUrl: bot1-submit'))).toEqual({
+      errorClass: 'configuration_error', retryable: false,
+    });
+    expect(
+      classifyError(Object.assign(new Error('missing url'), { name: 'ConfigError' }))
+    ).toEqual({ errorClass: 'configuration_error', retryable: false });
+  });
+
   it('defaults unknown errors to retryable internal_error', () => {
     expect(classifyError(new Error('something else'))).toEqual({
       errorClass: 'internal_error', retryable: true,

--- a/src/__tests__/delivery/notificationContract.test.ts
+++ b/src/__tests__/delivery/notificationContract.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for the 2026-09-12 stuck notification outbox row.
+ *
+ * `NotificationPolicy.noteOutcome()` addressed per-target failures to
+ * `target.delivery.target` — a SUBMISSION endpoint (multipart POST of a work),
+ * not a notification endpoint — and enqueued without checking whether that
+ * target could receive a notification at all. Production config declares only
+ * `bot1-submit` / `bot2-submit`, neither with a `notificationUrl`, so the row
+ * could never be delivered:
+ *
+ *   outbox 7b5ab057 kind=notification delivery_target=bot1-submit
+ *   status=retry_wait attempts=7
+ *   last_error="Delivery target does not configure notificationUrl: bot1-submit"
+ *
+ * Two invariants are pinned here:
+ *   1. a notification is only enqueued for a target that can receive one;
+ *   2. a local configuration error dead-letters immediately instead of burning
+ *      a retry budget in `retry_wait`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Database } from '../../storage/Database';
+import { NotificationPolicy } from '../../notification/NotificationPolicy';
+import { OutboxWorker } from '../../delivery/OutboxWorker';
+import { ConfigError } from '../../utils/errors';
+import { SlotContext } from '../../scheduler/SlotCoordinator';
+
+const slot: SlotContext = {
+  slotId: 'bot1-daily@2026-09-12T1800',
+  scheduleId: 'bot1',
+  occurrenceAt: Date.parse('2026-09-12T10:00:00Z'),
+  occurrenceDate: '2026-09-12',
+  occurrenceLabel: '18:00',
+  timezone: 'Asia/Shanghai',
+  triggerSource: 'http',
+  slotName: '18:00',
+  slotDate: '2026-09-12',
+};
+
+const schedule = { id: 'bot1', name: 'Bot1' } as any;
+
+/** Two submission targets, exactly like the canonical production config. */
+function config(targets: Record<string, unknown>): any {
+  return { delivery: { targets } };
+}
+
+const submissionTarget = {
+  id: 'bot1-illust-botefuku',
+  type: 'illustration',
+  tag: 'ボテ腹',
+  delivery: { target: 'bot1-submit' },
+} as any;
+
+const failedOutcome = { kind: 'failed', retryable: false, error: 'aborted before rate-limit slot' } as any;
+
+function withDb<T>(fn: (db: Database) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-notify-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('notifications only target endpoints that can receive them', () => {
+  it('does not enqueue for a submission target without notificationUrl', () => {
+    withDb((db) => {
+      const policy = new NotificationPolicy(
+        db,
+        config({ 'bot1-submit': { type: 'httpMultipart', url: 'https://telepost.example/submit' } })
+      );
+
+      policy.noteOutcome(slot.slotId, slot, schedule, submissionTarget, failedOutcome);
+
+      // Pre-fix this produced a row that could never be delivered.
+      expect(db.outbox.list()).toHaveLength(0);
+    });
+  });
+
+  it('enqueues when the delivery target exposes a notificationUrl', () => {
+    withDb((db) => {
+      const policy = new NotificationPolicy(
+        db,
+        config({
+          'bot1-submit': {
+            type: 'httpMultipart',
+            url: 'https://telepost.example/submit',
+            notificationUrl: 'https://telepost.example/notify',
+          },
+        })
+      );
+
+      policy.noteOutcome(slot.slotId, slot, schedule, submissionTarget, failedOutcome);
+
+      const rows = db.outbox.list();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ kind: 'notification', deliveryTarget: 'bot1-submit' });
+    });
+  });
+
+  it('stays silent when no target is notifiable at all', () => {
+    withDb((db) => {
+      const policy = new NotificationPolicy(
+        db,
+        config({ 'bot1-submit': { type: 'httpMultipart', url: 'https://telepost.example/submit' } })
+      );
+
+      policy.sendSlotSummary(slot, schedule, [
+        {
+          targetId: 'bot1-illust-botefuku',
+          label: 'bot1-illust-botefuku',
+          workType: 'illustration',
+          status: 'submitted',
+          workId: '149590937',
+          error: null,
+        },
+      ]);
+
+      expect(db.outbox.list()).toHaveLength(0);
+    });
+  });
+});
+
+/** A provider that rejects the notification because the target is misconfigured. */
+class ConfigFailingDispatcher {
+  notifyCalls = 0;
+  async isReady(): Promise<boolean> {
+    return true;
+  }
+  async deliver(): Promise<never> {
+    throw new Error('unexpected deliver call');
+  }
+  async notify(name: string): Promise<void> {
+    this.notifyCalls++;
+    throw new ConfigError(`Delivery target does not configure notificationUrl: ${name}`);
+  }
+}
+
+describe('a configuration error dead-letters instead of retrying forever', () => {
+  it('goes straight to dead on the first attempt', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pixivflow-notify-dead-'));
+    const db = new Database(join(dir, 'test.db'));
+    db.migrate();
+    try {
+      const dispatcher = new ConfigFailingDispatcher();
+      const dead: string[] = [];
+      const worker = new OutboxWorker(db, dispatcher as any, {
+        retryBaseMs: 0,
+        onDead: (row) => dead.push(row.id),
+      });
+      db.outbox.enqueue({
+        kind: 'notification',
+        deliveryTarget: 'bot1-submit',
+        idempotencyKey: 'k-notify-dead',
+        payload: { text: '❌ PixivFlow 本次处理失败' },
+      });
+
+      const first = await worker.drainOnce();
+
+      // `markRetry` would have parked it in retry_wait for up to 12 attempts.
+      expect(first).toMatchObject({ processed: 1, retried: 0, dead: 1 });
+      expect(db.outbox.getByKey('notification', 'k-notify-dead')).toMatchObject({
+        status: 'dead',
+        attempts: 1,
+      });
+      expect(dead).toHaveLength(1);
+      expect(dispatcher.notifyCalls).toBe(1);
+
+      // Nothing left to retry, so the outbox drains clean.
+      expect(db.outbox.counts().retryWait).toBe(0);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/delivery/OutboxWorker.ts
+++ b/src/delivery/OutboxWorker.ts
@@ -5,7 +5,7 @@ import { OutboxRow, OutboxStatus, RecordEventInput } from '../storage/repositori
 import { DeliveryDispatcher } from './DeliveryDispatcher';
 import { DeliveryRequest } from './types';
 import { DeliveryAck } from './DeliveryAck';
-import { classifyError } from './errorClass';
+import { classifyError, DeliveryErrorClass } from './errorClass';
 import { redactError } from '../utils/redact';
 import { logger } from '../logger';
 
@@ -276,24 +276,23 @@ export class OutboxWorker {
       }
       return 'done';
     } catch (error) {
-      // Transport-level error (fetch threw) or ack-classified failure: retryable.
       const message = redactError(error).slice(0, 1000);
       const { errorClass } = classifyError(error);
+
+      // A local configuration error is deterministic: every attempt re-reads the
+      // same config, so retrying only parks the row in `retry_wait` until its
+      // attempt budget runs out. Dead-letter it now so it is visible instead.
+      if (errorClass === 'configuration_error') {
+        this.database.outbox.markDead(row.id, message);
+        this.deadLetter(row, `${message} (configuration error)`, errorClass);
+        return 'dead';
+      }
+
+      // Transport-level error (fetch threw) or ack-classified failure: retryable.
       const delay = backoffDelayMs(row.attempts + 1, this.retryBaseMs, this.retryMaxMs);
       const status = this.database.outbox.markRetry(row.id, Date.now() + delay, message);
       if (status === 'dead') {
-        logger.error('Outbox item dead after max attempts', { outboxId: row.id, kind: row.kind, error: message });
-        this.recordEvent(row, {
-          event: 'outbox.dead',
-          errorClass,
-          retryable: false,
-          countsAsAttempt: 1,
-          detail: { attempt: row.attempts + 1 },
-        });
-        this.onDead?.(row, message);
-        if (row.deliveryId) {
-          this.database.deliveries.recordAck(row.deliveryId, { status: 'failed', error: message });
-        }
+        this.deadLetter(row, message, errorClass);
       } else {
         logger.warn('Outbox item will retry', { outboxId: row.id, kind: row.kind, attempt: row.attempts + 1, delayMs: delay });
         this.recordEvent(row, {
@@ -305,6 +304,22 @@ export class OutboxWorker {
         });
       }
       return status;
+    }
+  }
+
+  /** Terminal delivery failure: audit it, release the delivery, notify the hooks. */
+  private deadLetter(row: OutboxRow, message: string, errorClass: DeliveryErrorClass): void {
+    logger.error('Outbox item dead', { outboxId: row.id, kind: row.kind, errorClass, error: message });
+    this.recordEvent(row, {
+      event: 'outbox.dead',
+      errorClass,
+      retryable: false,
+      countsAsAttempt: 1,
+      detail: { attempt: row.attempts + 1 },
+    });
+    this.onDead?.(row, message);
+    if (row.deliveryId) {
+      this.database.deliveries.recordAck(row.deliveryId, { status: 'failed', error: message });
     }
   }
 

--- a/src/delivery/errorClass.ts
+++ b/src/delivery/errorClass.ts
@@ -10,6 +10,7 @@ export type DeliveryErrorClass =
   | 'remote_4xx'
   | 'invalid_payload'
   | 'telegram_send_failed'
+  | 'configuration_error'
   | 'duplicate'
   | 'internal_error';
 
@@ -21,6 +22,16 @@ export interface ErrorClassification {
 /** Classify one failed delivery attempt from its thrown error and/or HTTP status. */
 export function classifyError(error: unknown, status?: number): ErrorClassification {
   const message = error instanceof Error ? error.message : String(error ?? '');
+
+  // A local ConfigError is thrown before any network call and is deterministic:
+  // retrying re-reads the exact same config, so the attempt budget only parks the
+  // row in `retry_wait` for hours. Terminal for the outbox.
+  if (
+    (error as { name?: string })?.name === 'ConfigError' ||
+    /does not configure|unsupported delivery target/i.test(message)
+  ) {
+    return { errorClass: 'configuration_error', retryable: false };
+  }
 
   // Explicit HTTP status wins when present.
   if (status === 429) return { errorClass: 'rate_limited', retryable: true };

--- a/src/notification/NotificationPolicy.ts
+++ b/src/notification/NotificationPolicy.ts
@@ -23,6 +23,26 @@ export class NotificationPolicy {
     return target.delivery?.target?.trim() || null;
   }
 
+  /**
+   * Delivery targets that can actually RECEIVE an operational notification.
+   *
+   * `delivery.target` names a SUBMISSION endpoint (multipart POST of a work).
+   * Only targets that also declare a `notificationUrl` accept notifications —
+   * the same rule `config/validation.ts` enforces for `noMatchPolicy.notify`
+   * and that `docs/CONFIG.md` documents. A submission endpoint without one
+   * rejects every notification, so enqueuing to it would only grow an outbox
+   * row that can never be delivered.
+   */
+  private notifiableTargets(): Set<string> {
+    const targets = this.config.delivery?.targets ?? {};
+    return new Set(
+      Object.keys(targets).filter((name) => {
+        const target = targets[name];
+        return target?.type === 'httpMultipart' && Boolean(target.notificationUrl?.trim());
+      })
+    );
+  }
+
   /** Stable slot-scoped keys (two occurrences on one date never collide). */
   static keys = {
     noMatch: (slotId: string, targetId: string) => `notification:${slotId}:${targetId}:no-candidate`,
@@ -40,6 +60,9 @@ export class NotificationPolicy {
   ): void {
     const name = this.targetName(target);
     if (!name) return;
+    // No notifiable endpoint configured: drop the notification instead of
+    // enqueuing it against a submission target that will reject it forever.
+    if (!this.notifiableTargets().has(name)) return;
     const label = target.id || target.filterTag || target.tag || target.type;
 
     if (outcome.kind === 'no_candidate' && target.noMatchPolicy?.notify === true) {
@@ -68,13 +91,7 @@ export class NotificationPolicy {
     schedule: ScheduleConfig,
     rows: Array<{ targetId: string; label: string; workType: string; status: string; workId: string | null; error: string | null }>
   ): void {
-    const targets = this.config.delivery?.targets ?? {};
-    const notifiable = new Set(
-      Object.keys(targets).filter((n) => {
-        const target = targets[n];
-        return target?.type === 'httpMultipart' && Boolean(target.notificationUrl?.trim());
-      })
-    );
+    const notifiable = this.notifiableTargets();
     if (notifiable.size === 0 || rows.length === 0) return;
 
     const icon = (s: string) =>

--- a/src/storage/repositories/OutboxRepository.ts
+++ b/src/storage/repositories/OutboxRepository.ts
@@ -185,6 +185,23 @@ export class OutboxRepository extends BaseRepository {
       .run({ id, now });
   }
 
+  /**
+   * Dead-letter a row whose failure cannot be fixed by retrying — a local
+   * configuration error is re-read identically on every attempt, so scheduling
+   * retries would only keep the row in `retry_wait` until the budget runs out.
+   */
+  markDead(id: string, error: string, now: number = Date.now()): void {
+    this.db
+      .prepare(
+        `UPDATE outbox
+         SET attempts=attempts+1, status='dead',
+             lease_owner=NULL, lease_until=NULL,
+             last_error=@error, updated_at=@now
+         WHERE id=@id`
+      )
+      .run({ id, error: error.slice(0, 1000), now });
+  }
+
   /** Schedule a later retry, or flip to dead once attempts are exhausted. */
   markRetry(
     id: string,


### PR DESCRIPTION
## Blocker 3 — notification outbox stuck in `retry_wait` forever

```text
outbox 7b5ab057 kind=notification delivery_target=bot1-submit
status=retry_wait attempts=7
last_error="Delivery target does not configure notificationUrl: bot1-submit"
```

**Root cause (contract level).** `NotificationPolicy.noteOutcome()` enqueued the per-target failure notification against `target.delivery.target` — the *submission* endpoint (multipart work submission), not a notification endpoint — and never checked whether that target could receive notifications. The canonical production config's `delivery.targets` (`bot1-submit`, `bot2-submit`) have no `notificationUrl`, so the row could never be delivered and burned its attempt budget on `retry_wait`.

## Change (honour the existing contract; nothing invented or removed)
- Gate notification producers by the same rule `sendSlotSummary()` already uses — `httpMultipart` **and** a non-empty `notificationUrl`, consistent with `config/validation.ts` and `docs/CONFIG.md`. Extracted as shared `notifiableTargets()`.
- `classifyError`: new `configuration_error` — local config mistakes are deterministic and must not be retried.
- `OutboxWorker`: a configuration error is dead-lettered immediately instead of consuming the attempt budget on `retry_wait` (new `OutboxRepository.markDead()`).

This also satisfies "no permanent `retry_wait`" without deleting the notification path or fabricating a URL.

## Verification
New `notificationContract` / `errorClass` tests plus existing delivery + outbox suites green.

Part 3/3 of the Controlled V4 recovery set.