### PR TITLE
fix(search): advance pager cursor across fallback pages

### DIFF
--- a/src/__tests__/pixiv-client/TargetSearchRunner.pagination.test.ts
+++ b/src/__tests__/pixiv-client/TargetSearchRunner.pagination.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression: date-aware pagination must advance the kit's next_url cursor.
+ *
+ * Root cause of CONTROLLED_V4_E2E_ATTEMPT_2 (2026-09-12):
+ * TargetSearchRunner passed the cursor inside the options object, but the kit's
+ * `searchPage(options, cursor)` reads it from its SECOND POSITIONAL argument.
+ * The cursor therefore stayed `null`, page 1 (the newest works) was re-fetched
+ * on every iteration, and a fallback day whose page 1 holds no in-range work
+ * never terminated: the tag search never returned, the pipeline never moved on,
+ * and the run burned the full 1800s schedule timeout while hammering
+ * /v1/search/illust until Pixiv answered 429.
+ *
+ * The date bounds below are deliberately far apart so the assertions hold in
+ * any host timezone.
+ */
+
+import type {
+  PixivClient as KitPixivClient,
+  PixivIllust,
+  PixivNovel,
+  IllustSearchOptions,
+  NovelSearchOptions,
+} from '@redtidev/pixiv-client';
+
+import { TargetSearchRunner } from '../../pixiv-client/TargetSearchRunner';
+import { PaginationError } from '../../utils/errors';
+import type { TargetConfig } from '../../config';
+
+jest.mock('../../logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+/** A day that predates the newest page, exactly like a lookback/fallback day. */
+const TARGET_DAY = { startDate: '2026-09-01', endDate: '2026-09-11' };
+const NEWER_THAN_RANGE = '2026-09-20T12:00:00Z';
+const INSIDE_RANGE = '2026-09-10T12:00:00Z';
+
+/** Fail fast when a pager stops advancing instead of looping forever. */
+const MAX_PAGE_FETCHES = 4;
+
+function makeTarget(): TargetConfig {
+  return {
+    tag: 'botehara',
+    sort: 'date_desc',
+    searchTarget: 'partial_match_for_tags',
+    limit: 1,
+    ...TARGET_DAY,
+  } as unknown as TargetConfig;
+}
+
+interface Recorded {
+  word: string;
+  cursor: string | null;
+}
+
+describe('TargetSearchRunner pagination cursor', () => {
+  it('walks the kit next_url cursor instead of re-fetching page 1 (fallback-day hang)', async () => {
+    const calls: Recorded[] = [];
+    const kit = {
+      illustrations: {
+        searchPage: async (options: IllustSearchOptions, cursor: string | null = null) => {
+          calls.push({ word: options.word, cursor });
+          if (calls.length > MAX_PAGE_FETCHES) {
+            throw new Error(
+              `pager never advanced: /v1/search/illust page 1 fetched ${calls.length} times`
+            );
+          }
+          if (cursor === null) {
+            // Newest page: every work is newer than the target day -> the date
+            // walk can neither include nor stop, so only the cursor can end it.
+            return {
+              items: [1, 2, 3].map(
+                (n) => ({ id: 1000 + n, create_date: NEWER_THAN_RANGE }) as unknown as PixivIllust
+              ),
+              next: 'PAGE2',
+            };
+          }
+          if (cursor === 'PAGE2') {
+            return {
+              items: [{ id: 2001, create_date: INSIDE_RANGE } as unknown as PixivIllust],
+              next: null,
+            };
+          }
+          throw new Error(`unexpected cursor: ${cursor}`);
+        },
+      },
+    } as unknown as KitPixivClient;
+
+    const result = await new TargetSearchRunner(kit).searchIllustrations(makeTarget(), 0);
+
+    expect(result.map((i) => i.id)).toEqual([2001]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].cursor).toBeNull();
+    // The regression: the cursor returned by page 1 must be handed back to the kit.
+    expect(calls[1].cursor).toBe('PAGE2');
+  });
+
+  it('walks the kit next_url cursor for novels too', async () => {
+    const calls: Recorded[] = [];
+    const kit = {
+      novels: {
+        searchPage: async (options: NovelSearchOptions, cursor: string | null = null) => {
+          calls.push({ word: options.word, cursor });
+          if (calls.length > MAX_PAGE_FETCHES) {
+            throw new Error(
+              `pager never advanced: /v1/search/novel page 1 fetched ${calls.length} times`
+            );
+          }
+          if (cursor === null) {
+            return {
+              items: [{ id: 3001, create_date: NEWER_THAN_RANGE } as unknown as PixivNovel],
+              next: 'NOVEL2',
+            };
+          }
+          if (cursor === 'NOVEL2') {
+            return {
+              items: [{ id: 3002, create_date: INSIDE_RANGE } as unknown as PixivNovel],
+              next: null,
+            };
+          }
+          throw new Error(`unexpected cursor: ${cursor}`);
+        },
+      },
+    } as unknown as KitPixivClient;
+
+    const result = await new TargetSearchRunner(kit).searchNovels(makeTarget(), 0);
+
+    expect(result.map((i) => i.id)).toEqual([3002]);
+    expect(calls.map((c) => c.cursor)).toEqual([null, 'NOVEL2']);
+  });
+
+  it('fails explicitly when the adapter keeps handing back the same cursor', async () => {
+    const calls: Recorded[] = [];
+    const kit = {
+      illustrations: {
+        searchPage: async (options: IllustSearchOptions, cursor: string | null = null) => {
+          calls.push({ word: options.word, cursor });
+          // Every page advertises the same next cursor. Even with a correct
+          // passthrough this would repeat the same page forever, so the pager
+          // must refuse rather than keep issuing requests.
+          return {
+            items: [1, 2, 3].map(
+              (n) => ({ id: 1000 + n, create_date: NEWER_THAN_RANGE }) as unknown as PixivIllust
+            ),
+            next: 'STUCK',
+          };
+        },
+      },
+    } as unknown as KitPixivClient;
+
+    await expect(
+      new TargetSearchRunner(kit).searchIllustrations(makeTarget(), 0)
+    ).rejects.toBeInstanceOf(PaginationError);
+    // Bounded: page 1 once, then the repeat is detected on the second request.
+    expect(calls).toHaveLength(2);
+  });
+
+  it('fails explicitly on a cursor cycle (A -> B -> A)', async () => {
+    const calls: Recorded[] = [];
+    const cycle: Record<string, string> = { A: 'B', B: 'A' };
+    const kit = {
+      illustrations: {
+        searchPage: async (options: IllustSearchOptions, cursor: string | null = null) => {
+          calls.push({ word: options.word, cursor });
+          return {
+            items: [{ id: 1001, create_date: NEWER_THAN_RANGE } as unknown as PixivIllust],
+            next: cursor === null ? 'A' : cycle[cursor],
+          };
+        },
+      },
+    } as unknown as KitPixivClient;
+
+    await expect(
+      new TargetSearchRunner(kit).searchIllustrations(makeTarget(), 0)
+    ).rejects.toBeInstanceOf(PaginationError);
+    // null -> A -> B -> (A repeats) => three bounded requests, never an infinite loop.
+    expect(calls.map((c) => c.cursor)).toEqual([null, 'A', 'B']);
+  });
+});

