### PR TITLE
docs(release): refresh download pages to v2.19.4

### DIFF
--- a/.release-policy.yml
+++ b/.release-policy.yml
@@ -32,6 +32,9 @@
       "verify": "docker buildx imagetools inspect ghcr.io/redtidev1918/pixivflow:$RELEASE_VERSION"
     }
   },
+  "release": {
+    "post_publish": "python3 .github/scripts/update_download_page.py && git config user.name github-actions[bot] && git config user.email 41898282+github-actions[bot]@users.noreply.github.com && git add docs/download.md docs/en/download.md && (git diff --cached --quiet || (git commit -m 'docs: update release download page' && git push))"
+  },
   "retention": {
     "stable": 1,
     "prerelease": 1,

--- a/docs/download.md
+++ b/docs/download.md
@@ -4,9 +4,9 @@
 
 本页由 GitHub Actions 在每次发版时**自动更新**，始终指向最新 Release。
 
-## 最新版本：`v2.17.0`（2026-09-11）
+## 最新版本：`v2.19.4`（2026-09-12）
 
-👉 [查看 Release 说明与校验和](https://github.com/redtidev1918/PixivFlow/releases/tag/v2.17.0)
+👉 [查看 Release 说明与校验和](https://github.com/redtidev1918/PixivFlow/releases/tag/v2.19.4)
 
 PixivFlow 以 npm 包为主，同时提供发布包与官方 Docker 镜像。完整资产与历史版本见 [Releases](https://github.com/redtidev1918/PixivFlow/releases)。
 
@@ -47,6 +47,6 @@ grep '\.tgz' SHA256SUMS | sha256sum -c -
 
 | 平台 | 文件 | 大小 | 下载 |
 |---|---|---|---|
-| 通用 | `RELEASE-METADATA.json` | 2 KB | [⬇️ 下载](https://github.com/redtidev1918/PixivFlow/releases/download/v2.17.0/RELEASE-METADATA.json) |
-| 通用 | `SHA256SUMS` | 0 KB | [⬇️ 下载](https://github.com/redtidev1918/PixivFlow/releases/download/v2.17.0/SHA256SUMS) |
-| 通用 | `pixivflow-2.17.0.tgz` | 1.8 MB | [⬇️ 下载](https://github.com/redtidev1918/PixivFlow/releases/download/v2.17.0/pixivflow-2.17.0.tgz) |
+| 通用 | `RELEASE-METADATA.json` | 2 KB | [⬇️ 下载](https://github.com/redtidev1918/PixivFlow/releases/download/v2.19.4/RELEASE-METADATA.json) |
+| 通用 | `SHA256SUMS` | 0 KB | [⬇️ 下载](https://github.com/redtidev1918/PixivFlow/releases/download/v2.19.4/SHA256SUMS) |
+| 通用 | `pixivflow-2.19.4.tgz` | 1.7 MB | [⬇️ 下载](https://github.com/redtidev1918/PixivFlow/releases/download/v2.19.4/pixivflow-2.19.4.tgz) |

--- a/docs/en/download.md
+++ b/docs/en/download.md
@@ -4,12 +4,12 @@
 
 This page is **generated automatically** by GitHub Actions on every release and always points at the latest one.
 
-## Latest version: `v2.17.0` (2026-09-11)
+## Latest version: `v2.19.4` (2026-09-12)
 
-👉 [Release notes and checksums](https://github.com/redtidev1918/PixivFlow/releases/tag/v2.17.0)
+👉 [Release notes and checksums](https://github.com/redtidev1918/PixivFlow/releases/tag/v2.19.4)
 
 | Platform | File | Size | Download |
 |---|---|---|---|
-| All platforms | `RELEASE-METADATA.json` | 2 KB | [⬇️ Download](https://github.com/redtidev1918/PixivFlow/releases/download/v2.17.0/RELEASE-METADATA.json) |
-| All platforms | `SHA256SUMS` | 0 KB | [⬇️ Download](https://github.com/redtidev1918/PixivFlow/releases/download/v2.17.0/SHA256SUMS) |
-| All platforms | `pixivflow-2.17.0.tgz` | 1.8 MB | [⬇️ Download](https://github.com/redtidev1918/PixivFlow/releases/download/v2.17.0/pixivflow-2.17.0.tgz) |
+| All platforms | `RELEASE-METADATA.json` | 2 KB | [⬇️ Download](https://github.com/redtidev1918/PixivFlow/releases/download/v2.19.4/RELEASE-METADATA.json) |
+| All platforms | `SHA256SUMS` | 0 KB | [⬇️ Download](https://github.com/redtidev1918/PixivFlow/releases/download/v2.19.4/SHA256SUMS) |
+| All platforms | `pixivflow-2.19.4.tgz` | 1.7 MB | [⬇️ Download](https://github.com/redtidev1918/PixivFlow/releases/download/v2.19.4/pixivflow-2.19.4.tgz) |


### PR DESCRIPTION
## What

- Regenerate `docs/download.md` and `docs/en/download.md`; both were pinned at v2.17.0 while production is v2.19.4.
- Fix the cause: PixivFlow had **no** `release.post_publish` hook, so no download page was regenerated on any release. Add the same hook TelePost uses, staging both locales.

## Evidence

| | before | after |
|---|---|---|
| `docs/download.md` | v2.17.0 | v2.19.4 |
| `docs/en/download.md` | v2.17.0 | v2.19.4 |

Generated entirely by the repo's own `.github/scripts/update_download_page.py`; re-running it is idempotent.

## Scope

Documentation + release-policy hook only. No runtime code, no version bump, no release.