### PR TITLE
fix(scheduler): preserve locked work identity across recovery

### DIFF
--- a/src/__tests__/delivery/DeliveryLedgerPort.test.ts
+++ b/src/__tests__/delivery/DeliveryLedgerPort.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The delivery ledger port answers the ONLY delivery question crash recovery may
+ * ask about a `delivery_pending` cell: does something downstream still own it?
+ *
+ * Getting this wrong is how a recovery becomes a second post, so each answer is
+ * pinned down here from real ledger rows (no mocks): live intents are delegated,
+ * terminal ones are converged, and nothing is ever "repaired" by re-selecting.
+ */
+import { Database } from '../../storage/Database';
+import { createDeliveryLedgerPort } from '../../delivery/DeliveryLedgerPort';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const SLOT = 'slot-1';
+const TARGET = 'daily-illust';
+
+function withDb<T>(fn: (db: Database) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-ledger-port-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function insertIntent(db: Database, pixivId: string, id = `delivery-${pixivId}`) {
+  return db.deliveries.insertIntent({
+    id,
+    deliveryTarget: 'telepost',
+    workType: 'illustration',
+    pixivId,
+    slotId: SLOT,
+    targetId: TARGET,
+    idempotencyKey: `pixivflow:telepost:illustration:${pixivId}:${SLOT}:${TARGET}`,
+  }).row;
+}
+
+function ask(db: Database) {
+  return createDeliveryLedgerPort(db).stateFor({
+    deliveryTarget: 'telepost',
+    slotId: SLOT,
+    targetId: TARGET,
+  });
+}
+
+describe('createDeliveryLedgerPort', () => {
+  it('reports unknown when the cell never produced an intent', () => {
+    withDb((db) => {
+      expect(ask(db)).toEqual({ kind: 'unknown' });
+    });
+  });
+
+  it('reports live while the outbox still has an actionable row for the intent', () => {
+    withDb((db) => {
+      const row = insertIntent(db, '100');
+      db.outbox.enqueue({
+        kind: 'delivery',
+        deliveryTarget: 'telepost',
+        deliveryId: row.id,
+        idempotencyKey: `outbox:${row.idempotencyKey}`,
+        payload: {},
+      });
+
+      expect(ask(db)).toEqual({ kind: 'live' });
+    });
+  });
+
+  it('reports lost once the outbox exhausted the intent without an ACK', () => {
+    withDb((db) => {
+      const row = insertIntent(db, '100');
+      const outbox = db.outbox.enqueue({
+        kind: 'delivery',
+        deliveryTarget: 'telepost',
+        deliveryId: row.id,
+        idempotencyKey: `outbox:${row.idempotencyKey}`,
+        payload: {},
+      });
+      db.outbox.markDead(outbox.id, 'max attempts exhausted');
+
+      expect(ask(db)).toEqual({
+        kind: 'lost',
+        reason: expect.stringContaining('terminal failure'),
+      });
+    });
+  });
+
+  it('reports lost for a pending intent that never reached the outbox', () => {
+    withDb((db) => {
+      insertIntent(db, '100');
+
+      // Nothing will ever retry this: the worker only pumps outbox rows.
+      expect(ask(db)).toEqual({ kind: 'lost', reason: expect.stringContaining('terminal failure') });
+    });
+  });
+
+  it('reports confirmed (with the work identity) when the ACK already landed', () => {
+    withDb((db) => {
+      const row = insertIntent(db, '100');
+      db.deliveries.recordAck(row.id, { status: 'delivered', remoteId: 'msg-1' });
+
+      expect(ask(db)).toEqual({ kind: 'confirmed', workId: '100', workType: 'illustration' });
+    });
+  });
+
+  it('treats a downstream-attested duplicate as confirmed, not as something to retry', () => {
+    withDb((db) => {
+      const row = insertIntent(db, '100');
+      db.deliveries.recordAck(row.id, { status: 'duplicate', reuseReason: 'telepost already had it' });
+
+      expect(ask(db)).toEqual({ kind: 'confirmed', workId: '100', workType: 'illustration' });
+    });
+  });
+
+  it('scopes the answer to the cell, so another cell\'s delivery never stops a run', () => {
+    withDb((db) => {
+      insertIntent(db, '100');
+
+      expect(
+        createDeliveryLedgerPort(db).stateFor({
+          deliveryTarget: 'telepost',
+          slotId: SLOT,
+          targetId: 'a-different-target',
+        })
+      ).toEqual({ kind: 'unknown' });
+    });
+  });
+});

--- a/src/__tests__/download/handlers/workIdentityRecovery.test.ts
+++ b/src/__tests__/download/handlers/workIdentityRecovery.test.ts
@@ -20,8 +20,9 @@ import { PixivIllust } from '@redtidev/pixiv-client';
 import { Database } from '../../../storage/Database';
 import { SlotCoordinator } from '../../../scheduler/SlotCoordinator';
 import { createDeliveryLedgerPort } from '../../../delivery/DeliveryLedgerPort';
+import { DeliveryService } from '../../../delivery/DeliveryService';
 import { DownloadedArtifact } from '../../../delivery/types';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -366,5 +367,77 @@ describe('work identity across recovery', () => {
       expect(mockClient.getIllustration).not.toHaveBeenCalled();
       expect(mockPipeline.run).toHaveBeenCalled();
     });
+  });
+
+  it('maps the locked work to a STABLE delivery idempotency identity across recovery', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pixivflow-workid-idem-'));
+    const db = new Database(join(dir, 'test.db'));
+    db.migrate();
+    const file = join(dir, '100.jpg');
+    writeFileSync(file, 'img');
+    try {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      // The runtime injects the occurrence into delivery.executionContext; the
+      // intent key must be scoped to this slot, not fall back to 'adhoc'.
+      const scopedTarget = {
+        ...target(),
+        delivery: { target: SLOT_TARGET, executionContext: { slotId: slot.slotId } },
+      } as TargetConfig;
+      coord.prepare(slot, schedule, [scopedTarget]);
+
+      // Crash after the download bound A, before any delivery intent existed.
+      coord.lockWorkCas(slot.slotId, TARGET_ID, '100', 'illustration');
+
+      const recoveringHandler = new IllustrationTargetHandler(
+        mockClient,
+        mockDatabase,
+        mockRankingService,
+        mockIllustrationDownloader,
+        mockPipeline,
+        undefined,
+        new DeliveryService(db)
+      );
+      mockClient.getIllustration.mockResolvedValue(createMockIllust(100));
+      mockIllustrationDownloader.downloadIllustration.mockResolvedValue({
+        type: 'illustration',
+        pixivId: '100',
+        title: 'Illust 100',
+        files: [file],
+        pageCount: 1,
+        cachedDir: dir,
+      } as unknown as DownloadedArtifact);
+
+      const resumed = new SlotCoordinator(db);
+      const pending = resumed.pendingTargets(slot.slotId, [scopedTarget]);
+      const outcome = await recoveringHandler.handle(
+        scopedTarget,
+        resumed.executionContextsFor(slot.slotId, pending).get(TARGET_ID)
+      );
+
+      expect(outcome.kind).toBe('delivery_pending');
+      const intents = db.deliveries.listForCell(SLOT_TARGET, slot.slotId, TARGET_ID);
+      // One logical item => exactly one intent, still pointing at the locked work.
+      expect(intents).toHaveLength(1);
+      expect(intents[0].pixivId).toBe('100');
+
+      // The key is a pure function of the work identity, so recovering the SAME
+      // work always yields the SAME downstream idempotency identity (a replay
+      // converges to one remote record instead of double-posting).
+      const keyFor = (pixivId: string) =>
+        DeliveryService.idempotencyKey(
+          SLOT_TARGET,
+          { type: 'illustration', pixivId } as DownloadedArtifact,
+          slot.slotId,
+          TARGET_ID
+        );
+      expect(intents[0].idempotencyKey).toBe(keyFor('100'));
+      // ...whereas a swapped work would carry a different identity — which is
+      // exactly what silently re-pointing the item at B would have produced.
+      expect(keyFor('200')).not.toBe(keyFor('100'));
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/download/handlers/workIdentityRecovery.test.ts
+++ b/src/__tests__/download/handlers/workIdentityRecovery.test.ts
@@ -1,0 +1,370 @@
+/**
+ * RECOVERY MUST NOT SWAP THE WORK (the core regression).
+ *
+ * Before this fix the resume path reduced `pending` to `p.target`, losing
+ * `cell.workId`. The handler then had no idea it was a recovery: it re-ran the
+ * candidate pipeline, `downloads` filtered out the work the cell ALREADY had,
+ * and a different work was selected for the same logical item.
+ *
+ * These tests drive the real handler with a real slot ledger, so they assert the
+ * execution path — not just a DB column.
+ */
+import { IllustrationTargetHandler } from '../../../download/handlers/IllustrationTargetHandler';
+import { TargetConfig, ScheduleConfig, StandaloneConfig } from '../../../config';
+import { IPixivClient } from '../../../interfaces/IPixivClient';
+import { IDatabase } from '../../../interfaces/IDatabase';
+import { RankingService } from '../../../download/RankingService';
+import { IllustrationDownloader } from '../../../download/IllustrationDownloader';
+import { DownloadPipeline } from '../../../download/pipeline/DownloadPipeline';
+import { PixivIllust } from '@redtidev/pixiv-client';
+import { Database } from '../../../storage/Database';
+import { SlotCoordinator } from '../../../scheduler/SlotCoordinator';
+import { createDeliveryLedgerPort } from '../../../delivery/DeliveryLedgerPort';
+import { DownloadedArtifact } from '../../../delivery/types';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+jest.mock('../../../logger');
+jest.mock('../../../utils/pixiv-date-utils', () => ({
+  getTodayDate: jest.fn().mockReturnValue('2026-09-08'),
+  getYesterdayDate: jest.fn().mockReturnValue('2026-09-07'),
+}));
+
+const TARGET_ID = 'daily-illust';
+const SLOT_TARGET = 'telepost';
+/** One work per run — the shape the work-identity invariant is defined for. */
+const target = (): TargetConfig =>
+  ({
+    id: TARGET_ID,
+    type: 'illustration',
+    tag: 'landscape',
+    mode: 'search',
+    limit: 1,
+    storageMode: 'cache',
+    delivery: { target: SLOT_TARGET },
+  }) as TargetConfig;
+
+const schedule = {
+  id: 'schedule-a',
+  name: 'Schedule A',
+  cron: '0 10 * * *',
+  timezone: 'Asia/Shanghai',
+  enabled: true,
+} as ScheduleConfig;
+const config = { schedulerRuntime: { trigger: { graceMinutes: 120 } } } as StandaloneConfig;
+const AT = new Date('2026-09-08T02:00:30Z');
+
+const createMockIllust = (id: number): PixivIllust =>
+  ({
+    id,
+    title: `Illust ${id}`,
+    page_count: 1,
+    user: { id: '12345', name: 'Test User' },
+    image_urls: {
+      square_medium: `https://example.com/${id}_square.jpg`,
+      medium: `https://example.com/${id}_medium.jpg`,
+      large: `https://example.com/${id}_large.jpg`,
+    },
+    create_date: '2026-09-08',
+    total_bookmarks: 100,
+    total_view: 1000,
+  }) as PixivIllust;
+
+const artifact = (pixivId: string): DownloadedArtifact =>
+  ({
+    type: 'illustration',
+    pixivId,
+    title: `Illust ${pixivId}`,
+    files: [`/tmp/${pixivId}.jpg`],
+    pageCount: 1,
+    cachedDir: `/tmp/${pixivId}`,
+  }) as unknown as DownloadedArtifact;
+
+describe('work identity across recovery', () => {
+  let handler: IllustrationTargetHandler;
+  let mockClient: jest.Mocked<IPixivClient>;
+  let mockDatabase: jest.Mocked<IDatabase>;
+  let mockRankingService: jest.Mocked<RankingService>;
+  let mockIllustrationDownloader: jest.Mocked<IllustrationDownloader>;
+  let mockPipeline: jest.Mocked<DownloadPipeline>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockClient = { searchIllustrations: jest.fn(), getIllustration: jest.fn() } as any;
+    mockDatabase = { logExecution: jest.fn() } as any;
+    mockRankingService = { getRankingIllustrationsWithFallback: jest.fn() } as any;
+    mockIllustrationDownloader = { downloadIllustration: jest.fn() } as any;
+    mockPipeline = { run: jest.fn() } as any;
+
+    handler = new IllustrationTargetHandler(
+      mockClient,
+      mockDatabase,
+      mockRankingService,
+      mockIllustrationDownloader,
+      mockPipeline
+    );
+  });
+
+  /**
+   * A sequential candidate loop: the first work that yields an artifact stops
+   * the run. This is what DownloadPipeline does for a single-work target, and it
+   * is what makes "which candidate wins" observable.
+   */
+  function pipelineDownloadsEveryCandidate(): void {
+    mockPipeline.run.mockImplementation(async (items: any, _t: any, _ty: any, downloadFn: any) => {
+      for (const item of items) await downloadFn(item, 'landscape');
+      return { downloaded: items.length, skipped: 0, alreadyDownloaded: 0, filteredOut: 0 };
+    });
+  }
+
+  async function withSlot<T>(fn: (ctx: { db: Database; slotId: string }) => Promise<T>): Promise<T> {
+    const dir = mkdtempSync(join(tmpdir(), 'pixivflow-workid-handler-'));
+    const db = new Database(join(dir, 'test.db'));
+    db.migrate();
+    const coord = new SlotCoordinator(db);
+    const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+    coord.prepare(slot, schedule, [target()]);
+    try {
+      return await fn({ db, slotId: slot.slotId });
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('binds the cell to the selected work BEFORE any side effect', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(100)]);
+
+      let workIdAtDownload: string | null | undefined;
+      let statusAtDownload: string | undefined;
+      mockIllustrationDownloader.downloadIllustration.mockImplementation(async () => {
+        // Sampled exactly when the downloader runs: before it writes a downloads
+        // row and before any delivery is enqueued.
+        const cell = db.slots.getCell(slotId, TARGET_ID)!;
+        workIdAtDownload = cell.workId;
+        statusAtDownload = cell.status;
+        return artifact('100');
+      });
+      pipelineDownloadsEveryCandidate();
+
+      await handler.handle(
+        target(),
+        coord.executionContextsFor(slotId, coord.pendingTargets(slotId, [target()])).get(TARGET_ID)
+      );
+
+      expect(workIdAtDownload).toBe('100');
+      expect(statusAtDownload).toBe('selected');
+    });
+  });
+
+  it('resumes the SAME work after a crash that followed the download', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      // First run: A was selected, bound and downloaded; then the process died
+      // before a delivery intent existed. `downloads` now holds A — which is
+      // exactly what used to make the resume filter A out and pick B.
+      coord.lockWorkCas(slotId, TARGET_ID, '100', 'illustration');
+
+      // Restart: a fresh coordinator, then the resume path the runtime uses.
+      const resumed = new SlotCoordinator(db);
+      const pending = resumed.pendingTargets(slotId, [target()]);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].cell.workId).toBe('100');
+
+      mockClient.getIllustration.mockResolvedValue(createMockIllust(100));
+      mockIllustrationDownloader.downloadIllustration.mockResolvedValue(artifact('100'));
+
+      await handler.handle(target(), resumed.executionContextsFor(slotId, pending).get(TARGET_ID));
+
+      // A is fetched and processed by identity...
+      expect(mockClient.getIllustration).toHaveBeenCalledWith(100);
+      expect(mockIllustrationDownloader.downloadIllustration).toHaveBeenCalledTimes(1);
+      expect(mockIllustrationDownloader.downloadIllustration.mock.calls[0][0]).toMatchObject({ id: 100 });
+      // ...and selection never ran, so no other work could be selected for it.
+      expect(mockClient.searchIllustrations).not.toHaveBeenCalled();
+      expect(mockRankingService.getRankingIllustrationsWithFallback).not.toHaveBeenCalled();
+      expect(mockPipeline.run).not.toHaveBeenCalled();
+      expect(db.slots.getCell(slotId, TARGET_ID)!.workId).toBe('100');
+    });
+  });
+
+  it('CONTRAST: dropping the cell at dispatch is exactly what swaps the work', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      // Crash after the download: the cell owns A and `downloads` holds A.
+      coord.lockWorkCas(slotId, TARGET_ID, '100', 'illustration');
+
+      // Pre-fix wiring: `pending.map(p => p.target)` threw the cell away, so the
+      // handler ran selection again. `downloads` (and later the delivery ledger)
+      // exclude A, so the pool the pipeline sees is [B] — and B is what it
+      // processes under A's logical identity.
+      const preFixRunTargets = coord.pendingTargets(slotId, [target()]).map((p) => p.target);
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(200)]);
+      pipelineDownloadsEveryCandidate();
+      mockIllustrationDownloader.downloadIllustration.mockResolvedValue(artifact('200'));
+
+      await handler.handle(preFixRunTargets[0]);
+
+      expect(mockIllustrationDownloader.downloadIllustration.mock.calls[0][0]).toMatchObject({ id: 200 });
+      // The cell's identity stays 100 while work 200 is what was processed.
+      expect(db.slots.getCell(slotId, TARGET_ID)!.workId).toBe('100');
+    });
+  });
+
+  it('never substitutes another work when the locked work is permanently gone', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      coord.lockWorkCas(slotId, TARGET_ID, '100', 'illustration');
+      mockClient.getIllustration.mockRejectedValue(new Error('HTTP 404: work is deleted or private'));
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(200)]);
+
+      const pending = new SlotCoordinator(db).pendingTargets(slotId, [target()]);
+      const outcome = await handler.handle(
+        target(),
+        coord.executionContextsFor(slotId, pending).get(TARGET_ID)
+      );
+
+      // The item fails AS A. It must not silently become B.
+      expect(outcome).toMatchObject({ kind: 'failed', retryable: false });
+      expect(outcome.kind === 'failed' && outcome.error).toContain('LOCKED_WORK_UNAVAILABLE');
+      expect(mockClient.searchIllustrations).not.toHaveBeenCalled();
+      expect(mockIllustrationDownloader.downloadIllustration).not.toHaveBeenCalled();
+      expect(db.slots.getCell(slotId, TARGET_ID)!.workId).toBe('100');
+    });
+  });
+
+  it('does not invoke the handler at all while the outbox still owns the cell', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      coord.lockWorkCas(slotId, TARGET_ID, '100', 'illustration');
+      coord.applyOutcome(slotId, TARGET_ID, {
+        kind: 'delivery_pending',
+        workId: '100',
+        workType: 'illustration',
+        deliveryId: 'delivery-100',
+      });
+      // The intent survived the crash, and its outbox row is still actionable.
+      const intent = db.deliveries.insertIntent({
+        id: 'delivery-100',
+        deliveryTarget: SLOT_TARGET,
+        workType: 'illustration',
+        pixivId: '100',
+        slotId,
+        targetId: TARGET_ID,
+        idempotencyKey: `pixivflow:${SLOT_TARGET}:illustration:100:${slotId}:${TARGET_ID}`,
+      }).row;
+      db.outbox.enqueue({
+        kind: 'delivery',
+        deliveryTarget: SLOT_TARGET,
+        deliveryId: intent.id,
+        idempotencyKey: `outbox:${intent.idempotencyKey}`,
+        payload: {},
+      });
+
+      // Resume with the real ledger port: the outbox owns this delivery.
+      const resumed = new SlotCoordinator(db, createDeliveryLedgerPort(db));
+      const dispatch = resumed.pendingTargets(slotId, [target()]);
+
+      for (const { target: t, cell } of dispatch) {
+        await handler.handle(t, resumed.executionContextsFor(slotId, [{ target: t, cell }]).get(TARGET_ID));
+      }
+
+      expect(dispatch).toEqual([]);
+      expect(mockClient.searchIllustrations).not.toHaveBeenCalled();
+      expect(mockClient.getIllustration).not.toHaveBeenCalled();
+      expect(mockPipeline.run).not.toHaveBeenCalled();
+      expect(mockIllustrationDownloader.downloadIllustration).not.toHaveBeenCalled();
+      expect(mockRankingService.getRankingIllustrationsWithFallback).not.toHaveBeenCalled();
+      // Still exactly one logical delivery for the cell, still pointing at A.
+      const deliveries = db.deliveries.listForCell(SLOT_TARGET, slotId, TARGET_ID);
+      expect(deliveries).toHaveLength(1);
+      expect(deliveries[0].pixivId).toBe('100');
+    });
+  });
+
+  it('refuses to process a work the cell does not own (first selection wins)', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      // The context was built while the cell was still unbound...
+      const contextsWhileUnbound = coord.executionContextsFor(
+        slotId,
+        coord.pendingTargets(slotId, [target()])
+      );
+      // ...then another worker elected work 100 for it.
+      coord.lockWorkCas(slotId, TARGET_ID, '100', 'illustration');
+
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(200)]);
+      pipelineDownloadsEveryCandidate();
+      mockIllustrationDownloader.downloadIllustration.mockResolvedValue(artifact('200'));
+
+      await handler.handle(target(), contextsWhileUnbound.get(TARGET_ID));
+
+      // The loser must not keep processing its own candidate B.
+      expect(mockIllustrationDownloader.downloadIllustration).not.toHaveBeenCalled();
+      expect(db.slots.getCell(slotId, TARGET_ID)!.workId).toBe('100');
+    });
+  });
+
+  it('frees a failed candidate, so an unbound cell is never stuck on it', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(100)]);
+      // The candidate fails without persisting anything, so nothing is committed
+      // and the cell must stay free — otherwise a 404 candidate would consume the
+      // logical item's identity forever.
+      mockIllustrationDownloader.downloadIllustration.mockRejectedValue(
+        new Error('HTTP 404: candidate 100 is gone')
+      );
+      pipelineDownloadsEveryCandidate();
+
+      const outcome = await handler.handle(
+        target(),
+        coord.executionContextsFor(slotId, coord.pendingTargets(slotId, [target()])).get(TARGET_ID)
+      );
+
+      expect(outcome.kind).toBe('failed');
+      const cell = db.slots.getCell(slotId, TARGET_ID)!;
+      expect(cell.workId).toBeNull();
+      expect(cell.status).toBe('pending');
+    });
+  });
+
+  it('binds only the work that actually produced an artifact', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(200)]);
+      mockIllustrationDownloader.downloadIllustration.mockResolvedValue(artifact('200'));
+      pipelineDownloadsEveryCandidate();
+
+      await handler.handle(
+        target(),
+        coord.executionContextsFor(slotId, coord.pendingTargets(slotId, [target()])).get(TARGET_ID)
+      );
+
+      expect(db.slots.getCell(slotId, TARGET_ID)!.workId).toBe('200');
+    });
+  });
+
+  it('ignores the execution context for targets that intentionally own N works per run', async () => {
+    await withSlot(async ({ db, slotId }) => {
+      const coord = new SlotCoordinator(db);
+      const multi: TargetConfig = { ...target(), limit: 10 } as TargetConfig;
+      mockClient.searchIllustrations.mockResolvedValue([createMockIllust(100), createMockIllust(200)]);
+      mockIllustrationDownloader.downloadIllustration.mockResolvedValue(artifact('100'));
+      pipelineDownloadsEveryCandidate();
+
+      // A cell with a stale binding must still fetch the whole feed: pinning it
+      // to one work would silently shrink the run.
+      coord.lockWorkCas(slotId, TARGET_ID, '100', 'illustration');
+      await handler.handle(multi, coord.executionContextsFor(slotId, [{ target: multi, cell: db.slots.getCell(slotId, TARGET_ID)! }]).get(TARGET_ID));
+
+      expect(mockClient.searchIllustrations).toHaveBeenCalled();
+      expect(mockClient.getIllustration).not.toHaveBeenCalled();
+      expect(mockPipeline.run).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/scheduler/SlotCoordinator.test.ts
+++ b/src/__tests__/scheduler/SlotCoordinator.test.ts
@@ -66,7 +66,7 @@ describe('SlotCoordinator', () => {
     });
   });
 
-  it('a locked work id survives a resume (automatic retry never swaps it)', async () => {
+  it('a locked work id survives a resume AND is handed to the handler', async () => {
     await withDb(async (db) => {
       const coord = new SlotCoordinator(db);
       const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
@@ -80,6 +80,18 @@ describe('SlotCoordinator', () => {
       const cell = db.slots.getCell(slot.slotId, 'a')!;
       expect(cell.workId).toBe('100');
       expect(cell.status).toBe('selected');
+
+      // The column alone proves nothing — this was the original false comfort.
+      // The resume path must actually carry the identity to the handler; if it
+      // drops the cell, the handler re-ranks and selects a DIFFERENT work.
+      // (The end-to-end assertion lives in
+      //  __tests__/download/handlers/workIdentityRecovery.test.ts.)
+      const pending = coord2.pendingTargets(slot.slotId, [target('a')]);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].cell.workId).toBe('100');
+
+      const contexts = coord2.executionContextsFor(slot.slotId, pending);
+      expect(contexts.get('a')?.lockedWorkId).toBe('100');
     });
   });
 

--- a/src/__tests__/scheduler/workIdentity.test.ts
+++ b/src/__tests__/scheduler/workIdentity.test.ts
@@ -1,0 +1,249 @@
+/**
+ * WORK-IDENTITY INVARIANT
+ *
+ *   (slotId, targetId) -> ONE stable workId
+ *
+ * A crash / shutdown / lease recovery is NOT an intentional second run. It must
+ * continue the work the cell already owns; re-running selection on resume would
+ * silently re-point the logical item at a different work (A -> B), leaving A
+ * downloaded-but-never-delivered while the item reports success.
+ *
+ * These tests pin the coordinator half of that contract: the CAS binding, the
+ * provisional release, what a resume hands to the handler, and the hand-off of
+ * `delivery_pending` cells to the outbox (C).
+ */
+import { Database } from '../../storage/Database';
+import { CellDeliveryState, SlotCoordinator } from '../../scheduler/SlotCoordinator';
+import { StandaloneConfig, ScheduleConfig, TargetConfig } from '../../config';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function withDb<T>(fn: (db: Database) => T | Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-workid-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  return Promise.resolve()
+    .then(() => fn(db))
+    .finally(() => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    });
+}
+
+/** One work per run: the shape the work-identity invariant is defined for. */
+const singleWorkTarget = (id: string): TargetConfig =>
+  ({
+    id,
+    type: 'illustration',
+    mode: 'topic',
+    topic: 'landscape',
+    date: 'YESTERDAY',
+    limit: 1,
+    storageMode: 'cache',
+    delivery: { target: 'telepost' },
+  }) as TargetConfig;
+
+/** Ten works per run: one cell legitimately owns N works, so no single identity. */
+const multiWorkTarget = (id: string): TargetConfig =>
+  ({
+    id,
+    type: 'illustration',
+    mode: 'search',
+    tag: 'landscape',
+    limit: 10,
+    storageMode: 'cache',
+    delivery: { target: 'telepost' },
+  }) as TargetConfig;
+
+const schedule = {
+  id: 'schedule-a',
+  name: 'Schedule A',
+  cron: '0 10 * * *',
+  timezone: 'Asia/Shanghai',
+  enabled: true,
+} as ScheduleConfig;
+const config = { schedulerRuntime: { trigger: { graceMinutes: 120 } } } as StandaloneConfig;
+// 2026-09-08 10:00 Shanghai == 02:00 UTC.
+const AT = new Date('2026-09-08T02:00:30Z');
+
+const fixedPort = (state: CellDeliveryState) => ({ stateFor: () => state });
+
+describe('work identity (slotId, targetId) -> workId', () => {
+  it('a resume hands the locked work back to the handler instead of re-selecting', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+      coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+
+      // Process restart: the resumed cell must carry the identity to the handler.
+      const coord2 = new SlotCoordinator(db);
+      const pending = coord2.pendingTargets(slot.slotId, [singleWorkTarget('daily')]);
+
+      expect(pending).toHaveLength(1);
+      expect(pending[0].cell.workId).toBe('100');
+      expect(pending[0].cell.status).toBe('selected');
+    });
+  });
+
+  it('first selection wins: two racing workers elect exactly one work', async () => {
+    await withDb((db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+
+      const worker1 = coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+      const worker2 = coord.lockWorkCas(slot.slotId, 'daily', '200', 'illustration');
+
+      expect(worker1).toEqual({ workId: '100', won: true });
+      // The loser must continue with the winner, never with its own candidate.
+      expect(worker2).toEqual({ workId: '100', won: false });
+      expect(db.slots.getCell(slot.slotId, 'daily')!.workId).toBe('100');
+      expect(db.slots.getCell(slot.slotId, 'daily')!.status).toBe('selected');
+    });
+  });
+
+  it('re-binding the same work is idempotent, so retries keep the identity', async () => {
+    await withDb((db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+
+      expect(coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration').won).toBe(true);
+      expect(coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration').won).toBe(true);
+      expect(db.slots.getCell(slot.slotId, 'daily')!.workId).toBe('100');
+    });
+  });
+
+  it('releases a provisional binding so an unbound cell can try the next candidate', async () => {
+    await withDb((db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+
+      coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+      coord.releaseWorkCas(slot.slotId, 'daily', '100');
+
+      const cell = db.slots.getCell(slot.slotId, 'daily')!;
+      expect(cell.workId).toBeNull();
+      expect(cell.status).toBe('pending');
+      // The freed cell may bind a different work.
+      expect(coord.lockWorkCas(slot.slotId, 'daily', '200', 'illustration')).toEqual({
+        workId: '200',
+        won: true,
+      });
+    });
+  });
+
+  it('never releases a released-after-commit binding: a delivery_pending cell keeps its work', async () => {
+    await withDb((db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+
+      coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+      coord.applyOutcome(slot.slotId, 'daily', {
+        kind: 'delivery_pending',
+        workId: '100',
+        workType: 'illustration',
+        deliveryId: 'delivery-1',
+      });
+
+      // A late release (e.g. the enqueue threw after the artifact was persisted)
+      // must not erase an identity that already has side effects behind it.
+      coord.releaseWorkCas(slot.slotId, 'daily', '100');
+
+      const cell = db.slots.getCell(slot.slotId, 'daily')!;
+      expect(cell.workId).toBe('100');
+      expect(cell.status).toBe('delivery_pending');
+    });
+  });
+
+  it('a release can never clear ANOTHER work\'s binding', async () => {
+    await withDb((db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+      coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+
+      coord.releaseWorkCas(slot.slotId, 'daily', '999');
+
+      expect(db.slots.getCell(slot.slotId, 'daily')!.workId).toBe('100');
+    });
+  });
+
+  describe('delivery_pending ownership (C)', () => {
+    const withPendingDelivery = async (
+      db: Database,
+      coord: SlotCoordinator,
+      target: TargetConfig,
+      workId = '100'
+    ) => {
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [target]);
+      coord.lockWorkCas(slot.slotId, target.id!, workId, 'illustration');
+      coord.applyOutcome(slot.slotId, target.id!, {
+        kind: 'delivery_pending',
+        workId,
+        workType: 'illustration',
+        deliveryId: `delivery-${workId}`,
+      });
+      return slot;
+    };
+
+    it('delegates the cell to the outbox while the intent is still actionable', async () => {
+      await withDb((db) => {
+        const coord = new SlotCoordinator(db, fixedPort({ kind: 'live' }));
+        return withPendingDelivery(db, coord, singleWorkTarget('daily')).then((slot) => {
+          // Handler must NOT run: the outbox owns A and will ACK it to submitted.
+          expect(coord.pendingTargets(slot.slotId, [singleWorkTarget('daily')])).toEqual([]);
+          expect(db.slots.getCell(slot.slotId, 'daily')!.status).toBe('delivery_pending');
+        });
+      });
+    });
+
+    it('fails the cell on a terminal delivery failure instead of selecting another work', async () => {
+      await withDb((db) => {
+        const coord = new SlotCoordinator(
+          db,
+          fixedPort({ kind: 'lost', reason: 'outbox exhausted retries for work 100' })
+        );
+        return withPendingDelivery(db, coord, singleWorkTarget('daily')).then((slot) => {
+          expect(coord.pendingTargets(slot.slotId, [singleWorkTarget('daily')])).toEqual([]);
+
+          const cell = db.slots.getCell(slot.slotId, 'daily')!;
+          expect(cell.status).toBe('failed');
+          // The identity is preserved: the item FAILS as A, it never becomes B.
+          expect(cell.workId).toBe('100');
+        });
+      });
+    });
+
+    it('heals a cell whose ACK landed but whose promotion was lost', async () => {
+      await withDb((db) => {
+        const coord = new SlotCoordinator(
+          db,
+          fixedPort({ kind: 'confirmed', workId: '100', workType: 'illustration' })
+        );
+        return withPendingDelivery(db, coord, singleWorkTarget('daily')).then((slot) => {
+          expect(coord.pendingTargets(slot.slotId, [singleWorkTarget('daily')])).toEqual([]);
+          // Promoted from the ledger instead of re-posting a second work.
+          expect(db.slots.getCell(slot.slotId, 'daily')!.status).toBe('submitted');
+        });
+      });
+    });
+
+    it('keeps re-running cells that intentionally own N works per run', async () => {
+      await withDb((db) => {
+        const coord = new SlotCoordinator(db, fixedPort({ kind: 'live' }));
+        return withPendingDelivery(db, coord, multiWorkTarget('feed')).then((slot) => {
+          // One cell = N works here, so there is no single identity to pin: the
+          // target must still run to fetch the remaining works of its feed.
+          const pending = coord.pendingTargets(slot.slotId, [multiWorkTarget('feed')]);
+          expect(pending.map((p) => p.target.id)).toEqual(['feed']);
+        });
+      });
+    });
+  });
+});

--- a/src/__tests__/scheduler/workIdentity.test.ts
+++ b/src/__tests__/scheduler/workIdentity.test.ts
@@ -14,6 +14,7 @@
  */
 import { Database } from '../../storage/Database';
 import { CellDeliveryState, SlotCoordinator } from '../../scheduler/SlotCoordinator';
+import { shouldTerminaliseAbortedSlot } from '../../commands/scheduler-runtime';
 import { StandaloneConfig, ScheduleConfig, TargetConfig } from '../../config';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -170,6 +171,45 @@ describe('work identity (slotId, targetId) -> workId', () => {
       coord.releaseWorkCas(slot.slotId, 'daily', '999');
 
       expect(db.slots.getCell(slot.slotId, 'daily')!.workId).toBe('100');
+    });
+  });
+
+  it('a SHUTDOWN recovery resumes the same work, not the same target with a new one', async () => {
+    await withDb(async (db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+      coord.claimRunLease(slot.slotId, 'run-1', 180_000);
+      coord.markRunning(slot.slotId);
+      coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+
+      // Shutdown is NOT the timeout path: the occurrence stays resumable.
+      expect(shouldTerminaliseAbortedSlot('shutdown', false)).toBe(false);
+      coord.releaseRunLease(slot.slotId, 'run-1');
+      expect(db.slots.recoverableSlots().map((s) => s.id)).toContain(slot.slotId);
+
+      // After the restart the same occurrence resumes — AND the same work.
+      const resumed = new SlotCoordinator(db);
+      const pending = resumed.pendingTargets(slot.slotId, [singleWorkTarget('daily')]);
+      expect(pending).toHaveLength(1);
+      expect(resumed.executionContextsFor(slot.slotId, pending).get('daily')?.lockedWorkId).toBe('100');
+    });
+  });
+
+  it('a TIMEOUT still terminalises the slot and is never re-dispatched (unchanged)', async () => {
+    await withDb((db) => {
+      const coord = new SlotCoordinator(db);
+      const slot = coord.resolveOccurrence(schedule, config, 'http', AT).context!;
+      coord.prepare(slot, schedule, [singleWorkTarget('daily')]);
+      coord.claimRunLease(slot.slotId, 'run-1', 180_000);
+      coord.markRunning(slot.slotId);
+      coord.lockWorkCas(slot.slotId, 'daily', '100', 'illustration');
+
+      // The timeout path is untouched by this fix: it must stay terminal.
+      expect(shouldTerminaliseAbortedSlot('timeout', false)).toBe(true);
+      coord.finish(slot, schedule, [singleWorkTarget('daily')]);
+      coord.releaseRunLease(slot.slotId, 'run-1');
+      expect(db.slots.recoverableSlots().map((s) => s.id)).not.toContain(slot.slotId);
     });
   });
 

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -25,6 +25,7 @@ import {
 } from '../scheduler/SlotCoordinator';
 import { TargetOutcome } from '../scheduler/TargetOutcome';
 import { DeliveryService } from '../delivery/DeliveryService';
