### PR TITLE
fix(delivery): a remote failure is never an end-to-end success

### DIFF
--- a/src/__tests__/delivery/remoteDeliveryFailureSemantics.test.ts
+++ b/src/__tests__/delivery/remoteDeliveryFailureSemantics.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Regression: a provider may accept the request (HTTP 2xx) yet persist a record
+ * that is ALREADY terminally failed. That record is keyed by OUR idempotency
+ * key, so a retry only ever returns the same broken record.
+ *
+ * The production failure this pins down: TelePost answered a reused record with
+ * `status=failed, reuse_reason=idempotent_replay`; Core's ack parser classified
+ * it as `idempotent_replay`, the ledger recorded `delivered`, and the Slot cell
+ * was promoted to `submitted` — a REMOTE FAILURE REPORTED AS END-TO-END SUCCESS.
+ *
+ * The invariant: remote failure must never be reported as success. These tests
+ * fail on the pre-fix code (which surfaced `idempotent_replay`/`accepted` and a
+ * `submitted` cell) and pass only when a terminal remote status outranks the
+ * transport-level 2xx.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Database } from '../../storage/Database';
+import { OutboxWorker } from '../../delivery/OutboxWorker';
+import { DeliveryAck, parseDeliveryAck } from '../../delivery/DeliveryAck';
+import { settleDeliveryTerminal } from '../../delivery/settleDeliveryTerminal';
+import { SlotCoordinator } from '../../scheduler/SlotCoordinator';
+import { StandaloneConfig, ScheduleConfig, TargetConfig } from '../../config';
+
+const SLOT_TARGET = 'daily-illust';
+const SCHEDULE: ScheduleConfig = {
+  id: 'schedule-a',
+  name: 'Schedule A',
+  cron: '0 10 * * *',
+  timezone: 'Asia/Shanghai',
+  enabled: true,
+} as ScheduleConfig;
+const CONFIG = { schedulerRuntime: { trigger: { graceMinutes: 120 } } } as StandaloneConfig;
+// 2026-09-08 10:00 Shanghai == 02:00 UTC.
+const AT = new Date('2026-09-08T02:00:30Z');
+
+function withDb<T>(fn: (db: Database) => Promise<T> | T): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-remote-failed-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+  return Promise.resolve(fn(db)).finally(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+/** Materialize a Slot whose cell is mid-delivery (delivery_pending). */
+function prepareDeliveryCell(db: Database) {
+  const coord = new SlotCoordinator(db);
+  const slot = coord.resolveOccurrence(SCHEDULE, CONFIG, 'http', AT).context!;
+  coord.prepare(slot, SCHEDULE, [{ id: SLOT_TARGET, type: 'illustration' } as TargetConfig]);
+  coord.lockWork(slot.slotId, SLOT_TARGET, '555', 'illustration');
+  coord.markCell(slot.slotId, SLOT_TARGET, 'delivery_pending');
+  return slot;
+}
+
+function insertBoundIntent(db: Database, slotId: string) {
+  return db.deliveries.insertIntent({
+    id: 'delivery-555',
+    deliveryTarget: 'telepost',
+    workType: 'illustration',
+    pixivId: '555',
+    slotId,
+    targetId: SLOT_TARGET,
+    idempotencyKey: `pixivflow:telepost:illustration:555:${slotId}:${SLOT_TARGET}`,
+  }).row;
+}
+
+/** Minimal programmable delivery dispatcher (delivery-only tests). */
+class StubDispatcher {
+  constructor(private script: Array<() => Promise<{ ack: DeliveryAck }>>) {}
+  async isReady(): Promise<boolean> {
+    return true;
+  }
+  async deliver(): Promise<{ ack: DeliveryAck }> {
+    const step = this.script.shift();
+    if (!step) throw new Error('unexpected deliver call');
+    return step();
+  }
+  async notify(): Promise<void> {}
+}
+
+// The exact TelePost envelope for review #59: a REUSED record that is failed.
+const failedReplayEnvelope = {
+  ok: true,
+  data: {
+    status: 'failed',
+    reused: true,
+    reuse_reason: 'idempotent_replay',
+    matched_idempotency_key: 'pixivflow:telepost:illustration:555:slot-1:daily-illust',
+    review_id: 59,
+  },
+};
+
+describe('remote delivery failure semantics', () => {
+  describe('parseDeliveryAck: a terminal remote status outranks HTTP 2xx', () => {
+    it('classifies a reused FAILED record as remote_failed, not idempotent_replay', () => {
+      const ack = parseDeliveryAck(200, failedReplayEnvelope);
+      expect(ack.kind).toBe('remote_failed');
+      if (ack.kind === 'remote_failed') {
+        expect(ack.remoteStatus).toBe('failed');
+        expect(ack.remoteId).toBe('59');
+      }
+    });
+
+    it('classifies a fresh (non-reused) FAILED record as remote_failed, not accepted', () => {
+      const ack = parseDeliveryAck(200, {
+        ok: true,
+        data: { status: 'failed', reused: false, review_id: 60 },
+      });
+      expect(ack.kind).toBe('remote_failed');
+    });
+
+    it.each(['failed', 'rejected', 'invalid', 'expired'])(
+      'treats remote status %s as terminal (case-insensitive)',
+      (status) => {
+        const ack = parseDeliveryAck(200, { ok: true, data: { status, review_id: 1 } });
+        expect(ack.kind).toBe('remote_failed');
+      }
+    );
+
+    it('does NOT over-reach: a reused PUBLISHED record stays idempotent_replay', () => {
+      const ack = parseDeliveryAck(200, {
+        ok: true,
+        data: { status: 'published', reused: true, reuse_reason: 'idempotent_replay', review_id: 7 },
+      });
+      expect(ack.kind).toBe('idempotent_replay');
+    });
+
+    it('does NOT over-reach: a plain 2xx accepted record stays accepted', () => {
+      const ack = parseDeliveryAck(200, {
+        ok: true,
+        data: { status: 'preparing', reused: false, review_id: 7 },
+      });
+      expect(ack.kind).toBe('accepted');
+    });
+  });
+
+  describe('OutboxWorker: a remote_failed ack is terminal and never promoted', () => {
+    it('records the ledger as failed and never retries the (pinned) remote record', async () => {
+      await withDb(async (db) => {
+        const dispatcher = new StubDispatcher([
+          async () => ({ ack: { kind: 'remote_failed', remoteId: '59', remoteStatus: 'failed', error: 'downstream failed' } as DeliveryAck }),
+        ]);
+        const terminal: string[] = [];
+        const worker = new OutboxWorker(db, dispatcher as never, {
+          retryBaseMs: 0,
+          onDeliveryTerminal: (_id, ack) => terminal.push(ack.kind),
+        });
+        const slot = prepareDeliveryCell(db);
+        const intent = insertBoundIntent(db, slot.slotId);
+        db.outbox.enqueue({
+          kind: 'delivery',
+          deliveryTarget: 'telepost',
+          idempotencyKey: 'outbox:555',
+          deliveryId: intent.id,
+          payload: { files: [], context: { idempotencyKey: intent.idempotencyKey } },
+          maxAttempts: 5,
+        });
+
+        const first = await worker.drainOnce();
+        const second = await worker.drainOnce();
+
+        expect(first.done + second.done).toBe(1);
+        expect(second.processed).toBe(0); // nothing left to retry
+        const ledger = db.deliveries.getById(intent.id)!;
+        expect(ledger.status).toBe('failed');
+        expect(ledger.remoteStatus).toBe('failed');
+        expect(terminal).toEqual(['remote_failed']);
+      });
+    });
+  });
+
+  describe('settleDeliveryTerminal: the Slot cell follows the remote truth', () => {
+    it('settles a delivery_pending cell as failed (NEVER submitted) for remote_failed', async () => {
+      await withDb(async (db) => {
+        const slot = prepareDeliveryCell(db);
+        const intent = insertBoundIntent(db, slot.slotId);
+
+        const applied = settleDeliveryTerminal(db, intent.id, {
+          kind: 'remote_failed',
+          remoteId: '59',
+          remoteStatus: 'failed',
+          error: 'downstream reported terminal status failed',
+        });
+
+        expect(applied).toBe(true);
+        const cell = db.slots.getCell(slot.slotId, SLOT_TARGET)!;
+        expect(cell.status).toBe('failed');
+        expect(cell.status).not.toBe('submitted');
+        expect(cell.lastError).toContain('failed');
+      });
+    });
+
+    it('still promotes a confirmed accepted ack to submitted', async () => {
+      await withDb(async (db) => {
+        const slot = prepareDeliveryCell(db);
+        const intent = insertBoundIntent(db, slot.slotId);
+
+        settleDeliveryTerminal(db, intent.id, { kind: 'accepted', remoteId: '60' });
+
+        expect(db.slots.getCell(slot.slotId, SLOT_TARGET)!.status).toBe('submitted');
+      });
+    });
+
+    it('settles a historical duplicate as duplicate, not submitted', async () => {
+      await withDb(async (db) => {
+        const slot = prepareDeliveryCell(db);
+        const intent = insertBoundIntent(db, slot.slotId);
+
+        settleDeliveryTerminal(db, intent.id, {
+          kind: 'duplicate_existing',
+          remoteId: '1',
+          matchedKey: 'older-key',
+        });
+
+        expect(db.slots.getCell(slot.slotId, SLOT_TARGET)!.status).toBe('duplicate');
+      });
+    });
+
+    it('is a no-op for an intent with no Slot (ad-hoc/batch run)', async () => {
+      await withDb(async (db) => {
+        const intent = db.deliveries.insertIntent({
+          id: 'd-adhoc',
+          deliveryTarget: 'telepost',
+          workType: 'illustration',
+          pixivId: '777',
+          idempotencyKey: 'adhoc-key',
+        }).row;
+
+        expect(
+          settleDeliveryTerminal(db, intent.id, {
+            kind: 'remote_failed',
+            remoteStatus: 'failed',
+            error: 'x',
+          })
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe('end to end: 2xx envelope with status=failed never ends as submitted', () => {
+    it('runs the real parser -> outbox -> settle chain and fails the cell', async () => {
+      await withDb(async (db) => {
+        const parsed = parseDeliveryAck(200, failedReplayEnvelope);
+        const dispatcher = new StubDispatcher([async () => ({ ack: parsed })]);
+        const slot = prepareDeliveryCell(db);
+        const intent = insertBoundIntent(db, slot.slotId);
+        const worker = new OutboxWorker(db, dispatcher as never, {
+          retryBaseMs: 0,
+          onDeliveryTerminal: (deliveryId, ack) => settleDeliveryTerminal(db, deliveryId, ack),
+        });
+        db.outbox.enqueue({
+          kind: 'delivery',
+          deliveryTarget: 'telepost',
+          idempotencyKey: 'outbox:e2e',
+          deliveryId: intent.id,
+          payload: { files: [], context: { idempotencyKey: intent.idempotencyKey } },
+        });
+
+        await worker.drainOnce();
+
+        expect(db.deliveries.getById(intent.id)!.status).toBe('failed');
+        expect(db.slots.getCell(slot.slotId, SLOT_TARGET)!.status).toBe('failed');
+      });
+    });
+  });
+});

--- a/src/commands/scheduler-runtime.ts
+++ b/src/commands/scheduler-runtime.ts
@@ -27,6 +27,7 @@ import { TargetOutcome } from '../scheduler/TargetOutcome';
 import { DeliveryService } from '../delivery/DeliveryService';
 import { createDeliveryLedgerPort } from '../delivery/DeliveryLedgerPort';
 import { OutboxWorker } from '../delivery/OutboxWorker';
+import { settleDeliveryTerminal } from '../delivery/settleDeliveryTerminal';
 import { migrateLegacyOutbox } from '../delivery/LegacyOutboxMigration';
 import { DeliveryAck } from '../delivery/DeliveryAck';
 import { NotificationPolicy } from '../notification/NotificationPolicy';
@@ -332,21 +333,10 @@ export async function createSchedulerRuntime(configPathArg?: string): Promise<Sc
   const outboxWorker = new OutboxWorker(database, deliveryDispatcher, {
     retryBaseMs: config.delivery?.outboxRetryBaseMs,
     retryMaxMs: config.delivery?.outboxRetryMaxMs,
-    // A confirmed ACK promotes the delivery_pending cell to submitted.
+    // A confirmed ACK settles the owning Slot cell (submitted / duplicate /
+    // failed); see settleDeliveryTerminal for the invariant it enforces.
     onDeliveryTerminal: (deliveryId, ack) => {
-      const row = database.deliveries.getById(deliveryId);
-      if (!row || !row.slotId || !row.targetId) return;
-      if (ack.kind === 'duplicate_existing') {
-        const coord = new SlotCoordinator(database);
-        coord.applyOutcome(row.slotId, row.targetId, {
-          kind: 'duplicate',
-          workId: row.pixivId,
-          reason: 'downstream attested historical duplicate',
-        });
-        return;
-      }
-      const coord = new SlotCoordinator(database);
-      coord.markDelivered(row.slotId, row.targetId, row.pixivId, row.workType as 'illustration' | 'novel');
+      settleDeliveryTerminal(database, deliveryId, ack);
     },
   });
   const notificationPolicy = new NotificationPolicy(database, config);

--- a/src/delivery/DeliveryAck.ts
+++ b/src/delivery/DeliveryAck.ts
@@ -26,10 +26,21 @@ export type DeliveryAck =
       matchedKey?: string;
       raw?: unknown;
     }
+  /**
+   * The provider accepted the request and persisted a record, but that record
+   * is in a TERMINAL FAILURE state (`failed`/`rejected`/`invalid`/`expired`).
+   * Nothing will ever be published from this intent, and because the provider
+   * keys its record by OUR idempotency_key, another attempt only returns the
+   * same failed record. Terminal: never retried, never reported as delivered.
+   */
+  | { kind: 'remote_failed'; remoteId?: string; remoteStatus: string; error: string; raw?: unknown }
   /** Transient failure: timeouts, 5xx, 429, connection errors. Retryable. */
   | { kind: 'retryable_failure'; retryAfterMs?: number; error: string }
   /** Deterministic failure: 4xx (except 408/429), validation rejection. */
   | { kind: 'permanent_failure'; error: string };
+
+/** Downstream record states that will never become a published delivery. */
+const TERMINAL_REMOTE_STATUSES = new Set(['failed', 'rejected', 'invalid', 'expired']);
 
 /** Where the provider put the machine-readable result in its envelope. */
 export interface AckEnvelopeHints {
@@ -102,6 +113,22 @@ export function parseDeliveryAck(
     typeof idValue === 'number' ? String(idValue) : asString(idValue);
   const remoteStatus = asString(rec[h.statusField]);
   const reused = rec[h.reusedField] === true;
+  // A 2xx envelope can still describe a RECORD THAT FAILED downstream: the
+  // provider persists the record before doing the real work, so "accepted" and
+  // "the persisted record is broken" arrive on the same HTTP status. The record
+  // is what gets published (and what a retry will find again), so its terminal
+  // state outranks the transport-level success of this request — otherwise a
+  // remote failure is recorded here as an end-to-end success.
+  const terminalStatus = remoteStatus?.trim().toLowerCase();
+  if (terminalStatus && TERMINAL_REMOTE_STATUSES.has(terminalStatus)) {
+    return {
+      kind: 'remote_failed',
+      remoteId,
+      remoteStatus: terminalStatus,
+      error: `delivery endpoint reported terminal status ${terminalStatus}`,
+      raw: body,
+    };
+  }
   if (!reused) {
     return { kind: 'accepted', remoteId, remoteStatus, raw: body };
   }

--- a/src/delivery/OutboxWorker.ts
+++ b/src/delivery/OutboxWorker.ts
@@ -345,6 +345,19 @@ export class OutboxWorker {
         });
         this.onDeliveryTerminal?.(row.deliveryId, ack, payload);
         break;
+      case 'remote_failed':
+        // The provider persisted the record, but it will never publish and the
+        // idempotency key pins us to that same record forever: retrying cannot
+        // change the outcome. Terminal, so the failure reaches the Slot instead
+        // of being masked as a delivered cell. Content is kept for inspection.
+        this.database.deliveries.recordAck(row.deliveryId, {
+          status: 'failed',
+          remoteId: ack.remoteId,
+          remoteStatus: ack.remoteStatus,
+          error: ack.error,
+        });
+        this.onDeliveryTerminal?.(row.deliveryId, ack, payload);
+        break;
       case 'permanent_failure':
         // Deterministic rejection: still retry a couple times to survive a
         // misconfigured blip, the outbox max-attempts then dead-letters it.

--- a/src/delivery/settleDeliveryTerminal.ts
+++ b/src/delivery/settleDeliveryTerminal.ts
@@ -1,0 +1,63 @@
+/**
+ * Terminal-ACK settlement: the ONE place a confirmed downstream delivery ACK
+ * becomes a Slot cell state.
+ *
+ * The outbox worker already recorded the durable delivery ledger outcome before
+ * calling here; this maps that ack onto the Slot FSM. Keeping it as a named,
+ * dependency-light function (instead of an inline closure in the scheduler
+ * runtime) is what makes the central invariant directly testable:
+ *
+ *   REMOTE FAILURE MUST NOT BE REPORTED AS END-TO-END SUCCESS.
+ *
+ * A provider can answer HTTP 2xx while the record it persisted is terminally
+ * broken. The provider keys that record by OUR idempotency key, so a retry only
+ * returns the same broken record. Such an ack must settle the cell as `failed`,
+ * never promote it to `submitted` as though the content had been published.
+ */
+import type { Database } from '../storage/Database';
+import type { DeliveryAck } from './DeliveryAck';
+import { SlotCoordinator } from '../scheduler/SlotCoordinator';
+
+/**
+ * Apply a terminal delivery ack to the Slot cell that owns the delivery intent.
+ * Returns false when the delivery has no Slot cell (ad-hoc / batch runs), which
+ * is a normal no-op rather than an error.
+ */
+export function settleDeliveryTerminal(
+  database: Database,
+  deliveryId: string,
+  ack: DeliveryAck
+): boolean {
+  const row = database.deliveries.getById(deliveryId);
+  if (!row || !row.slotId || !row.targetId) return false;
+  const coord = new SlotCoordinator(database);
+  if (ack.kind === 'duplicate_existing') {
+    // Historical duplicate: a record from a DIFFERENT intent already exists, so
+    // THIS intent published nothing. Never a successful submission.
+    coord.applyOutcome(row.slotId, row.targetId, {
+      kind: 'duplicate',
+      workId: row.pixivId,
+      reason: 'downstream attested historical duplicate',
+    });
+    return true;
+  }
+  if (ack.kind === 'remote_failed') {
+    // The downstream record is terminally broken, so nothing was published:
+    // settle the cell as failed instead of promoting it to submitted. Not
+    // retryable — the same idempotency key can only return that record.
+    coord.applyOutcome(row.slotId, row.targetId, {
+      kind: 'failed',
+      retryable: false,
+      error: `downstream reported terminal status ${ack.remoteStatus} (review ${ack.remoteId ?? 'unknown'})`,
+    });
+    return true;
+  }
+  // accepted / idempotent_replay: a confirmed ACK is the sole path to submitted.
+  coord.markDelivered(
+    row.slotId,
+    row.targetId,
+    row.pixivId,
+    row.workType as 'illustration' | 'novel'
+  );
+  return true;
+}


### PR DESCRIPTION
## Problem

A delivery endpoint can answer **HTTP 2xx** while the record it persisted is **already terminally failed**. The provider keys that record by *our* idempotency key, so a retry only returns the same broken record.

Before this fix Core parsed that reused envelope as `idempotent_replay`, recorded the delivery ledger as `delivered`, and promoted the Slot cell to `submitted` — reporting a **remote failure as end-to-end success**.

## Fix

- **`DeliveryAck`**: new `remote_failed` variant. A terminal downstream status (`failed`/`rejected`/`invalid`/`expired`) outranks the transport-level 2xx and is returned before the accepted / `idempotent_replay` branch.
- **`OutboxWorker`**: handle `remote_failed` as terminal — record the ledger `failed`, notify the terminal hook, never retry (the key pins us to that record).
- **`settleDeliveryTerminal`** (new): extract the single place a confirmed ACK becomes a Slot cell state so the invariant is directly testable. `duplicate_existing` → `duplicate`, `remote_failed` → `failed` (non-retryable), `accepted`/`idempotent_replay` → `submitted`.

## Tests

`src/__tests__/delivery/remoteDeliveryFailureSemantics.test.ts` — 14 tests, **OLD FAIL / NEW PASS** verified:
- parse-level terminal classification (incl. the reused-failed envelope)
- outbox terminality (ledger `failed`, no retry)
- Slot cell settlement (`failed`, never `submitted`)
- full `parseDeliveryAck → OutboxWorker → settleDeliveryTerminal` chain

Full app suite: **688 passed**.

## Risk

Additive discriminated-union variant; existing `accepted` / `idempotent_replay` / `duplicate_existing` paths are unchanged and still covered.