--- a/src/__tests__/topic/TopicFeature.test.ts
+++ b/src/__tests__/topic/TopicFeature.test.ts
@@ -13,6 +13,7 @@ import { TopicCache } from '../../topic/TopicCache';
 import { TopicResolver } from '../../topic/TopicResolver';
 import { TopicPipeline } from '../../topic/TopicPipeline';
 import type { TopicClient, WorkLike } from '../../topic/types';
+import { PaginationError } from '../../utils/errors';
 
 const tag = (name: string) => ({ name });
 const work = (id: number, tags: string[], opts: Partial<WorkLike> = {}): WorkLike => ({
@@ -333,5 +334,26 @@ describe('TopicPipeline', () => {
     for (const s of seen) {
       expect(s.includeR18).toBe(true);
     }
+  });
+
+  it('propagates a broken pager contract instead of degrading it into "no works today"', async () => {
+    // A non-terminating cursor is a deterministic contract violation. Swallowing
+    // it as "no results for this tag" would hide the failure and let the run
+    // report success, so the collector must rethrow it.
+    const brokenClient: TopicClient = {
+      getTagAutocomplete: async () => [{ name: 'seed' }],
+      searchIllustrationsForTags: async () => {
+        throw new PaginationError('Search pager for tag "seed" did not advance');
+      },
+      searchNovelsForTags: async () => [],
+    };
+    const dir = await fs.mkdtemp(join(os.tmpdir(), 'topic-pager-'));
+    const resolver = new TopicResolver(brokenClient, new TopicCache(dir), 0);
+    const pipeline = new TopicPipeline(brokenClient, resolver, 0);
+    const target = { type: 'illustration', mode: 'topic', topic: 'seed' } as never;
+
+    await expect(
+      pipeline.selectWorks(target, 'illustration', DAY, 1, {}, {})
+    ).rejects.toBeInstanceOf(PaginationError);
   });
 });