+import { createDeliveryLedgerPort } from '../delivery/DeliveryLedgerPort';
 import { OutboxWorker } from '../delivery/OutboxWorker';
 import { migrateLegacyOutbox } from '../delivery/LegacyOutboxMigration';
 import { DeliveryAck } from '../delivery/DeliveryAck';
@@ -374,7 +375,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       return;
     }
 
-    const coordinator = new SlotCoordinator(database);
+    const coordinator = new SlotCoordinator(database, createDeliveryLedgerPort(database));
 
     // Ad-hoc/manual execution (run-once / explicit refetch) runs the download
     // plan WITHOUT a scheduled Slot: it can never mark a scheduled occurrence
@@ -487,7 +488,16 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
     // re-runs a finished cell — that is what prevents a second post). Membership
     // comes from the materialized snapshot, so a config reload cannot add cells.
     const pending = slotCtx ? coordinator.pendingTargets(slotCtx.slotId, targets) : targets.map((target) => ({ target, cell: null }));
-    let runTargets = (onlyTarget ? pending.filter((p) => p.target.id === onlyTarget) : pending).map((p) => p.target);
+    const selected = onlyTarget ? pending.filter((p) => p.target.id === onlyTarget) : pending;
+
+    // Hand each cell its durable identity. Without this the handler cannot tell a
+    // first selection from a recovery, and would re-rank on resume — silently
+    // re-pointing the logical item at a different work than the one it owns.
+    const targetExecutionContexts = slotCtx
+      ? coordinator.executionContextsFor(slotCtx.slotId, selected)
+      : undefined;
+
+    let runTargets = selected.map((p) => p.target);
 
     if (slotCtx && runTargets.length === 0) {
       logger.info('All slot cells already complete', { slot: slotCtx.slotId });
@@ -533,6 +543,7 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
       });
     }
     const downloadManager = new DownloadManager(scopedConfig, pixivClient, database, fileService);
+    if (targetExecutionContexts) downloadManager.setTargetExecutionContexts(targetExecutionContexts);
     if (options.excludedWorkIds) downloadManager.setProcessedWorkIds(options.excludedWorkIds);
     activeDownloadManager = downloadManager;
     await downloadManager.initialise();

--- a/src/delivery/DeliveryLedgerPort.ts
+++ b/src/delivery/DeliveryLedgerPort.ts
@@ -1,0 +1,46 @@
+import { Database } from '../storage/Database';
+import { CellDeliveryState, SchedulerDeliveryPort } from '../scheduler/SlotCoordinator';
+
+/**
+ * Answers the slot FSM's only delivery question — "does this cell still have an
+ * owner downstream?" — from the durable delivery ledger.
+ *
+ * The distinction matters after a crash: a `delivery_pending` cell whose intent
+ * is still live must be left alone (the OutboxWorker retries THAT work to a
+ * terminal ACK), while one whose intent is terminally failed must be failed
+ * explicitly. Both are read from committed rows, so the answer is the same
+ * before and after a restart — which is exactly what a recovery decision needs.
+ */
+export function createDeliveryLedgerPort(database: Database): SchedulerDeliveryPort {
+  return {
+    stateFor({ deliveryTarget, slotId, targetId }): CellDeliveryState {
+      const rows = database.deliveries.listForCell(deliveryTarget, slotId, targetId);
+      if (rows.length === 0) return { kind: 'unknown' };
+
+      const confirmed = rows.find((r) => r.status === 'delivered' || r.status === 'duplicate');
+      if (confirmed) {
+        return { kind: 'confirmed', workId: confirmed.pixivId, workType: confirmed.workType };
+      }
+
+      const pending = rows.filter((r) => r.status === 'pending');
+      // Still actionable = the outbox is going to try again. Its retry budget is
+      // the only thing that may converge this delivery, so keep hands off.
+      if (pending.some((r) => database.outbox.hasActionableDelivery(r.id))) {
+        return { kind: 'live' };
+      }
+
+      // Either the outbox exhausted its retries (dead/failed) or the intent was
+      // never queued. Nobody will converge it, and re-running selection would
+      // re-point the logical item at a different work — so fail it as-is.
+      if (pending.length > 0 || rows.some((r) => r.status === 'failed')) {
+        return {
+          kind: 'lost',
+          reason:
+            'delivery intent reached a terminal failure without an ACK; failing the cell instead of re-selecting a different work',
+        };
+      }
+
+      return { kind: 'unknown' };
+    },
+  };
+}