--- a/src/pixiv-client/TargetSearchRunner.ts
+++ b/src/pixiv-client/TargetSearchRunner.ts
@@ -11,7 +11,7 @@ import { logger } from '../logger';
 import { parseDateRange } from '../utils/date-utils';
 import { isDateInRange } from '../utils/date-utils';
 import { sortPixivItems } from '../utils/pixiv-sort';
-import { throwIfAborted } from '../utils/errors';
+import { PaginationError, throwIfAborted } from '../utils/errors';
 import type { TargetConfig } from '../config';
 import { mapTargetToIllustQuery, mapTargetToNovelQuery } from './query-mapper';
 
@@ -86,7 +86,7 @@ export class TargetSearchRunner {
       target,
       tag,
       requestDelayMs,
-      (options) => this.kit.illustrations.searchPage(options),
+      (options, cursor) => this.kit.illustrations.searchPage(options, cursor),
       (t, g) => mapTargetToIllustQuery({ ...t, tag: g }),
       signal
     );
@@ -102,7 +102,7 @@ export class TargetSearchRunner {
       target,
       tag,
       requestDelayMs,
-      (options) => this.kit.novels.searchPage(options),
+      (options, cursor) => this.kit.novels.searchPage(options, cursor),
       (t, g) => mapTargetToNovelQuery({ ...t, tag: g }),
       signal
     );