--- a/src/download/DownloadManager.ts
+++ b/src/download/DownloadManager.ts
@@ -15,6 +15,7 @@ import { DownloadPipeline } from './pipeline/DownloadPipeline';
 import { OperationCancelledError } from '../utils/errors';
 import { DeliveryService } from '../delivery/DeliveryService';
 import { TargetOutcome } from '../scheduler/TargetOutcome';
+import { TargetExecutionContext } from '../scheduler/WorkIdentity';
 import { IllustrationTargetHandler } from './handlers/IllustrationTargetHandler';
 import { NovelTargetHandler } from './handlers/NovelTargetHandler';
 import { createTopicPipelineFactory } from '../topic/createTopicPipeline';
@@ -100,6 +101,14 @@ export class DownloadManager implements IDownloadManager {
     slotName: string;
     slotDate: string;
   };
+
+  /** Per-cell work identity for THIS run, keyed by target id (scheduled runs only). */
+  private targetExecutionContexts = new Map<string, TargetExecutionContext>();
+
+  /** Publish the durable cell identity each handler must honour (scheduled runs). */
+  public setTargetExecutionContexts(contexts: Map<string, TargetExecutionContext>): void {
+    this.targetExecutionContexts = contexts;
+  }
 
   /**
    * Request cooperative cancellation of the current run. In-flight item
@@ -292,11 +301,15 @@ export class DownloadManager implements IDownloadManager {
   }
 
   private async dispatchTarget(target: TargetConfig): Promise<TargetOutcome> {
+    // The cell identity must reach the handler or it cannot tell a first
+    // selection from a recovery: it would re-rank and silently re-point the
+    // logical item at a different work.
+    const execution = target.id ? this.targetExecutionContexts.get(target.id) : undefined;
     switch (target.type) {
       case 'illustration':
-        return await this.illustrationHandler.handle(target);
+        return await this.illustrationHandler.handle(target, execution);
       case 'novel':
-        return await this.novelHandler.handle(target);
+        return await this.novelHandler.handle(target, execution);
       default:
         logger.warn(`Unsupported target type ${target.type}`);
         return { kind: 'failed', retryable: false, error: `unsupported target type ${target.type}` };

--- a/src/download/handlers/IllustrationTargetHandler.ts
+++ b/src/download/handlers/IllustrationTargetHandler.ts
@@ -11,12 +11,21 @@ import { calculatePopularityScore } from '../../utils/pixiv-utils';
 import { PixivIllust } from '@redtidev/pixiv-client';
 import { DeliveryService } from '../../delivery/DeliveryService';
 import { TargetOutcome } from '../../scheduler/TargetOutcome';
+import { TargetExecutionContext, isSingleWorkCell } from '../../scheduler/WorkIdentity';
+import type { DownloadedArtifact } from '../../delivery/types';
 import type { TopicPipelineFactory } from '../../topic/createTopicPipeline';
 import { getTargetLabel } from '../../utils/target-label';
 
 export class IllustrationTargetHandler {
   /** Outcomes produced during this handle() call (deliveries + terminal non-matches). */
   private outcomes: TargetOutcome[] = [];
+
+  /**
+   * Cell identity for this handle() call. Set only for a single-work cell of a
+   * scheduled occurrence; null for ad-hoc runs and N-works-per-run targets, which
+   * have no single (slotId,targetId) -> workId identity to honour.
+   */
+  private execution: TargetExecutionContext | null = null;
 
   constructor(
     private readonly client: IPixivClient,
@@ -28,8 +37,19 @@ export class IllustrationTargetHandler {
     private readonly deliveryService?: DeliveryService
   ) {}
 
-  async handle(target: TargetConfig): Promise<TargetOutcome> {
+  async handle(target: TargetConfig, execution?: TargetExecutionContext): Promise<TargetOutcome> {
     this.outcomes = [];
+    this.execution = execution && isSingleWorkCell(target) ? execution : null;
+
+    // A cell that already owns a work is in RECOVERY, not in a new selection.
+    // Crash/shutdown recovery is not an intentional second run: running the
+    // candidate pipeline here would re-rank and could bind this logical item to a
+    // different work than the one it already committed to.
+    if (this.execution?.lockedWorkId) {
+      await this.recoverLockedWork(target, this.execution.lockedWorkId);
+      return this.summarize(target);
+    }
+
     if (target.illustId) {
       await this.handleSingleIllustration(target);
       return this.summarize(target);
@@ -455,23 +475,106 @@ export class IllustrationTargetHandler {
     });
   }
 
+  /**
+   * Continue the work this cell ALREADY owns. Selection is deliberately skipped:
+   * no search, no ranking, no topic expansion, no backfill pool, and no
+   * "already downloaded / already delivered" exclusion — the cell's own work must
+   * never be filtered out of its own recovery.
+   *
+   * A locked work that is permanently gone is a terminal failure of THIS logical
+   * item (`LOCKED_WORK_UNAVAILABLE`). It is never silently replaced by another
+   * candidate; that would mutate the item's identity behind the operator's back.
+   */
+  private async recoverLockedWork(target: TargetConfig, lockedWorkId: string): Promise<void> {
+    const displayTag = getTargetLabel(target);
+    logger.info(`Recovering locked work ${lockedWorkId} for ${displayTag}; candidate selection is skipped`, {
+      slotId: this.execution?.slotId,
+      targetId: this.execution?.targetId,
+      lockedWorkId,
+    });
+
+    const illustId = Number(lockedWorkId);
+    if (!Number.isFinite(illustId)) {
+      this.outcomes.push({
+        kind: 'failed',
+        retryable: false,
+        error: `LOCKED_WORK_UNAVAILABLE: cell work id "${lockedWorkId}" is not a valid illustration id`,
+      });
+      return;
+    }
+
+    try {
+      const detail = await this.client.getIllustration(illustId);
+      await this.downloadAndDeliver(detail, displayTag, target);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const retryable = isRetryableNetworkError(error);
+      this.logError(error, `Failed to recover locked illustration ${lockedWorkId}`);
+      this.outcomes.push({
+        kind: 'failed',
+        retryable,
+        error: retryable
+          ? `locked work ${lockedWorkId} could not be fetched (will retry the SAME work): ${message}`
+          : `LOCKED_WORK_UNAVAILABLE: locked work ${lockedWorkId} is no longer fetchable: ${message}`,
+      });
+    }
+  }
+
+  /**
+   * Process ONE candidate work for this cell.
+   *
+   * The cell is bound to `illust` BEFORE any side effect: it is the binding, not
+   * the candidate list, that decides what a later recovery resumes. The binding
+   * is only rolled back when the attempt produced no artifact at all, so in-run
+   * backfill still works for a cell that has committed to nothing.
+   */
   private async downloadAndDeliver(
     illust: PixivIllust,
     tag: string,
     target: TargetConfig
   ): Promise<void> {
-    const artifact = await this.illustrationDownloader.downloadIllustration(
-      illust,
-      tag,
-      {
-        aiMetadataCheck: target.aiMetadataCheck === true,
-        maxPageCount: target.maxPageCount,
-        includeDeliveryPreviews: Boolean(
-          target.storageMode === 'cache' && target.delivery?.target?.trim()
-        ),
+    const execution = this.execution;
+    const workId = String(illust.id);
+    // Recovery continues a work the cell already bound; it must never be released.
+    const recovering = Boolean(execution?.lockedWorkId);
+    if (execution && !recovering) {
+      const binding = execution.bind(workId, 'illustration');
+      if (!binding.won) {
+        // Another writer elected a different work for this cell. First selection
+        // is authoritative: never process a work the cell does not own.
+        logger.warn(`Cell is bound to work ${binding.workId}; declining to select ${workId}`, {
+          slotId: execution.slotId,
+          targetId: execution.targetId,
+          boundWorkId: binding.workId,
+        });
+        return;
       }
-    );
-    if (!artifact) return;
+    }
+
+    let artifact: DownloadedArtifact | null = null;
+    try {
+      artifact = await this.illustrationDownloader.downloadIllustration(
+        illust,
+        tag,
+        {
+          aiMetadataCheck: target.aiMetadataCheck === true,
+          maxPageCount: target.maxPageCount,
+          includeDeliveryPreviews: Boolean(
+            target.storageMode === 'cache' && target.delivery?.target?.trim()
+          ),
+        }
+      );
+    } catch (error) {
+      // Nothing was persisted, so the cell may still pick another candidate.
+      if (execution && !recovering) execution.release(workId);
+      throw error;
+    }
+    if (!artifact) {
+      if (execution && !recovering) execution.release(workId);
+      return;
+    }
+    // Committed: the artifact is durable and this work now defines the cell. Even
+    // if enqueue throws below, recovery must resume THIS work — never release.
     this.recordArtifactOutcome(artifact, target);
   }
 

--- a/src/download/handlers/NovelTargetHandler.ts
+++ b/src/download/handlers/NovelTargetHandler.ts
@@ -11,11 +11,20 @@ import { calculatePopularityScore } from '../../utils/pixiv-utils';
 import { PixivNovel } from '@redtidev/pixiv-client';
 import { DeliveryService } from '../../delivery/DeliveryService';
 import { TargetOutcome } from '../../scheduler/TargetOutcome';
+import { TargetExecutionContext, isSingleWorkCell } from '../../scheduler/WorkIdentity';
+import type { DownloadedArtifact } from '../../delivery/types';
 import type { TopicPipelineFactory } from '../../topic/createTopicPipeline';
 import { getTargetLabel } from '../../utils/target-label';
 
 export class NovelTargetHandler {
   private outcomes: TargetOutcome[] = [];
+
+  /**
+   * Cell identity for this handle() call. Set only for a single-work cell of a
+   * scheduled occurrence; null for ad-hoc runs and N-works-per-run targets, which
+   * have no single (slotId,targetId) -> workId identity to honour.
+   */
+  private execution: TargetExecutionContext | null = null;
 
   constructor(
     private readonly client: IPixivClient,
@@ -27,8 +36,19 @@ export class NovelTargetHandler {
     private readonly deliveryService?: DeliveryService
   ) {}
 
-  async handle(target: TargetConfig): Promise<TargetOutcome> {
+  async handle(target: TargetConfig, execution?: TargetExecutionContext): Promise<TargetOutcome> {
     this.outcomes = [];
+    this.execution = execution && isSingleWorkCell(target) ? execution : null;
+
+    // A cell that already owns a work is in RECOVERY, not in a new selection.
+    // Crash/shutdown recovery is not an intentional second run: running the
+    // candidate pipeline here would re-rank and could bind this logical item to a
+    // different work than the one it already committed to.
+    if (this.execution?.lockedWorkId) {
+      await this.recoverLockedWork(target, this.execution.lockedWorkId);
+      return this.summarize();
+    }
+
     if (target.novelId !== undefined && target.novelId !== null && target.novelId !== ('' as unknown)) {
       const novelNum = typeof target.novelId === 'number' ? target.novelId : Number(target.novelId);
       if (!Number.isFinite(novelNum)) {
@@ -535,13 +555,102 @@ export class NovelTargetHandler {
     });
   }
 
+  /**
+   * Continue the work this cell ALREADY owns. Selection is deliberately skipped:
+   * no search, no ranking, no topic expansion, no backfill pool, and no
+   * "already downloaded / already delivered" exclusion — the cell's own work must
+   * never be filtered out of its own recovery.
+   *
+   * A locked work that is permanently gone is a terminal failure of THIS logical
+   * item (`LOCKED_WORK_UNAVAILABLE`). It is never silently replaced by another
+   * candidate; that would mutate the item's identity behind the operator's back.
+   */
+  private async recoverLockedWork(target: TargetConfig, lockedWorkId: string): Promise<void> {
+    const displayTag = getTargetLabel(target);
+    logger.info(`Recovering locked work ${lockedWorkId} for ${displayTag}; candidate selection is skipped`, {
+      slotId: this.execution?.slotId,
+      targetId: this.execution?.targetId,
+      lockedWorkId,
+    });
+
+    const novelId = Number(lockedWorkId);
+    if (!Number.isFinite(novelId)) {
+      this.outcomes.push({
+        kind: 'failed',
+        retryable: false,
+        error: `LOCKED_WORK_UNAVAILABLE: cell work id "${lockedWorkId}" is not a valid novel id`,
+      });
+      return;
+    }
+
+    try {
+      const detail = await this.client.getNovelDetail(novelId);
+      const novel: PixivNovel = {
+        id: detail.id,
+        title: detail.title,
+        user: detail.user,
+        create_date: detail.create_date,
+      };
+      await this.downloadAndDeliver(novel, `novel-${novelId}`, target);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const retryable = isRetryableNetworkError(error);
+      this.logError(error, `Failed to recover locked novel ${lockedWorkId}`);
+      this.outcomes.push({
+        kind: 'failed',
+        retryable,
+        error: retryable
+          ? `locked work ${lockedWorkId} could not be fetched (will retry the SAME work): ${message}`
+          : `LOCKED_WORK_UNAVAILABLE: locked work ${lockedWorkId} is no longer fetchable: ${message}`,
+      });
+    }
+  }
+
+  /**
+   * Process ONE candidate work for this cell.
+   *
+   * The cell is bound to `novel` BEFORE any side effect: it is the binding, not
+   * the candidate list, that decides what a later recovery resumes. The binding
+   * is only rolled back when the attempt produced no artifact at all, so in-run
+   * backfill still works for a cell that has committed to nothing.
+   */
   private async downloadAndDeliver(
     novel: PixivNovel,
     tag: string,
     target: TargetConfig
   ): Promise<void> {
-    const artifact = await this.novelDownloader.download(novel, tag, target);
-    if (!artifact) return;
+    const execution = this.execution;
+    const workId = String(novel.id);
+    // Recovery continues a work the cell already bound; it must never be released.
+    const recovering = Boolean(execution?.lockedWorkId);
+    if (execution && !recovering) {
+      const binding = execution.bind(workId, 'novel');
+      if (!binding.won) {
+        // Another writer elected a different work for this cell. First selection
+        // is authoritative: never process a work the cell does not own.
+        logger.warn(`Cell is bound to work ${binding.workId}; declining to select ${workId}`, {
+          slotId: execution.slotId,
+          targetId: execution.targetId,
+          boundWorkId: binding.workId,
+        });
+        return;
+      }
+    }
+
+    let artifact: DownloadedArtifact | undefined;
+    try {
+      artifact = await this.novelDownloader.download(novel, tag, target);
+    } catch (error) {
+      // Nothing was persisted, so the cell may still pick another candidate.
+      if (execution && !recovering) execution.release(workId);
+      throw error;
+    }
+    if (!artifact) {
+      if (execution && !recovering) execution.release(workId);
+      return;
+    }
+    // Committed: the artifact is durable and this work now defines the cell. Even
+    // if the delivery below throws, recovery must resume THIS work — never release.
     const isDelivery = target.storageMode === 'cache' && target.delivery?.target?.trim();
     if (!isDelivery || !this.deliveryService) {
       this.outcomes.push({ kind: 'stored', workId: artifact.pixivId, workType: artifact.type });

--- a/src/scheduler/SlotCoordinator.ts
+++ b/src/scheduler/SlotCoordinator.ts
@@ -15,6 +15,7 @@ import {
   scheduleTimezone,
 } from './OccurrenceResolver';
 import { TargetOutcome } from './TargetOutcome';
+import { TargetExecutionContext, WorkBinding, isSingleWorkCell } from './WorkIdentity';
 
 /**
  * Execution-lease TTL and heartbeat cadence.
@@ -73,6 +74,38 @@ export interface SlotResolveResult {
 }
 
 /**
+ * What a `delivery_pending` cell still owes downstream, read from the durable
+ * delivery ledger.
+ *
+ *  - `live`      : a non-terminal intent still owns the cell — the outbox is
+ *                  retrying THAT work toward a terminal ACK.
+ *  - `confirmed` : the ACK already landed but the cell promotion was lost.
+ *  - `lost`      : the intent is terminally failed; nobody will converge it.
+ *  - `unknown`   : no delivery fact for this cell (not a delivery cell).
+ */
+export type CellDeliveryState =
+  | { kind: 'live' }
+  | { kind: 'confirmed'; workId: string; workType: string }
+  | { kind: 'lost'; reason: string }
+  | { kind: 'unknown' };
+
+/**
+ * Port for the delivery ledger, injected by the runtime. It lets the slot FSM
+ * hand a `delivery_pending` cell to whoever owns its delivery without this class
+ * learning anything about TelePost, bots or any hosting platform (see below).
+ */
+export interface SchedulerDeliveryPort {
+  stateFor(input: { deliveryTarget: string; slotId: string; targetId: string }): CellDeliveryState;
+}
+
+/** The delivery channel a scheduled cell publishes to (null = download-only). */
+function deliveryTargetOf(target: TargetConfig): string | null {
+  if (target.storageMode !== 'cache') return null;
+  const name = target.delivery?.target;
+  return typeof name === 'string' && name.trim() ? name.trim() : null;
+}
+
+/**
  * Owns the Schedule Slot ledger for one scheduler run. A Slot is one durable
  * execution occurrence of a Schedule (NOT a morning/evening row). It ensures
  * duplicate/concurrent/retry triggers converge on one slot, completed cells are
@@ -83,7 +116,10 @@ export interface SlotResolveResult {
  * hosting platform — only schedules, targets and the slot ledger.
  */
 export class SlotCoordinator {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly delivery?: SchedulerDeliveryPort
+  ) {}
 
   /**
    * Resolve + validate the canonical occurrence for a trigger. Uses ONLY the
@@ -192,15 +228,70 @@ export class SlotCoordinator {
       const cell = this.database.slots.getCell(slotId, target.id);
       if (!cell) continue;
       if (cell.status === 'submitted' || cell.status === 'no_candidate') continue;
+      // A cell whose work already has a durable delivery intent is NOT the
+      // scheduler's to re-run: the OutboxWorker retries the SAME work to a
+      // terminal ACK. Re-selecting here is what let recovery stop pointing at the
+      // cell's own work (or enqueue a second one), so it is delegated instead.
+      if (cell.status === 'delivery_pending' && isSingleWorkCell(target) && this.settlePendingDelivery(slotId, target)) {
+        continue;
+      }
       out.push({ target, cell });
     }
     return out;
+  }
+
+  /**
+   * Build the per-target execution contexts for one run, so every handler
+   * receives the cell's durable identity instead of just a TargetConfig.
+   *
+   * This is the boundary where the identity used to be dropped (`pending` was
+   * reduced to `p.target`), which is what let a resume re-rank and re-point the
+   * logical item at a different work.
+   */
+  executionContextsFor(
+    slotId: string,
+    entries: { target: TargetConfig; cell: SlotItemRecord | null }[]
+  ): Map<string, TargetExecutionContext> {
+    const contexts = new Map<string, TargetExecutionContext>();
+    for (const { target, cell } of entries) {
+      if (!target.id || !cell) continue;
+      const targetId = target.id;
+      contexts.set(targetId, {
+        slotId,
+        targetId,
+        lockedWorkId: cell.workId,
+        bind: (workId, workType) => this.lockWorkCas(slotId, targetId, workId, workType),
+        release: (workId) => this.releaseWorkCas(slotId, targetId, workId),
+      });
+    }
+    return contexts;
   }
 
   /** Lock the selected work for a cell (first selection wins; retries keep it). */
   lockWork(slotId: string, targetId: string, workId: string, workType: string): void {
     this.database.slots.ensureCell(slotId, targetId, workType);
     this.database.slots.lockCellWork(slotId, targetId, workId, workType);
+  }
+
+  /**
+   * CAS-bind a cell to the work a handler is about to process. Returns the
+   * authoritative binding: when another worker already elected a different work,
+   * `won` is false and the caller MUST continue with the returned `workId`
+   * instead of its own candidate.
+   */
+  lockWorkCas(slotId: string, targetId: string, workId: string, workType: string): WorkBinding {
+    this.database.slots.ensureCell(slotId, targetId, workType);
+    const { cell, won } = this.database.slots.tryLockCellWork(slotId, targetId, workId, workType);
+    return { workId: cell.workId ?? workId, won };
+  }
+
+  /**
+   * Release a provisional binding whose work produced no local artifact, so the
+   * next candidate of an UNBOUND cell can be tried. Refused once anything was
+   * committed (see SlotRepository.releaseCellWork).
+   */
+  releaseWorkCas(slotId: string, targetId: string, workId: string): void {
+    this.database.slots.releaseCellWork(slotId, targetId, workId);
   }
 
   /** Record a cell's terminal state from the download/delivery outcome. */
@@ -261,6 +352,53 @@ export class SlotCoordinator {
   markDelivered(slotId: string, targetId: string, workId: string, workType: string): void {
     this.database.slots.lockCellWork(slotId, targetId, workId, workType);
     this.safeTransition(slotId, targetId, 'submitted');
+  }
+
+  /**
+   * Decide what a `delivery_pending` cell owes, from the durable delivery
+   * ledger, and converge the FSM accordingly. Returns true when the scheduler
+   * must NOT run the target handler for it.
+   *
+   * Once an intent is durable the outbox owns the delivery: re-running selection
+   * could only produce a DIFFERENT work for the same logical item (and a second
+   * delivery, since the delivery idempotency key is work-scoped). A terminally
+   * failed delivery is converged explicitly — never "repaired" by picking
+   * another work behind the operator's back.
+   */
+  private settlePendingDelivery(slotId: string, target: TargetConfig): boolean {
+    const deliveryTarget = deliveryTargetOf(target);
+    if (!deliveryTarget || !this.delivery || !target.id) return false;
+    const state = this.delivery.stateFor({ deliveryTarget, slotId, targetId: target.id });
+    switch (state.kind) {
+      case 'live':
+        logger.info('Cell delivery still owned by the outbox; selection not re-run', {
+          slot: slotId,
+          target: target.id,
+          deliveryTarget,
+        });
+        return true;
+      case 'confirmed':
+        // The ACK landed but the promotion was lost (crash between the delivery
+        // ledger write and the cell transition). Heal from the ledger — the work
+        // IS delivered, so re-selecting would post a second one.
+        logger.info('Cell delivery already confirmed; promoting the cell from the ledger', {
+          slot: slotId,
+          target: target.id,
+          workId: state.workId,
+        });
+        this.markDelivered(slotId, target.id, state.workId, state.workType);
+        return true;
+      case 'lost':
+        logger.warn('Cell delivery failed terminally; failing the cell instead of re-selecting', {
+          slot: slotId,
+          target: target.id,
+          reason: state.reason,
+        });
+        this.applyOutcome(slotId, target.id, { kind: 'failed', retryable: false, error: state.reason });
+        return true;
+      case 'unknown':
+        return false;
+    }
   }
 
   private safeTransition(

--- a/src/scheduler/WorkIdentity.ts
+++ b/src/scheduler/WorkIdentity.ts
@@ -1,0 +1,62 @@
+import { TargetConfig } from '../config';
+
+/**
+ * Work identity for a scheduled cell.
+ *
+ * Invariant: (slotId, targetId) -> ONE stable workId. The first selection wins,
+ * and every later crash / shutdown / lease recovery continues with THAT work.
+ * Re-running candidate selection on resume silently re-points the logical item
+ * at a different work (A -> B): the item then reports success while A sits
+ * downloaded-but-never-delivered, and if A's delivery intent was already
+ * durable both A and B get posted under different idempotency identities.
+ */
+export interface WorkBinding {
+  /** Authoritative work id for the cell after the attempt (the CAS winner). */
+  workId: string;
+  /** True when this caller established — or already held — the binding. */
+  won: boolean;
+}
+
+/**
+ * Per-cell execution context handed to a target handler, so the cell's identity
+ * travels with the work instead of being dropped at the dispatch boundary.
+ *
+ * `lockedWorkId` is an authoritative INPUT: when it is set, the handler must
+ * continue exactly that work and must not run ranking / topic selection /
+ * backfill / already-seen filtering. `bind()` is called for a candidate BEFORE
+ * any of its side effects, so a crash during the download can never resume the
+ * cell onto a different work.
+ */
+export interface TargetExecutionContext {
+  readonly slotId: string;
+  readonly targetId: string;
+  /** The work this logical item is already bound to; null for a fresh cell. */
+  readonly lockedWorkId: string | null;
+  /** CAS-bind the cell to `workId`; returns the authoritative binding. */
+  bind(workId: string, workType: string): WorkBinding;
+  /** Roll back a provisional binding for a work that produced no artifact. */
+  release(workId: string): void;
+}
+
+/**
+ * True when one cell of this target selects at most ONE work per run — the only
+ * shape the (slotId, targetId) -> workId invariant can hold for.
+ *
+ * A target that intentionally pulls N works per run (limit > 1, a novel series,
+ * a user feed) owns N works inside a single cell, so pinning that cell to one
+ * locked id on resume would silently shrink the run to a single work. Those keep
+ * per-run candidate selection; the work-identity contract covers single-work
+ * cells, which is what a scheduled "one post per slot" target is.
+ */
+export function isSingleWorkCell(target: TargetConfig): boolean {
+  // An explicit limit is the operator's own answer to "how many per run?".
+  if (typeof target.limit === 'number' && target.limit > 0) return target.limit === 1;
+  // Pinned single-work targets.
+  if (target.type === 'novel' && target.novelId !== undefined && target.novelId !== null) return true;
+  if (target.type !== 'novel' && target.illustId) return true;
+  // N-work containers never collapse into a single identity.
+  if (target.userId) return false;
+  if (target.type === 'novel' && target.seriesId) return false;
+  // Search/ranking default to ten works per run; a topic run defaults to one.
+  return target.mode === 'topic';
+}

--- a/src/storage/repositories/DeliveryRepository.ts
+++ b/src/storage/repositories/DeliveryRepository.ts
@@ -74,6 +74,25 @@ export class DeliveryRepository extends BaseRepository {
   }
 
   /**
+   * Every delivery intent this ledger recorded for ONE slot cell, oldest first.
+   *
+   * Scoped by (slot_id, target_id) on purpose: the dedup key above is per WORK,
+   * so it structurally cannot answer "does this logical item still owe a
+   * delivery?" — which is the question crash recovery has to ask before it is
+   * allowed to re-run selection for a `delivery_pending` cell.
+   */
+  listForCell(deliveryTarget: string, slotId: string, targetId: string): DeliveryRow[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM deliveries
+         WHERE delivery_target = ? AND slot_id = ? AND target_id = ?
+         ORDER BY created_at ASC`
+      )
+      .all(deliveryTarget, slotId, targetId) as any[];
+    return rows.map((r) => this.toRow(r));
+  }
+
+  /**
    * True when this exact work is already CONFIRMED (delivered, or an attested
    * historical duplicate) for this target. Pending/failed intents do not block
    * selection — they are retried, not treated as a delivered fact.

--- a/src/storage/repositories/OutboxRepository.ts
+++ b/src/storage/repositories/OutboxRepository.ts
@@ -123,6 +123,26 @@ export class OutboxRepository extends BaseRepository {
     return row ? this.toRow(row) : null;
   }
 
+  /**
+   * True when this delivery intent still has a row the worker can act on
+   * (pending / claimed / waiting to retry).
+   *
+   * This is the "the outbox still owns it" test. A delivery whose outbox row is
+   * done/dead/cancelled is NOT actionable: whatever happened downstream is
+   * terminal, so nobody is going to converge that delivery by retrying it.
+   */
+  hasActionableDelivery(deliveryId: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT 1 FROM outbox
+         WHERE delivery_id = ? AND kind = 'delivery'
+           AND status IN ('pending','processing','retry_wait')
+         LIMIT 1`
+      )
+      .get(deliveryId);
+    return Boolean(row);
+  }
+
   list(status?: OutboxStatus, limit = 100): OutboxRow[] {
     const bounded = Math.max(1, Math.min(Math.trunc(limit), 500));
     const rows = status

--- a/src/storage/repositories/SlotRepository.ts
+++ b/src/storage/repositories/SlotRepository.ts
@@ -217,6 +217,62 @@ export class SlotRepository extends BaseRepository {
     return this.getCell(slotId, targetId)!;
   }
 
+  /**
+   * Compare-and-set the cell's work binding, with real concurrency semantics.
+   *
+   * `lockCellWork` above only stops *this* process from overwriting an existing
+   * id (COALESCE); it cannot elect a winner between two callers that both read
+   * "no binding". This one can: the write is guarded by `work_id IS NULL OR
+   * work_id = @workId`, so if two workers select A and B at the same instant
+   * exactly one UPDATE lands. The returned record is authoritative — a losing
+   * caller MUST continue with `cell.workId`, never with its own candidate, or
+   * the cell would process a work it does not own.
+   */
+  public tryLockCellWork(
+    slotId: string,
+    targetId: string,
+    workId: string,
+    workType: string
+  ): { cell: SlotItemRecord; won: boolean } {
+    this.db
+      .prepare(
+        `UPDATE schedule_slot_items
+         SET work_id = @workId,
+             work_type = CASE WHEN work_id IS NULL THEN @workType ELSE work_type END,
+             status = CASE WHEN status = 'pending' THEN 'selected' ELSE status END,
+             attempt_count = CASE WHEN work_id IS NULL THEN attempt_count + 1 ELSE attempt_count END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE slot_id = @slotId AND target_id = @targetId
+           AND (work_id IS NULL OR work_id = @workId)`
+      )
+      .run({ slotId, targetId, workId, workType });
+    const cell = this.getCell(slotId, targetId)!;
+    return { cell, won: cell.workId === workId };
+  }
+
+  /**
+   * Roll back a PROVISIONAL binding taken for a work that produced no local
+   * artifact (a candidate that failed while the cell was still unbound).
+   *
+   * Deliberately narrow: it only clears the row while it still holds exactly
+   * `workId` AND is still `selected`. Once the cell moved on (an artifact was
+   * persisted -> delivery_pending/submitted/..., or another writer rebound it)
+   * the release is refused, so it can never erase a committed work identity.
+   * Re-selecting is only ever allowed while nothing was committed — that is what
+   * keeps (slotId,targetId) -> workId stable.
+   */
+  public releaseCellWork(slotId: string, targetId: string, workId: string): boolean {
+    const info = this.db
+      .prepare(
+        `UPDATE schedule_slot_items
+         SET work_id = NULL, status = 'pending', updated_at = CURRENT_TIMESTAMP
+         WHERE slot_id = @slotId AND target_id = @targetId
+           AND work_id = @workId AND status = 'selected'`
+      )
+      .run({ slotId, targetId, workId });
+    return info.changes > 0;
+  }
+
   /** Explicit operator action: forget the locked work so a re-run picks another candidate. */
   public clearCellWork(slotId: string, targetId: string): void {
     this.db


### PR DESCRIPTION
## Invariant

`ONE SLOT + ONE TARGET/CELL = ONE STABLE WORK IDENTITY` — `(slotId, targetId) -> first selected workId wins`.

Recovery (crash / shutdown / lease resume) is **not** an intentional second run. It must continue the work the cell already owns.

## Root cause

`pendingTargets()` reduced `pending` to `p.target`, dropping `cell.workId`. The handler therefore could not tell a first selection from a recovery, re-ran the candidate pipeline, and `downloads` filtered out the work the cell already had — so the resume bound the logical item to a **different** work (A -> B), leaving A downloaded-but-never-delivered while the item reported success.

## Fix (A + C)

**A — persist logical-item identity, lock before side effects.** Lifecycle changes from `SELECT -> DOWNLOAD -> SIDE EFFECTS -> OUTCOME -> LOCK` to `SELECT -> LOCK -> SIDE EFFECTS`.

- `SlotRepository.tryLockCellWork()` is compare-and-set (`work_id IS NULL OR work_id = @workId`), so **first-selection-wins** holds under concurrency; the losing worker reloads and uses the winner.
- The handler receives `{ target, slotId, cell, lockedWorkId }` via `TargetExecutionContext`.
- A locked cell is recovered by fetching the **exact work by id**, bypassing ranking / topic selection / backfill / downloads-filtering. `downloads`/`deliveries`/`history` never filter out a cell's own locked work.
- A permanently-gone locked work is terminal `LOCKED_WORK_UNAVAILABLE` — the item fails **as A**, it is never silently replaced by B.

**C — `delivery_pending` delegates to the durable outbox.** A cell with a valid non-terminal outbox/delivery intent does **not** invoke the handler / ranking / re-download / re-enqueue; it is delegated to the durable outbox. Lives repository state decides the answer:
- `live` -> skip (the outbox will ACK it);
- `confirmed` -> promote from the ledger (no second post);
- `lost` -> converge to an explicit terminal failure (never re-rank as B);
- `unknown` -> run.

N-works-per-run targets (no single identity) still run normally.

## Delivery idempotency

The key is unchanged: `pixivflow:<target>:<type>:<pixivId>:<slotId>:<targetId>`. A test now proves the **same locked workId -> same idempotency identity**, and a swapped work would map to a different one.

## Tests

- New: `workIdentity.test.ts`, `workIdentityRecovery.test.ts`, `DeliveryLedgerPort.test.ts`; strengthened `SlotCoordinator.test.ts`.
- Covers: lock-before-side-effect, resume resumes the SAME work, first-selection-wins race, provisional release, shutdown resume, timeout stays terminal (unchanged), `LOCKED_WORK_UNAVAILABLE`, backfill, N-work targets, delivery_pending ownership, work-bound idempotency.
- The bug was reproduced behaviorally against the old implementation (work 200 processed for a cell owning 100) before the fix.
- Full suite: **71 suites / 669 tests pass**; `tsc --noEmit` clean.

## Scope

- Branch `fix/recovery-selection-stability`, based on latest `origin/master`.
- **No deploy, no restart, no prod DB mutation, no second trigger.** Production stays FROZEN; Attempt 2 remains OBSERVATION_PENDING.
- No schema migration.
- Does **not** implement B (auto-select replacement work); not mixed with the Attempt 2 HTTP/timeout blocker.

## Commits

- `deb4ba4` fix(scheduler): preserve locked work identity across recovery
- `fbfab96` test(scheduler): pin shutdown resume, timeout terminality and work-bound delivery idempotency