@@ -120,11 +120,11 @@ export class TargetSearchRunner {
     target: TargetConfig,
     tag: string,
     requestDelayMs: number,
-    fetchPage: (options: O) => Promise<{ items: T[]; next: string | null }>,
+    fetchPage: (options: O, cursor: string | null) => Promise<{ items: T[]; next: string | null }>,
     buildBase: (t: TargetConfig, tag: string) => O,
     signal?: AbortSignal
   ): Promise<T[]> {
-    const fetchOne = fetchPage as (options: IllustSearchOptions | NovelSearchOptions) => Promise<{ items: T[]; next: string | null }>;
+    const fetchOne = fetchPage as (options: IllustSearchOptions | NovelSearchOptions, cursor: string | null) => Promise<{ items: T[]; next: string | null }>;
     logger.debug('Searching Pixiv', {
       tag,
       sort: target.sort,
@@ -154,24 +154,45 @@ export class TargetSearchRunner {
     let cursor: string | null = null;
     let pageCount = 0;
     let shouldStop = false;
+    // Progress invariant: every iteration must terminate, advance to a cursor we
+    // have never fetched, or fail explicitly. A cursor that repeats (same `next`
+    // twice, or an A -> B -> A cycle) proves the upstream adapter is not making
+    // progress; re-requesting would spin forever, so we refuse instead.
+    const seenCursors = new Set<string>();
 
     while ((!fetchLimit || results.length < fetchLimit) && !shouldStop) {
       throwIfAborted(signal, 'search cancelled');
       pageCount++;
       // Dates are intentionally filtered CLIENT-side below (legacy behavior;
       // PixivFlow needs the early-stop walk on create_date).
-      const page = await fetchOne({
-        word: base.word,
-        sort: base.sort,
-        searchTarget: base.searchTarget,
-        includeR18: base.includeR18,
-        cursor,
-        // Threaded into the kit transport, which combines it with its per-request
-        // timeout and honours it in retry back-off. Without this the pager could
-        // stay blocked in a single hung request for the rest of the run.
-        signal,
-      });
-      cursor = page.next;
+      //
+      // The cursor must travel as searchPage's SECOND POSITIONAL argument: the
+      // kit reads `options.cursor` only inside its own `search()`. Putting it in
+      // the options object left the cursor permanently null, so page 1 (the
+      // newest works) was re-fetched on every iteration and a search that found
+      // no in-range work on that page never terminated.
+      const page = await fetchOne(
+        {
+          word: base.word,
+          sort: base.sort,
+          searchTarget: base.searchTarget,
+          includeR18: base.includeR18,
+          signal,
+        },
+        cursor
+      );
+      const nextCursor = page.next;
+      if (nextCursor !== null) {
+        if (nextCursor === cursor || seenCursors.has(nextCursor)) {
+          throw new PaginationError(
+            `Search pager for tag "${tag}" did not advance: page ${pageCount} returned a cursor that ` +
+              (nextCursor === cursor ? 'equals the one just fetched' : 'was already fetched') +
+              `. Refusing to re-request it indefinitely.`
+          );
+        }
+        seenCursors.add(nextCursor);
+      }
+      cursor = nextCursor;
 
       for (const item of page.items) {
         const decision = this.filterItemByDate(item, target, startDate, endDate, sortMode);

--- a/src/topic/TopicPipeline.ts
+++ b/src/topic/TopicPipeline.ts
@@ -3,7 +3,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { logger } from '../logger';
 import { calculatePopularityScore } from '../utils/pixiv-utils';
 import { isAIIllustration } from '../utils/ai-detection';
-import { rethrowIfCancelled, throwIfAborted } from '../utils/errors';
+import { PaginationError, rethrowIfCancelled, throwIfAborted } from '../utils/errors';
 import type { TargetConfig } from '../config';
 import type { TopicResolver } from './TopicResolver';
 import type {
@@ -155,6 +155,9 @@ export class TopicPipeline {
       // A cancellation must not be degraded into "no results for this tag": that
       // would silently continue the cancelled run across the remaining tags.
       rethrowIfCancelled(error, this.signal);
+      // A broken pager contract must not degrade either: reporting "no works
+      // today" would hide the failure and let the run claim success.
+      if (error instanceof PaginationError) throw error;
       logger.warn('[TopicCollector] search failed tag=' + tag + ' type=' + contentType + ': ' + (error instanceof Error ? error.message : String(error)));
       return [];
     }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -96,6 +96,19 @@ export class NetworkError extends PixivFlowError {
   }
 }
 
+/**
+ * The pagination adapter returned a cursor it had already handed back (the same
+ * `next` twice, or a cycle). Re-requesting would repeat the previous page
+ * forever, which is exactly the Attempt 2 fallback-day failure, so the pager
+ * fails deterministically instead of spinning.
+ */
+export class PaginationError extends PixivFlowError {
+  constructor(message: string, cause?: Error) {
+    super(message, 'PAGINATION_ERROR', undefined, cause);
+    this.name = 'PaginationError';
+  }
+}
+
 export class DownloadError extends PixivFlowError {
   constructor(
     message: string,


### PR DESCRIPTION
Closes the P0 blocker of the last controlled run.

## ROOT_CAUSE

`ATTEMPT_2_BLOCKER = PAGER_CURSOR_NON_TERMINATION`, `ROOT_CAUSE = CONFIRMED`.

```
handleTopicWithLookback
→ TopicPipeline.searchDay
→ searchIllustrationsForTags / novel equivalent
→ TargetSearchRunner.searchWithPagination
→ kit.*.searchPage(options, cursor)
→ @redtidev/pixiv-client Transport
→ fetch
```

This is **not** an HTTP timeout defect: the per-request timeout (30s) is present, the run `AbortSignal` is forwarded end-to-end, and both paths share the same `@redtidev/pixiv-client` `Transport`.

The real bug: `searchPage()` reads its cursor from the **second positional argument**, but the scheduler put it in `options.cursor`, which the kit ignores. The effective cursor stayed `null`, so every iteration re-requested page 1. On a fallback `date_desc` day whose page 1 is entirely newer than `endDate`:

```
shouldInclude = false (future item)
stop          = false (only an item older than startDate stops)
results       = 0
next cursor   = present but never transmitted
```

→ `page1 → page1 → page1 → ...` until `Job execution timeout 1800000ms`, with repeated Pixiv work and 429 pressure.

## Attempt 2 failure evidence

```
2026-09-12T16:41:36Z  Fetching 2026-09-11 illustrations for topic
2026-09-12T17:08:35Z  Refreshed Pixiv access token   (~28.5 min later)
2026-09-12T17:10:02Z  Job execution timeout after 1800000ms
```

## OLD FAIL / NEW PASS

Already proven locally (not re-run): with the pre-fix implementation the regression suite fails with `pager never advanced: /v1/search/illust page 1 fetched N times`; with this fix it passes.

## Fix

1. **Correctness** — illustration and novel pagers hand the current cursor to `searchPage` as its **second positional argument**. One shared implementation; no duplicated cursor logic.
2. **Defensive progress invariant** — every pagination iteration must either terminate, advance to a cursor that has never been fetched, or fail explicitly. A repeated cursor (same `next` twice) or a cycle (`A → B → A`) raises `PaginationError` instead of issuing more requests. `TopicPipeline.searchDay` rethrows it rather than degrading it into "no works today", so the failure is never silently reported as success.

## Coverage

- illustration cursor passthrough (`call #1 cursor = null`, `call #2 cursor = cursor2`, then stops)
- novel cursor passthrough
- page 1 entirely newer than `endDate` → advances instead of looping
- repeated cursor → bounded failure
- cursor cycle `A → B → A` → bounded failure
- topic: broken pager contract propagates out of `selectWorks`

No sleep-based tests.

## Scope

- No schema migration.
- No production mutation, no deploy, no restart, no trigger.
- `tsc --noEmit` clean; full suite **72 suites / 674 tests pass**.