### PR TITLE
fix(scheduler): 重复候选推进扫描而不是结束槽位

### DIFF
--- a/src/__tests__/download/handlers/IllustrationTargetHandler.test.ts
+++ b/src/__tests__/download/handlers/IllustrationTargetHandler.test.ts
@@ -5,6 +5,7 @@ import { IDatabase } from '../../../interfaces/IDatabase';
 import { RankingService } from '../../../download/RankingService';
 import { IllustrationDownloader } from '../../../download/IllustrationDownloader';
 import { DownloadPipeline } from '../../../download/pipeline/DownloadPipeline';
+import { emptyCandidateScan } from '../../../scheduler/TargetOutcome';
 import { PixivIllust } from '@redtidev/pixiv-client';
 import { NetworkError } from '../../../utils/errors';
 import { logger } from '../../../logger';
@@ -89,6 +90,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -116,6 +118,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -138,6 +141,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -186,6 +190,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 1,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await topicHandler.handle(target);
@@ -215,8 +220,8 @@ describe('IllustrationTargetHandler', () => {
         },
       });
       mockPipeline.run
-        .mockResolvedValueOnce({ downloaded: 0, skipped: 0, alreadyDownloaded: 0, filteredOut: 0 })
-        .mockResolvedValueOnce({ downloaded: 1, skipped: 0, alreadyDownloaded: 0, filteredOut: 0 });
+        .mockResolvedValueOnce({ downloaded: 0, skipped: 0, alreadyDownloaded: 0, filteredOut: 0, scan: emptyCandidateScan() })
+        .mockResolvedValueOnce({ downloaded: 1, skipped: 0, alreadyDownloaded: 0, filteredOut: 0, scan: emptyCandidateScan() });
       const topicHandler = new IllustrationTargetHandler(
         mockClient, mockDatabase, mockRankingService, mockIllustrationDownloader,
         mockPipeline, () => ({ selectWorks } as any)
@@ -242,6 +247,7 @@ describe('IllustrationTargetHandler', () => {
       });
       mockPipeline.run.mockResolvedValue({
         downloaded: 0, skipped: 0, alreadyDownloaded: 0, filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
       const topicHandler = new IllustrationTargetHandler(
         mockClient, mockDatabase, mockRankingService, mockIllustrationDownloader,
@@ -313,6 +319,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -338,6 +345,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -367,6 +375,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -392,6 +401,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -421,6 +431,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -447,6 +458,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -475,6 +487,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -501,6 +514,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -527,6 +541,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -557,6 +572,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -582,6 +598,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -608,6 +625,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 1,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -634,6 +652,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 1,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -659,6 +678,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -685,6 +705,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 1,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: true });
@@ -704,6 +725,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 5,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -727,6 +749,7 @@ describe('IllustrationTargetHandler', () => {
         skipped: 1,
         alreadyDownloaded: 1,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);

--- a/src/__tests__/download/handlers/NovelTargetHandler.test.ts
+++ b/src/__tests__/download/handlers/NovelTargetHandler.test.ts
@@ -5,6 +5,7 @@ import { IDatabase } from '../../../interfaces/IDatabase';
 import { RankingService } from '../../../download/RankingService';
 import { NovelDownloader } from '../../../download/NovelDownloader';
 import { DownloadPipeline } from '../../../download/pipeline/DownloadPipeline';
+import { emptyCandidateScan } from '../../../scheduler/TargetOutcome';
 import { PixivNovel } from '@redtidev/pixiv-client';
 import { NetworkError } from '../../../utils/errors';
 import { logger } from '../../../logger';
@@ -86,6 +87,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -113,6 +115,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -135,6 +138,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -203,6 +207,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -228,6 +233,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -425,6 +431,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -450,6 +457,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -479,6 +487,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -505,6 +514,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -533,6 +543,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -559,6 +570,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -585,6 +597,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -615,6 +628,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -640,6 +654,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -666,6 +681,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 1,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -692,6 +708,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 1,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -718,6 +735,7 @@ describe('NovelTargetHandler', () => {
         skipped: 1,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await expect(handler.handle(target)).resolves.toMatchObject({ kind: 'failed', retryable: true });
@@ -737,6 +755,7 @@ describe('NovelTargetHandler', () => {
         skipped: 5,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -760,6 +779,7 @@ describe('NovelTargetHandler', () => {
         skipped: 1,
         alreadyDownloaded: 1,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -785,7 +805,9 @@ describe('NovelTargetHandler', () => {
         },
       });
       mockPipeline.run.mockReset();
-      results.forEach((result) => mockPipeline.run.mockResolvedValueOnce(result));
+      results.forEach((result) =>
+        mockPipeline.run.mockResolvedValueOnce({ ...result, scan: emptyCandidateScan() })
+      );
       const topicHandler = new NovelTargetHandler(
         mockClient,
         mockDatabase,
@@ -853,6 +875,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       await handler.handle(target);
@@ -882,6 +905,7 @@ describe('NovelTargetHandler', () => {
         skipped: 0,
         alreadyDownloaded: 0,
         filteredOut: 0,
+        scan: emptyCandidateScan(),
       });
 
       // When no novels found and limit > 0, it should throw an error

--- a/src/__tests__/download/handlers/workIdentityRecovery.test.ts
+++ b/src/__tests__/download/handlers/workIdentityRecovery.test.ts
@@ -115,8 +115,20 @@ describe('work identity across recovery', () => {
    */
   function pipelineDownloadsEveryCandidate(): void {
     mockPipeline.run.mockImplementation(async (items: any, _t: any, _ty: any, downloadFn: any) => {
-      for (const item of items) await downloadFn(item, 'landscape');
-      return { downloaded: items.length, skipped: 0, alreadyDownloaded: 0, filteredOut: 0 };
+      const skipped: any[] = [];
+      let produced = 0;
+      for (const item of items) {
+        const attempt = await downloadFn(item, 'landscape');
+        if (attempt?.kind === 'skipped') skipped.push(attempt.skip);
+        else produced += 1;
+      }
+      return {
+        downloaded: produced,
+        skipped: 0,
+        alreadyDownloaded: 0,
+        filteredOut: 0,
+        scan: { bound: items.length, attempted: items.length, skipped, outages: [] },
+      };
     });
   }
 
@@ -327,7 +339,14 @@ describe('work identity across recovery', () => {
         coord.executionContextsFor(slotId, coord.pendingTargets(slotId, [target()])).get(TARGET_ID)
       );
 
-      expect(outcome.kind).toBe('failed');
+      // A 404 is a CANDIDATE-level fact, not a job failure: the candidate is
+      // skipped, so with no further candidate the target reports the explicit
+      // "no eligible candidate" verdict instead of a failed job.
+      expect(outcome.kind).toBe('no_candidate');
+      expect(outcome.scan?.skipped).toEqual([
+        expect.objectContaining({ code: 'deleted', workId: '100' }),
+      ]);
+      expect(outcome.scan?.attempted).toBe(1);
       const cell = db.slots.getCell(slotId, TARGET_ID)!;
       expect(cell.workId).toBeNull();
       expect(cell.status).toBe('pending');

--- a/src/__tests__/download/plan/DownloadPlanner.test.ts
+++ b/src/__tests__/download/plan/DownloadPlanner.test.ts
@@ -1,7 +1,10 @@
 import type { TargetConfig } from '../../../config';
 import type { IDatabase } from '../../../interfaces/IDatabase';
 import type { PixivIllust } from '@redtidev/pixiv-client';
-import { DownloadPlanner } from '../../../download/plan/DownloadPlanner';
+import {
+  DEFAULT_CANDIDATE_SCAN_LIMIT,
+  DownloadPlanner,
+} from '../../../download/plan/DownloadPlanner';
 
 jest.mock('../../../logger', () => ({
   logger: {
@@ -190,18 +193,30 @@ describe('DownloadPlanner', () => {
     expect(plan.queue.map((item) => item.id)).toEqual([1, 2, 3]);
   });
 
-  it('keeps a bounded ordered retry pool for topic illustration failures', () => {
+  it('bounds the topic candidate window by the configured scan limit, not the fetch pool', () => {
     const { database } = createDatabaseMock();
     const planner = new DownloadPlanner(database);
     const items = Array.from({ length: 30 }, (_, index) => createIllustration(index + 1));
 
-    const plan = planner.planDownloads(
+    // Topic discovery is still fetched as a ranked pool of 20, but a run may
+    // only ATTEMPT `candidateScanLimit` (default 5) of them: one knob governs
+    // attempts, so a page full of rejects cannot become a crawl.
+    const bounded = planner.planDownloads(
       items,
       createTarget({ mode: 'topic', topic: '丸呑み', limit: 1 }),
       'illustration'
     );
+    expect(bounded.scanBound).toBe(DEFAULT_CANDIDATE_SCAN_LIMIT);
+    expect(bounded.queue.map((item) => item.id)).toEqual([1, 2, 3, 4, 5]);
 
-    expect(plan.queue.map((item) => item.id)).toEqual(
+    // An operator who needs the deeper pool says so explicitly.
+    const deeper = planner.planDownloads(
+      items,
+      createTarget({ mode: 'topic', topic: '丸呑み', limit: 1, candidateScanLimit: 20 }),
+      'illustration'
+    );
+    expect(deeper.scanBound).toBe(20);
+    expect(deeper.queue.map((item) => item.id)).toEqual(
       Array.from({ length: 20 }, (_, index) => index + 1)
     );
   });

--- a/src/__tests__/scheduler/candidateScan.test.ts
+++ b/src/__tests__/scheduler/candidateScan.test.ts
@@ -1,0 +1,934 @@
+/**
+ * Bounded candidate scan: a duplicate candidate must ADVANCE the scan, never
+ * end the run.
+ *
+ * Production defect these tests pin down: the scheduler fetched/ranked ONE
+ * candidate, found it was already submitted, and the job ended as "success"
+ * with nothing submitted — burning the whole scheduled slot. The wrong model
+ * was `duplicate -> job completed`; the right one is
+ * `duplicate -> candidate rejected -> try the next candidate`.
+ *
+ * Every test drives the REAL chain (DownloadPlanner + DownloadPipeline +
+ * IllustrationTargetHandler + DeliveryService over a real SQLite database) and
+ * only fakes the two boundaries that would need the network: the Pixiv client
+ * and the artifact downloader.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Database } from '../../storage/Database';
+import { DeliveryService } from '../../delivery/DeliveryService';
+import { DownloadManager } from '../../download/DownloadManager';
+import {
+  DownloadPlanner,
+  DEFAULT_CANDIDATE_SCAN_LIMIT,
+  resolveCandidateScanLimit,
+} from '../../download/plan/DownloadPlanner';
+import { applyEnvironmentOverrides } from '../../config/environment';
+import { DownloadPipeline } from '../../download/pipeline/DownloadPipeline';
+import { DownloadExecutor } from '../../download/exec/DownloadExecutor';
+import { DefaultErrorRecovery } from '../../download/recovery/ErrorRecovery';
+import { ProgressReporter } from '../../download/report/ProgressReporter';
+import { IllustrationTargetHandler } from '../../download/handlers/IllustrationTargetHandler';
+import { RankingService } from '../../download/RankingService';
+import { IllustrationDownloader } from '../../download/IllustrationDownloader';
+import {
+  mergeScanSummaries,
+  noEligibleCandidateText,
+  outcomeSummary,
+  type TargetOutcome,
+} from '../../scheduler/TargetOutcome';
+import { SlotCoordinator, type SlotContext } from '../../scheduler/SlotCoordinator';
+import { createDeliveryLedgerPort } from '../../delivery/DeliveryLedgerPort';
+import type { ScheduleConfig, StandaloneConfig, TargetConfig } from '../../config';
+import type { IPixivClient } from '../../interfaces/IPixivClient';
+import type { DownloadedArtifact } from '../../delivery/types';
+import type { PixivIllust } from '@redtidev/pixiv-client';
+import { AuthenticationError, DatabaseError, NetworkError } from '../../utils/errors';
+
+jest.mock('../../logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const DELIVERY_TARGET = 'review';
+
+function illust(id: number): PixivIllust {
+  return {
+    id,
+    title: `Illust ${id}`,
+    page_count: 1,
+    user: { id: 'u1', name: 'User' },
+    image_urls: {
+      square_medium: `https://example.com/${id}/square`,
+      medium: `https://example.com/${id}/medium`,
+      large: `https://example.com/${id}/large`,
+    },
+    create_date: '2024-01-01T00:00:00+09:00',
+    total_bookmarks: 100,
+    total_view: 1000,
+  };
+}
+
+interface Harness {
+  db: Database;
+  handler: IllustrationTargetHandler;
+  target: TargetConfig;
+  downloader: { downloadIllustration: jest.Mock };
+  searchIllustrations: jest.Mock;
+  /** Make a work look already SUBMITTED to this target (delivered or pending). */
+  markSubmitted(pixivId: string, status: 'delivered' | 'pending' | 'duplicate'): void;
+  /** Ledger rows for one work: exactly one means exactly one submission. */
+  ledgerRowsFor(pixivId: string): Array<{ id: string; status: string; idempotencyKey: string }>;
+  /** Total delivery-ledger rows, whatever their work. */
+  ledgerRowCount(): number;
+  outboxDeliveryRows(): number;
+  /** The work the slot cell is bound to, or null when unbound. */
+  cellWorkId(): string | null;
+  cellStatus(): string | null;
+  /** Run one target through the handler, with the slot cell claim when enabled. */
+  handle(): Promise<TargetOutcome>;
+  /** Record an outcome on the slot ledger exactly as runJob's hook does. */
+  applyOutcomeToSlot(outcome: TargetOutcome): void;
+  /** Roll the slot up exactly as runJob does at the end of a run. */
+  finishSlot(): { status: string; cells: Array<{ targetId: string; status: string; workId?: string | null; error?: string | null }> };
+  close(): void;
+}
+
+function buildHarness(options: {
+  candidates: number[];
+  /** Per-candidate failure injected at the downloader boundary. */
+  failWith?: (pixivId: string) => Error | null;
+  /** Smallest config: no real delays, serial scan. */
+  config?: Partial<StandaloneConfig>;
+  /** Simulate a caller with no ledger visibility, forcing the post-download path. */
+  blindPlanner?: boolean;
+  /** Drive the real slot ledger + work-identity cell claim, as a scheduled run does. */
+  withSlot?: boolean;
+  target?: Partial<TargetConfig>;
+}): Harness {
+  const dir = mkdtempSync(join(tmpdir(), 'pixivflow-scan-'));
+  const db = new Database(join(dir, 'test.db'));
+  db.migrate();
+
+  const artifactDir = join(dir, 'artifacts');
+  require('node:fs').mkdirSync(artifactDir, { recursive: true });
+  const artifactFiles = new Map<string, string>();
+  for (const id of options.candidates) {
+    const file = join(artifactDir, `${id}.jpg`);
+    writeFileSync(file, 'image');
+    artifactFiles.set(String(id), file);
+  }
+
+  const downloader = {
+    downloadIllustration: jest.fn(
+      async (item: PixivIllust): Promise<DownloadedArtifact | null> => {
+        const failure = options.failWith?.(String(item.id));
+        if (failure) throw failure;
+        const file = artifactFiles.get(String(item.id));
+        if (!file) return null;
+        return {
+          pixivId: String(item.id),
+          type: 'illustration',
+          title: item.title,
+          files: [file],
+          previewFiles: [],
+        };
+      }
+    ),
+  };
+
+  const searchIllustrations = jest.fn().mockResolvedValue(options.candidates.map(illust));
+  const client = { searchIllustrations } as unknown as IPixivClient;
+  const rankingService = {} as RankingService;
+
+  const config = {
+    download: { concurrency: 1, maxRetries: 1, retryDelay: 0 },
+    storage: {},
+    targets: [],
+    ...(options.config ?? {}),
+  } as unknown as StandaloneConfig;
+
+  const deliveryService = new DeliveryService(db);
+  const planner = new DownloadPlanner(
+    db,
+    options.blindPlanner
+      ? undefined
+      : {
+          deliveredIds: (target, type, ids) => deliveryService.deliveredIds(target, type, ids),
+          submittedIds: (target, type, ids) => deliveryService.submittedIds(target, type, ids),
+        },
+    config.download?.candidateScanLimit
+  );
+  const pipeline = new DownloadPipeline({
+    config,
+    planner,
+    executor: new DownloadExecutor(),
+    progressReporter: new ProgressReporter(),
+    recovery: new DefaultErrorRecovery({ maxAttempts: 1, baseDelayMs: 0, maxDelayMs: 0 }),
+  });
+
+  const target: TargetConfig = {
+    id: 'target-a',
+    type: 'illustration',
+    mode: 'search',
+    tag: 'scan-tag',
+    limit: 1,
+    storageMode: 'cache',
+    delivery: { target: DELIVERY_TARGET },
+    ...(options.target ?? {}),
+  };
+
+  const handler = new IllustrationTargetHandler(
+    client,
+    db,
+    rankingService,
+    downloader as unknown as IllustrationDownloader,
+    pipeline,
+    undefined,
+    deliveryService
+  );
+
+  /**
+   * A real scheduled slot: cell membership + the (slotId,targetId) -> workId
+   * claim that must NOT stop the scan when a candidate is rejected.
+   */
+  let execution: ReturnType<SlotCoordinator['executionContextsFor']> extends Map<string, infer C>
+    ? C | undefined
+    : never;
+  let slotId: string | undefined;
+  let coordinator: SlotCoordinator | undefined;
+  let resolvedSlot: SlotContext | undefined;
+  const schedule = {
+    id: 'schedule-a',
+    name: 'Schedule A',
+    cron: '0 10 * * *',
+    timezone: 'Asia/Shanghai',
+    enabled: true,
+  } as ScheduleConfig;
+  if (options.withSlot) {
+    coordinator = new SlotCoordinator(db, createDeliveryLedgerPort(db));
+    const slotConfig = { schedulerRuntime: { trigger: { graceMinutes: 120 } } } as StandaloneConfig;
+    const resolved = coordinator.resolveOccurrence(
+      schedule,
+      slotConfig,
+      'http',
+      new Date('2026-09-08T02:00:30Z')
+    ).context;
+    if (!resolved) throw new Error('slot harness: occurrence not resolvable');
+    resolvedSlot = resolved;
+    slotId = resolved.slotId;
+    coordinator.prepare(resolved, schedule, [target]);
+    coordinator.markRunning(resolved.slotId);
+    // The delivery target must carry the slot id, exactly as runJob wires it.
+    target.delivery = { ...target.delivery, target: DELIVERY_TARGET, slotContext: resolved };
+    execution = coordinator
+      .executionContextsFor(resolved.slotId, coordinator.pendingTargets(resolved.slotId, [target]))
+      .get('target-a');
+  }
+
+  const markSubmitted: Harness['markSubmitted'] = (pixivId, status) => {
+    const id = `seed-${status}-${pixivId}-${Math.random().toString(16).slice(2)}`;
+    db.deliveries.insertIntent({
+      id,
+      deliveryTarget: DELIVERY_TARGET,
+      workType: 'illustration',
+      pixivId: String(pixivId),
+      slotId: null,
+      targetId: 'target-a',
+      idempotencyKey: `seed:${status}:${pixivId}:${id}`,
+    });
+    if (status !== 'pending') {
+      db.deliveries.recordAck(id, { status });
+    }
+  };
+
+  return {
+    db,
+    handler,
+    target,
+    downloader,
+    cellWorkId: () =>
+      slotId ? db.slots.getCell(slotId, 'target-a')?.workId ?? null : null,
+    cellStatus: () =>
+      slotId ? db.slots.getCell(slotId, 'target-a')?.status ?? null : null,
+    handle: () => handler.handle(target, execution),
+    applyOutcomeToSlot: (outcome) => {
+      if (!coordinator || !resolvedSlot) return;
+      coordinator.applyOutcome(resolvedSlot.slotId, 'target-a', outcome);
+    },
+    finishSlot: () => {
+      if (!coordinator || !resolvedSlot) throw new Error('slot harness not enabled');
+      const summary = coordinator.finish(resolvedSlot, schedule, [target]);
+      return {
+        status: summary.status as string,
+        cells: summary.cells.map((c) => ({
+          targetId: c.targetId,
+          status: c.status as string,
+          workId: c.workId,
+          error: c.error,
+        })),
+      };
+    },
+    searchIllustrations,
+    markSubmitted,
+    // The ledger is the submission record: every row is one durable delivery
+    // intent, so counting rows per work is counting submissions per work.
+    ledgerRowsFor: (pixivId) =>
+      [...db.deliveries.pending(1000), ...db.deliveries.listForCell(DELIVERY_TARGET, '', '')]
+        .filter((row) => row.pixivId === String(pixivId))
+        .map((row) => ({ id: row.id, status: row.status, idempotencyKey: row.idempotencyKey })),
+    ledgerRowCount: () =>
+      Object.values(db.deliveries.countByStatus()).reduce((sum, n) => sum + n, 0),
+    outboxDeliveryRows: () => db.outbox.list().filter((row) => row.kind === 'delivery').length,
+    close: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('scheduler candidate scan: duplicate -> next candidate, never a completed no-op', () => {
+  it('submits candidate #2 when candidate #1 is already submitted', async () => {
+    const h = buildHarness({ candidates: [100, 101] });
+    try {
+      h.markSubmitted('100', 'delivered');
+
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('101');
+      expect(outcome.scan?.skipped.map((s) => s.workId)).toEqual(['100']);
+      expect(outcome.scan?.skipped[0].code).toBe('duplicate');
+      // "submitted candidate X after skipping Y candidates"
+      expect(outcomeSummary(outcome)).toMatch(
+        /submitted candidate 101 \(illustration\) for review after skipping 1 candidate/
+      );
+    } finally {
+      h.close();
+    }
+  });
+
+  it('submits candidate #2 even when the duplicate is only discovered AFTER download', async () => {
+    // A planner with no ledger visibility cannot pre-filter, so candidate #1 is
+    // downloaded and only then found already delivered. It must still advance.
+    const h = buildHarness({ candidates: [100, 101], blindPlanner: true });
+    try {
+      h.markSubmitted('100', 'delivered');
+
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('101');
+      expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(2);
+      expect(outcome.scan?.attempted).toBe(2);
+      expect(outcome.scan?.skipped.map((s) => s.code)).toEqual(['duplicate']);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('submits candidate #3 when candidates #1 and #2 are duplicates', async () => {
+    const h = buildHarness({ candidates: [100, 101, 102], blindPlanner: true });
+    try {
+      h.markSubmitted('100', 'delivered');
+      h.markSubmitted('101', 'delivered');
+
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('102');
+      expect(outcome.scan?.skipped.map((s) => s.workId)).toEqual(['100', '101']);
+      expect(outcome.scan?.attempted).toBe(3);
+      expect(outcomeSummary(outcome)).toMatch(/after skipping 2 candidate/);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('treats an already-PENDING review submission as taken and moves on', async () => {
+    const h = buildHarness({ candidates: [100, 101] });
+    try {
+      h.markSubmitted('100', 'pending');
+
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('101');
+      expect(outcome.scan?.skipped[0]).toMatchObject({ code: 'duplicate', workId: '100' });
+    } finally {
+      h.close();
+    }
+  });
+
+  it('all candidates duplicates -> clean bounded no-op with an explicit outcome', async () => {
+    const h = buildHarness({ candidates: [100, 101, 102] });
+    try {
+      h.markSubmitted('100', 'delivered');
+      h.markSubmitted('101', 'delivered');
+      h.markSubmitted('102', 'delivered');
+
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('no_candidate');
+      expect(outcome.scan?.skipped).toHaveLength(3);
+      expect(outcome.scan?.skipped.every((s) => s.code === 'duplicate')).toBe(true);
+      const reason = outcome.kind === 'no_candidate' ? outcome.reason : '';
+      expect(reason).toMatch(/no eligible candidate found after scanning \d+/);
+      // Never the bare, unexplained "completed" the defect produced.
+      expect(outcomeSummary(outcome)).not.toMatch(/^completed/);
+      // No exception escaped: clean no-op.
+      expect(h.downloader.downloadIllustration).not.toHaveBeenCalled();
+    } finally {
+      h.close();
+    }
+  });
+
+  it('all candidates duplicates discovered post-download -> bounded scan, explicit outcome', async () => {
+    const h = buildHarness({ candidates: [100, 101, 102], blindPlanner: true });
+    try {
+      h.markSubmitted('100', 'delivered');
+      h.markSubmitted('101', 'delivered');
+      h.markSubmitted('102', 'delivered');
+
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('no_candidate');
+      expect(outcome.scan?.attempted).toBe(3);
+      expect(outcome.scan?.skipped).toHaveLength(3);
+      // Strictly bounded: each candidate attempted exactly once, then it stops.
+      expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(3);
+      expect(outcome.kind === 'no_candidate' && outcome.reason).toMatch(
+        /no eligible candidate found after scanning 3/
+      );
+    } finally {
+      h.close();
+    }
+  });
+
+  it.each([
+    ['deleted', () => new Error('404 not found: work deleted')],
+    ['access_denied', () => new Error('403 forbidden: private work')],
+    ['unsupported_media', () => new Error('ugoira unsupported media format')],
+    ['invalid_metadata', () => new Error('invalid metadata: no image urls')],
+  ])('candidate #1 %s -> next candidate is tried', async (expectedCode, makeError) => {
+    const h = buildHarness({
+      candidates: [100, 101],
+      blindPlanner: true,
+      failWith: (pixivId) => (pixivId === '100' ? (makeError() as Error) : null),
+    });
+    try {
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('101');
+      expect(outcome.scan?.attempted).toBe(2);
+      expect(outcome.scan?.skipped[0]).toMatchObject({ code: expectedCode, workId: '100' });
+    } finally {
+      h.close();
+    }
+  });
+
+  it('an unavailable candidate (transient) is skipped and the next one is submitted', async () => {
+    const h = buildHarness({
+      candidates: [100, 101],
+      blindPlanner: true,
+      failWith: (pixivId) => (pixivId === '100' ? new NetworkError('ETIMEDOUT fetching image') : null),
+    });
+    try {
+      const outcome = await h.handler.handle(h.target);
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('101');
+      expect(outcome.scan?.skipped[0]).toMatchObject({ code: 'unavailable', retryable: true });
+    } finally {
+      h.close();
+    }
+  });
+
+  describe('job-level failures never degrade into "no eligible candidate"', () => {
+    it('a general network outage FAILS the target as retryable', async () => {
+      const h = buildHarness({
+        candidates: [100, 101, 102],
+        blindPlanner: true,
+        failWith: () => new NetworkError('getaddrinfo ENOTFOUND app-api.pixiv.net'),
+      });
+      try {
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.kind).toBe('failed');
+        expect(outcome.kind === 'failed' && outcome.retryable).toBe(true);
+        expect(outcome.kind === 'failed' && outcome.error).toMatch(/transient|outage/);
+      } finally {
+        h.close();
+      }
+    });
+
+    it('a global Pixiv auth failure FAILS the target', async () => {
+      const h = buildHarness({
+        candidates: [100, 101],
+        blindPlanner: true,
+        failWith: () => new AuthenticationError('invalid refresh token (401 unauthorized)'),
+      });
+      try {
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.kind).toBe('failed');
+        expect(outcome.kind === 'failed' && outcome.error).toMatch(/invalid refresh token/);
+        expect(outcomeSummary(outcome)).not.toMatch(/no eligible candidate/);
+      } finally {
+        h.close();
+      }
+    });
+
+    it('a database outage FAILS the target', async () => {
+      const h = buildHarness({
+        candidates: [100, 101],
+        blindPlanner: true,
+        failWith: () => new DatabaseError('database is locked'),
+      });
+      try {
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.kind).toBe('failed');
+        expect(outcomeSummary(outcome)).not.toMatch(/no eligible candidate/);
+      } finally {
+        h.close();
+      }
+    });
+
+    it('a Telegram delivery outage FAILS the target as retryable', async () => {
+      const h = buildHarness({
+        candidates: [100, 101],
+        blindPlanner: true,
+        failWith: () =>
+          new Error('telegram delivery target unavailable: api.telegram.org answered 503'),
+      });
+      try {
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.kind).toBe('failed');
+        expect(outcome.kind === 'failed' && outcome.retryable).toBe(true);
+        expect(outcomeSummary(outcome)).not.toMatch(/no eligible candidate/);
+      } finally {
+        h.close();
+      }
+    });
+
+    it('an outage is NOT reported as an exhausted candidate list even next to real duplicates', async () => {
+      const h = buildHarness({
+        candidates: [100, 101, 102, 103, 104, 105],
+        blindPlanner: true,
+        failWith: (pixivId) => (pixivId === '101' ? new NetworkError('ECONNRESET api.pixiv.net') : null),
+      });
+      try {
+        h.markSubmitted('100', 'delivered');
+        h.markSubmitted('102', 'delivered');
+        h.markSubmitted('103', 'delivered');
+        h.markSubmitted('104', 'delivered');
+        h.markSubmitted('105', 'delivered');
+
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.kind).toBe('failed');
+        expect(outcome.kind === 'failed' && outcome.retryable).toBe(true);
+      } finally {
+        h.close();
+      }
+    });
+  });
+
+  describe('the configured bound N', () => {
+    it('never attempts more candidates than the per-target candidateScanLimit', async () => {
+      const h = buildHarness({
+        candidates: [100, 101, 102, 103, 104, 105, 106, 107],
+        blindPlanner: true,
+        target: { candidateScanLimit: 3 },
+      });
+      try {
+        for (const id of [100, 101, 102, 103, 104, 105, 106, 107]) {
+          h.markSubmitted(String(id), 'delivered');
+        }
+
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.scan?.bound).toBe(3);
+        expect(outcome.scan?.attempted).toBe(3);
+        expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(3);
+        expect(outcome.kind).toBe('no_candidate');
+        expect(outcome.kind === 'no_candidate' && outcome.reason).toMatch(
+          /no eligible candidate found after scanning 3/
+        );
+      } finally {
+        h.close();
+      }
+    });
+
+    it('falls back to the global download.candidateScanLimit', async () => {
+      const h = buildHarness({
+        candidates: [100, 101, 102, 103, 104, 105, 106],
+        blindPlanner: true,
+        config: { download: { concurrency: 1, maxRetries: 1, retryDelay: 0, candidateScanLimit: 2 } },
+      });
+      try {
+        for (const id of [100, 101, 102, 103, 104, 105, 106]) {
+          h.markSubmitted(String(id), 'delivered');
+        }
+
+        const outcome = await h.handler.handle(h.target);
+
+        expect(outcome.scan?.bound).toBe(2);
+        expect(outcome.scan?.attempted).toBe(2);
+        expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(2);
+      } finally {
+        h.close();
+      }
+    });
+
+    it('defaults to DEFAULT_CANDIDATE_SCAN_LIMIT and never drops below the target limit', () => {
+      const db = { getDownloadedIds: jest.fn(() => new Set<string>()) } as never;
+      const planner = new DownloadPlanner(db);
+      const items = [1, 2, 3, 4, 5, 6, 7, 8].map(illust);
+
+      const single = planner.planDownloads(items, { type: 'illustration', limit: 1 } as TargetConfig, 'illustration');
+      expect(single.scanBound).toBe(DEFAULT_CANDIDATE_SCAN_LIMIT);
+      expect(single.queue).toHaveLength(DEFAULT_CANDIDATE_SCAN_LIMIT);
+
+      const many = planner.planDownloads(items, { type: 'illustration', limit: 6 } as TargetConfig, 'illustration');
+      // A multi-work target must still be able to fill its own limit.
+      expect(many.scanBound).toBe(6);
+      expect(many.queue).toHaveLength(6);
+
+      const clamped = planner.planDownloads(
+        items,
+        { type: 'illustration', limit: 1, candidateScanLimit: 400 } as TargetConfig,
+        'illustration'
+      );
+      expect(clamped.scanBound).toBe(8); // clamped to 100, capped by 8 available
+    });
+  });
+
+  describe('concurrency safety against the ledger', () => {
+    it('two concurrent runs produce exactly ONE submission for a given work', async () => {
+      const h = buildHarness({ candidates: [100, 101], blindPlanner: true });
+      try {
+        // Force a genuine interleaving: both workers must be inside the
+        // download of work 100 before either can reach the delivery ledger.
+        let arrivals = 0;
+        let release: () => void = () => undefined;
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const fallback = setTimeout(release, 3000);
+        h.downloader.downloadIllustration.mockImplementation(
+          async (item: PixivIllust): Promise<DownloadedArtifact> => {
+            if (String(item.id) === '100') {
+              arrivals += 1;
+              if (arrivals >= 2) release();
+              await gate;
+            }
+            return {
+              pixivId: String(item.id),
+              type: 'illustration',
+              title: item.title,
+              files: [join(tmpdir(), `pixivflow-scan-race-${item.id}.jpg`)],
+              previewFiles: [],
+            } as DownloadedArtifact;
+          }
+        );
+        // Real files: enqueue refuses to create an intent for a missing artifact.
+        for (const id of [100, 101]) {
+          writeFileSync(join(tmpdir(), `pixivflow-scan-race-${id}.jpg`), 'image');
+        }
+
+        const [first, second] = await Promise.all([
+          h.handler.handle(h.target),
+          h.handler.handle(h.target),
+        ]);
+        clearTimeout(fallback);
+
+        expect(arrivals).toBe(2);
+
+        // THE invariant: one ledger row for the contested work, one outbox
+        // side effect, regardless of how many workers selected it.
+        const rowsFor100 = h.ledgerRowsFor('100');
+        expect(rowsFor100).toHaveLength(1);
+        expect(new Set(rowsFor100.map((r) => r.idempotencyKey)).size).toBe(1);
+
+        // Both runs reached a business outcome; neither reported an exhausted
+        // candidate list, and the contested work was submitted once.
+        expect([first.kind, second.kind]).toEqual(['delivery_pending', 'delivery_pending']);
+        if (first.kind === 'delivery_pending' && second.kind === 'delivery_pending') {
+          expect(first.workId).toBe('100');
+          expect(second.workId).toBe('100');
+          expect(first.deliveryId).toBe(second.deliveryId);
+        }
+        // Exactly one durable side effect for the contested work: one ledger
+        // row and one outbox item, whether one worker or both selected it.
+        expect(h.ledgerRowCount()).toBe(1);
+        expect(h.outboxDeliveryRows()).toBe(1);
+      } finally {
+        h.close();
+      }
+    });
+  });
+
+  describe('scenario #1 vs #2 vocabulary', () => {
+    it('merges per-page scans so a lookback reports the whole candidate picture', () => {
+      const merged = mergeScanSummaries(
+        { bound: 5, attempted: 2, skipped: [{ code: 'duplicate', workId: '1', reason: 'x' }], outages: [] },
+        {
+          bound: 5,
+          attempted: 3,
+          skipped: [{ code: 'deleted', workId: '2', reason: 'y' }],
+          outages: ['network_outage'],
+        }
+      );
+      expect(merged).toEqual({
+        bound: 10,
+        attempted: 5,
+        skipped: [
+          { code: 'duplicate', workId: '1', reason: 'x' },
+          { code: 'deleted', workId: '2', reason: 'y' },
+        ],
+        outages: ['network_outage'],
+      });
+      expect(noEligibleCandidateText(merged)).toContain('scanning 5');
+    });
+  });
+});
+
+describe('scheduled slot: the cell work-claim must not block the scan', () => {
+  it('releases the provisional cell claim when candidate #1 is a duplicate', async () => {
+    const h = buildHarness({ candidates: [100, 101], blindPlanner: true, withSlot: true });
+    try {
+      h.markSubmitted('100', 'delivered');
+
+      const outcome = await h.handle();
+
+      // Without the release, `bind()` would refuse work 101 and the slot would
+      // still end with nothing submitted: the production defect, one level down.
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('101');
+      expect(h.cellWorkId()).toBe('101');
+      expect(outcome.scan?.skipped.map((s) => s.code)).toEqual(['duplicate']);
+      expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(2);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('keeps the cell claim once a delivery intent exists (a committed identity is never swapped)', async () => {
+    const h = buildHarness({ candidates: [100, 101], blindPlanner: true, withSlot: true });
+    try {
+      const outcome = await h.handle();
+
+      expect(outcome.kind).toBe('delivery_pending');
+      expect(outcome.kind === 'delivery_pending' && outcome.workId).toBe('100');
+      expect(h.cellWorkId()).toBe('100');
+      // Committed: the outbox owns this work now, so the scan stopped here.
+      expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(1);
+      expect(h.ledgerRowsFor('100')).toHaveLength(1);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('exhausts the bounded scan with a slot attached and reports the explicit verdict', async () => {
+    const h = buildHarness({ candidates: [100, 101, 102], blindPlanner: true, withSlot: true });
+    try {
+      for (const id of [100, 101, 102]) h.markSubmitted(String(id), 'delivered');
+
+      const outcome = await h.handle();
+
+      expect(outcome.kind).toBe('no_candidate');
+      expect(outcome.scan?.attempted).toBe(3);
+      expect(h.downloader.downloadIllustration).toHaveBeenCalledTimes(3);
+      // Nothing was committed, so the cell must be left unbound rather than
+      // pinned to an undeliverable work.
+      expect(h.cellWorkId()).toBeNull();
+      expect(outcome.kind === 'no_candidate' && outcome.reason).toMatch(
+        /no eligible candidate found after scanning 3/
+      );
+    } finally {
+      h.close();
+    }
+  });
+
+  it('records the explicit no-eligible-candidate verdict on the slot ledger', async () => {
+    const h = buildHarness({ candidates: [100, 101], blindPlanner: true, withSlot: true });
+    try {
+      h.markSubmitted('100', 'delivered');
+      h.markSubmitted('101', 'delivered');
+
+      const outcome = await h.handle();
+
+      // Nothing was submitted, so the durable verdict must NAME the reason:
+      // never a bare "completed" cell with no explanation.
+      expect(outcome.kind).toBe('no_candidate');
+      h.applyOutcomeToSlot(outcome);
+      const summary = h.finishSlot();
+      expect(summary.status).toBe('failed');
+      const cell = summary.cells.find((c) => c.targetId === 'target-a')!;
+      expect(cell.status).toBe('no_candidate');
+      expect(cell.error).toMatch(/no eligible candidate found after scanning/);
+    } finally {
+      h.close();
+    }
+  });
+
+  it('records the chosen work id on the slot cell when a later candidate is eligible', async () => {
+    const h = buildHarness({ candidates: [100, 101], blindPlanner: true, withSlot: true });
+    try {
+      h.markSubmitted('100', 'delivered');
+
+      const outcome = await h.handle();
+      expect(outcome.kind).toBe('delivery_pending');
+      h.applyOutcomeToSlot(outcome);
+
+      expect(h.cellWorkId()).toBe('101');
+      expect(h.cellStatus()).toBe('delivery_pending');
+      const cell = h.finishSlot().cells.find((c) => c.targetId === 'target-a')!;
+      // delivery_pending is NOT submitted: only a confirmed ACK is.
+      expect(cell.status).toBe('delivery_pending');
+      expect(cell.workId).toBe('101');
+    } finally {
+      h.close();
+    }
+  });
+});
+
+
+describe('the candidate-scan bound is configurable', () => {
+  const ORIGINAL = process.env.PIXIV_CANDIDATE_SCAN_LIMIT;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.PIXIV_CANDIDATE_SCAN_LIMIT;
+    else process.env.PIXIV_CANDIDATE_SCAN_LIMIT = ORIGINAL;
+  });
+
+  it('reads PIXIV_CANDIDATE_SCAN_LIMIT into download.candidateScanLimit', () => {
+    process.env.PIXIV_CANDIDATE_SCAN_LIMIT = '9';
+
+    const overridden = applyEnvironmentOverrides({});
+
+    expect(overridden.download?.candidateScanLimit).toBe(9);
+  });
+
+  it('ignores a non-positive or non-numeric value instead of disabling the bound', () => {
+    process.env.PIXIV_CANDIDATE_SCAN_LIMIT = 'nonsense';
+    expect(applyEnvironmentOverrides({}).download?.candidateScanLimit).toBeUndefined();
+
+    process.env.PIXIV_CANDIDATE_SCAN_LIMIT = '0';
+    expect(applyEnvironmentOverrides({}).download?.candidateScanLimit).toBeUndefined();
+  });
+
+  it('defaults to 5 and clamps a bad per-target value', () => {
+    expect(DEFAULT_CANDIDATE_SCAN_LIMIT).toBe(5);
+    const targetBase = { type: 'illustration' } as TargetConfig;
+    expect(resolveCandidateScanLimit(targetBase, undefined)).toBe(5);
+    expect(resolveCandidateScanLimit({ ...targetBase, candidateScanLimit: 0 } as TargetConfig, undefined)).toBe(1);
+    expect(resolveCandidateScanLimit({ ...targetBase, candidateScanLimit: -3 } as TargetConfig, undefined)).toBe(1);
+    expect(resolveCandidateScanLimit({ ...targetBase, candidateScanLimit: 9999 } as TargetConfig, undefined)).toBe(100);
+    expect(resolveCandidateScanLimit({ ...targetBase, candidateScanLimit: 4 } as TargetConfig, 9)).toBe(4);
+  });
+});
+
+describe('the FETCH stage asks for the whole scan window', () => {
+  function rankingHarness() {
+    const db = { getDownloadedIds: () => new Set<string>(), logExecution: jest.fn() } as never;
+    const delivery = { isAlreadyDelivered: () => false } as never;
+    const getRankingIllustrations = jest.fn().mockResolvedValue(
+      [1, 2, 3, 4, 5, 6, 7, 8].map(illust)
+    );
+    const rankingService = {
+      getRankingIllustrationsWithFallback: jest.fn((_mode: string, _date: string, limit?: number) =>
+        getRankingIllustrations(limit)
+      ),
+    } as unknown as RankingService;
+    const handler = new IllustrationTargetHandler(
+      { searchIllustrations: jest.fn(), getIllustration: jest.fn() } as unknown as IPixivClient,
+      db,
+      rankingService,
+      { downloadIllustration: jest.fn() } as unknown as IllustrationDownloader,
+      { run: jest.fn() } as unknown as DownloadPipeline,
+      undefined,
+      delivery
+    );
+    return { handler, getRankingIllustrations };
+  }
+
+  it('asks the ranking API for the scan bound, not for `limit`, on a one-post-per-slot target', async () => {
+    const { handler, getRankingIllustrations } = rankingHarness();
+
+    const works = await (
+      handler as unknown as {
+        fetchIllustrations(target: TargetConfig, mode: string): Promise<PixivIllust[]>;
+      }
+    ).fetchIllustrations({ type: 'illustration', mode: 'ranking', limit: 1 } as TargetConfig, 'ranking');
+
+    // The old code passed `target.limit` straight through, so the whole run
+    // could only ever see ONE candidate — the defect's deepest root.
+    // The mock returns a fixed page, so only the REQUESTED size is the contract
+    // at this layer; the planner enforces the attempt cap downstream.
+    expect(getRankingIllustrations).toHaveBeenCalledWith(DEFAULT_CANDIDATE_SCAN_LIMIT);
+    expect(works.length).toBeGreaterThanOrEqual(DEFAULT_CANDIDATE_SCAN_LIMIT);
+  });
+
+  it('honours an explicit per-target bound when fetching', async () => {
+    const { handler, getRankingIllustrations } = rankingHarness();
+
+    const works = await (
+      handler as unknown as {
+        fetchIllustrations(target: TargetConfig, mode: string): Promise<PixivIllust[]>;
+      }
+    ).fetchIllustrations(
+      { type: 'illustration', mode: 'ranking', limit: 1, candidateScanLimit: 3 } as TargetConfig,
+      'ranking'
+    );
+
+    expect(getRankingIllustrations).toHaveBeenCalledWith(3);
+  });
+
+  it('still asks for at least `limit`, so a multi-work target is not shrunk', async () => {
+    const { handler, getRankingIllustrations } = rankingHarness();
+
+    await (
+      handler as unknown as {
+        fetchIllustrations(target: TargetConfig, mode: string): Promise<PixivIllust[]>;
+      }
+    ).fetchIllustrations({ type: 'illustration', mode: 'ranking', limit: 7 } as TargetConfig, 'ranking');
+
+    expect(getRankingIllustrations).toHaveBeenCalledWith(7);
+  });
+});
+
+describe('DownloadManager wiring', () => {
+  it('hands the global candidateScanLimit and the submitted-work ledger to the planner', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pixivflow-scan-mgr-'));
+    const db = new Database(join(dir, 'test.db'));
+    db.migrate();
+    try {
+      const manager = new DownloadManager(
+        {
+          download: { concurrency: 1, candidateScanLimit: 7 },
+          storage: {},
+          targets: [],
+        } as unknown as StandaloneConfig,
+        { searchIllustrations: jest.fn() } as unknown as IPixivClient,
+        db,
+        { initialise: jest.fn() } as never
+      );
+      const planner = (manager as unknown as { planner: { defaultCandidateScanLimit?: number } }).planner;
+      expect(planner.defaultCandidateScanLimit).toBe(7);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -40,6 +40,10 @@ export const DEFAULT_CONFIG = {
     maxRetries: 3,
     retryDelay: 2000,
     timeout: 60000,
+    // Candidates one execution may ATTEMPT while looking for an eligible work.
+    // Bounded so a ranking page full of already-delivered works cannot loop,
+    // but large enough that a single duplicate no longer burns the slot.
+    candidateScanLimit: 5,
   },
   initialDelay: 0,
 } as const;

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -100,6 +100,24 @@ export function applyEnvironmentOverrides(config: Partial<StandaloneConfig>): Pa
     }
   }
 
+  // Override the bounded candidate-scan window. A non-numeric or non-positive
+  // value is ignored (the config-file value stays authoritative) rather than
+  // silently becoming NaN, which would disable the bound entirely.
+  if (process.env.PIXIV_CANDIDATE_SCAN_LIMIT !== undefined) {
+    const parsed = Number.parseInt(process.env.PIXIV_CANDIDATE_SCAN_LIMIT, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      if (!overridden.download) {
+        overridden.download = { candidateScanLimit: parsed };
+      } else {
+        overridden.download.candidateScanLimit = parsed;
+      }
+    } else {
+      logger.warn('Ignoring PIXIV_CANDIDATE_SCAN_LIMIT: expected a positive integer', {
+        value: process.env.PIXIV_CANDIDATE_SCAN_LIMIT,
+      });
+    }
+  }
+
   // Override proxy from environment variables
   // Priority: all_proxy > https_proxy > http_proxy
   const proxyUrl = process.env.all_proxy || process.env.ALL_PROXY || 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -85,6 +85,20 @@ export interface TargetConfig {
    */
   limit?: number;
   /**
+   * Maximum CANDIDATE works one execution may attempt (not produce) while
+   * looking for an eligible work. A scheduled "one post per slot" target has
+   * `limit: 1`, so without this the run would hold a single candidate: if that
+   * one candidate is already delivered / deleted / private, the slot ends with
+   * nothing submitted. The scan walks up to N candidates in ranking order,
+   * skipping unusable ones, and is strictly bounded so a page full of
+   * duplicates cannot loop.
+   *
+   * Overrides `download.candidateScanLimit` / `PIXIV_CANDIDATE_SCAN_LIMIT`.
+   * Clamped to 1..100 and never below `limit`, so a multi-work target can still
+   * fill its own limit.
+   */
+  candidateScanLimit?: number;
+  /**
    * Search target parameter for Pixiv API.
    */
   searchTarget?: 'partial_match_for_tags' | 'exact_match_for_tags' | 'title_and_caption';
@@ -684,6 +698,13 @@ export interface StandaloneConfig {
      * Default: 60000
      */
     timeout?: number;
+    /**
+     * How many CANDIDATE works one execution may attempt while looking for an
+     * eligible one. Per-target `candidateScanLimit` overrides this.
+     *
+     * Default: 5 (clamped to 1..100)
+     */
+    candidateScanLimit?: number;
   };
 }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -487,6 +487,23 @@ export function validateConfig(config: Partial<StandaloneConfig>, location: stri
     if (config.download.maxRetries !== undefined && (config.download.maxRetries < 0 || config.download.maxRetries > 10)) {
       warnings.push('download.maxRetries: Should be between 0 and 10');
     }
+    if (
+      config.download.candidateScanLimit !== undefined &&
+      (!Number.isInteger(config.download.candidateScanLimit) ||
+        config.download.candidateScanLimit < 1 ||
+        config.download.candidateScanLimit > 100)
+    ) {
+      warnings.push('download.candidateScanLimit: Should be an integer between 1 and 100');
+    }
+  }
+
+  // The bounded candidate scan is what stops a page full of duplicates from
+  // burning a whole scheduled slot, so a non-integer value is reported here.
+  for (const target of config.targets ?? []) {
+    if (target.candidateScanLimit === undefined) continue;
+    if (!Number.isInteger(target.candidateScanLimit) || target.candidateScanLimit < 1 || target.candidateScanLimit > 100) {
+      warnings.push(`targets.${target.id ?? target.tag ?? '?'}.candidateScanLimit: Should be an integer between 1 and 100`);
+    }
   }
 
   // Validate log level

--- a/src/delivery/DeliveryService.ts
+++ b/src/delivery/DeliveryService.ts
@@ -61,6 +61,18 @@ export class DeliveryService {
   }
 
   /**
+   * Bulk CANDIDATE SELECTION dedupe: works already delivered to this target, or
+   * whose review submission is still PENDING an answer. A pending work is
+   * already submitted for review, so it must not be selected (and submitted)
+   * again; the scan moves on to the next candidate instead. Within-slot RESUME
+   * keeps using `isAlreadyDelivered` — a cell continuing its OWN pending work is
+   * resuming it, not duplicating it.
+   */
+  submittedIds(deliveryTarget: string, workType: string, pixivIds: string[]): Set<string> {
+    return this.database.deliveries.submittedIds(deliveryTarget, workType, pixivIds);
+  }
+
+  /**
    * Atomically create the delivery intent + outbox row and advance the cell.
    * Missing local artifact files are treated as a recoverable error (the
    * caller re-runs the download); a crash leaves the intent pending for the

--- a/src/download/DownloadManager.ts
+++ b/src/download/DownloadManager.ts
@@ -166,6 +166,10 @@ export class DownloadManager implements IDownloadManager {
     this.planner = new DownloadPlanner(database, {
       deliveredIds: (target, type, ids) =>
         this.deliveryService.deliveredIds(target, type, ids),
+      // CANDIDATE SELECTION dedupe: also treats a work whose review submission is
+      // still PENDING as taken, so it is skipped instead of submitted again.
+      submittedIds: (target, type, ids) =>
+        this.deliveryService.submittedIds(target, type, ids),
       // Durable duplicate history handed in by the caller (the batch runner asks
       // the control plane for it). Independent of any local delivery target, so it
       // also works for a shadow run that delivers nowhere.
@@ -174,7 +178,10 @@ export class DownloadManager implements IDownloadManager {
         if (!known || known.size === 0) return new Set<string>();
         return new Set(ids.filter((id) => known.has(id)));
       },
-    });
+      // Global bounded candidate-scan window (`download.candidateScanLimit`).
+      // Per-target `candidateScanLimit` overrides it. Without this the pipeline
+      // would only ever see as many candidates as the target's own `limit`.
+    }, config.download?.candidateScanLimit);
     this.executor = new DownloadExecutor();
 
     const downloadConfig = config.download ?? {};
@@ -233,6 +240,12 @@ export class DownloadManager implements IDownloadManager {
       topicFactory,
       this.deliveryService
     );
+
+    // The FETCH stage needs the same bound the planner applies to the attempt
+    // window, or a `limit: 1` target would ask the ranking API for one work and
+    // leave the bounded scan nothing to scan.
+    this.illustrationHandler.setDefaultCandidateScanLimit(config.download?.candidateScanLimit);
+    this.novelHandler.setDefaultCandidateScanLimit(config.download?.candidateScanLimit);
   }
 
   setProgressCallback(callback: (current: number, total: number, message?: string) => void): void {

--- a/src/download/handlers/IllustrationTargetHandler.ts
+++ b/src/download/handlers/IllustrationTargetHandler.ts
@@ -10,15 +10,58 @@ import { NetworkError, isRetryableNetworkError, isPixivKitError } from '../../ut
 import { calculatePopularityScore } from '../../utils/pixiv-utils';
 import { PixivIllust } from '@redtidev/pixiv-client';
 import { DeliveryService } from '../../delivery/DeliveryService';
-import { TargetOutcome } from '../../scheduler/TargetOutcome';
+import {
+  CandidateAttempt,
+  CandidateScanSummary,
+  TargetOutcome,
+  classifyCandidateFailure,
+  classifyJobLevelOutage,
+  hasTransientFailure,
+  mergeScanSummaries,
+  noEligibleCandidateText,
+  skipCandidateWithoutRetry,
+} from '../../scheduler/TargetOutcome';
 import { TargetExecutionContext, isSingleWorkCell } from '../../scheduler/WorkIdentity';
 import type { DownloadedArtifact } from '../../delivery/types';
 import type { TopicPipelineFactory } from '../../topic/createTopicPipeline';
 import { getTargetLabel } from '../../utils/target-label';
+import { resolveCandidateScanLimit } from '../plan/DownloadPlanner';
 
 export class IllustrationTargetHandler {
   /** Outcomes produced during this handle() call (deliveries + terminal non-matches). */
   private outcomes: TargetOutcome[] = [];
+
+  /**
+   * Candidate scan of the last pipeline.run() of this handle() call: how many
+   * candidates were attempted, which were skipped and why, and whether any
+   * job-level outage appeared. This is what turns an empty result into an
+   * explicit verdict instead of an ambiguous "completed".
+   */
+  private scan: CandidateScanSummary | null = null;
+
+  /**
+   * Global candidate-scan bound (`download.candidateScanLimit`), supplied by
+   * DownloadManager. This is what lets the FETCH stage ask for more than one
+   * candidate: a scheduled one-post-per-slot target has `limit: 1`, and asking
+   * the ranking API for exactly one work is the reason a single duplicate used
+   * to be unfixable downstream.
+   */
+  private defaultCandidateScanLimit?: number;
+
+  /** Publish the global candidate-scan bound for the fetch stage. */
+  public setDefaultCandidateScanLimit(limit: number | undefined): void {
+    this.defaultCandidateScanLimit = limit;
+  }
+
+  /**
+   * How many candidates to FETCH so the bounded scan has something to choose
+   * from. Same rule the planner applies to the attempt window, so fetch and
+   * scan agree on one bound.
+   */
+  private candidateFetchLimit(target: TargetConfig): number {
+    const targetLimit = target.limit && target.limit > 0 ? target.limit : 10;
+    return Math.max(targetLimit, resolveCandidateScanLimit(target, this.defaultCandidateScanLimit));
+  }
 
   /**
    * Cell identity for this handle() call. Set only for a single-work cell of a
@@ -39,6 +82,7 @@ export class IllustrationTargetHandler {
 
   async handle(target: TargetConfig, execution?: TargetExecutionContext): Promise<TargetOutcome> {
     this.outcomes = [];
+    this.scan = null;
     this.execution = execution && isSingleWorkCell(target) ? execution : null;
 
     // A cell that already owns a work is in RECOVERY, not in a new selection.
@@ -76,6 +120,7 @@ export class IllustrationTargetHandler {
         'illustration',
         (illust, tag) => this.downloadAndDeliver(illust, tag, target)
       );
+      this.scan = result.scan;
       this.handleDownloadResult(result, target, mode, illusts.length);
       return this.summarize(target);
     } catch (error) {
@@ -83,37 +128,87 @@ export class IllustrationTargetHandler {
     }
   }
 
-  /** Reduce the outcomes collected while processing one target to one cell result. */
+  /**
+   * Reduce the outcomes collected while processing one target to one cell
+   * result, including the bounded-scan bookkeeping.
+   *
+   * A `duplicate` is deliberately NOT a target verdict here: a duplicate is a
+   * CANDIDATE problem (skip it and try the next candidate), which is what the
+   * scan already did. Returning it as the target outcome is the bug that made a
+   * scheduled slot report success after submitting nothing.
+   */
   private summarize(target: TargetConfig): TargetOutcome {
+    const scan = this.scan ?? undefined;
     const submitted = this.outcomes.find((o) => o.kind === 'submitted');
-    if (submitted) return submitted;
+    if (submitted) return scan ? { ...submitted, scan } : submitted;
     const stored = this.outcomes.find((o) => o.kind === 'stored');
-    if (stored) return stored;
+    if (stored) return scan ? { ...stored, scan } : stored;
     const pending = this.outcomes.find((o) => o.kind === 'delivery_pending');
-    if (pending) return pending;
-    const duplicate = this.outcomes.find((o) => o.kind === 'duplicate');
-    if (duplicate) return duplicate;
-    const failed = this.outcomes.find((o) => o.kind === 'failed');
-    if (failed) return failed;
-    return { kind: 'no_candidate', reason: 'no matching illustration after filtering/dedupe' };
+    if (pending) return scan ? { ...pending, scan } : pending;
+    const alreadyFailed = this.outcomes.find((o) => o.kind === 'failed');
+    if (alreadyFailed) return scan ? { ...alreadyFailed, scan } : alreadyFailed;
+    const terminalDuplicate = this.outcomes.find((o) => o.kind === 'duplicate');
+    if (terminalDuplicate) return scan ? { ...terminalDuplicate, scan } : terminalDuplicate;
+    // A job-level outage is never an empty candidate list. Failing here keeps
+    // the existing retry/backoff semantics: the scheduler retries the job on a
+    // later trigger instead of recording a clean no-op.
+    if (scan && scan.outages.length > 0) {
+      return {
+        kind: 'failed',
+        retryable: true,
+        error: `job-level outage while scanning candidates: ${scan.outages.join(', ')}`,
+        scan,
+      };
+    }
+    if (scan && hasTransientFailure(scan)) {
+      return {
+        kind: 'failed',
+        retryable: true,
+        error:
+          `candidate scan hit transient infrastructure failures ` +
+          `(${scan.skipped.filter((s) => s.retryable).length} of ${scan.attempted} attempted)`,
+        scan,
+      };
+    }
+    if (scan && (scan.attempted > 0 || scan.skipped.length > 0)) {
+      return { kind: 'no_candidate', reason: noEligibleCandidateText(scan), scan };
+    }
+    return {
+      kind: 'no_candidate',
+      reason: 'no matching illustration after filtering/dedupe',
+      ...(scan ? { scan } : {}),
+    };
   }
 
   private classifyError(error: unknown, displayTag: string, mode: string, target: TargetConfig): TargetOutcome {
     const message = error instanceof Error ? error.message : String(error);
+    const scan = this.scan ?? undefined;
+    // A hard job-level outage is named as such and is never recorded as a
+    // no-candidate business outcome, whatever its message happens to look like.
+    const outage = classifyJobLevelOutage(error);
     this.database.logExecution(displayTag, 'illustration', 'failed', message);
     logger.error(`Illustration ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, {
       error: message,
       errorType: error instanceof Error ? error.constructor.name : typeof error,
+      ...(outage ? { jobLevelOutage: outage } : {}),
     });
+    if (outage) {
+      return {
+        kind: 'failed',
+        retryable: true,
+        error: `job-level outage (${outage}): ${message}`,
+        ...(scan ? { scan } : {}),
+      };
+    }
     // Explicit no-candidate signals are business outcomes, not failures.
     if (/no matching|all .*filtered|no_candidate/i.test(message)) {
-      return { kind: 'no_candidate', reason: message };
+      return { kind: 'no_candidate', reason: message, ...(scan ? { scan } : {}) };
     }
     // Network/transient => retryable so the SAME work resumes on next trigger.
     const retryable =
         isRetryableNetworkError(error) ||
         (error instanceof Error && /timeout|econn|enotfound|etimed|429|5\d\d/i.test(error.message));
-    return { kind: 'failed', retryable, error: message };
+    return { kind: 'failed', retryable, error: message, ...(scan ? { scan } : {}) };
   }
 
   private async fetchIllustrations(target: TargetConfig, mode: string): Promise<PixivIllust[]> {
@@ -178,16 +273,38 @@ export class IllustrationTargetHandler {
         'illustration',
         (illust, tag) => this.downloadAndDeliver(illust, tag, attemptTarget)
       );
+      // The lookback loop is one bounded scan: accumulate every day's
+      // skips/outages so the final verdict covers all candidates attempted.
+      this.scan = mergeScanSummaries(this.scan, result.scan);
       if (result.downloaded > 0) {
         this.handleDownloadResult(result, target, 'topic', illusts.length);
         return;
       }
+      if (this.scan && this.scan.outages.length > 0) {
+        // A dead token / dead database / dead network is not "no matching
+        // illustration": stop looking back and let the job fail/retry.
+        return;
+      }
     }
 
-    const message = `No matching illustrations found after checking ${checkedDays.length} day(s): ${checkedDays.join(', ')}`;
+    const scan = this.scan;
+    // An explicit no-eligible-candidate verdict needs something to have been
+    // considered. When the scan is empty (nothing surfaced at all) the richer
+    // existing message — which names the days actually checked — is the honest
+    // one, so it is kept.
+    const considered = Boolean(scan && (scan.attempted > 0 || scan.skipped.length > 0));
+    const message = considered
+      ? `${noEligibleCandidateText(scan!)} (checked ${checkedDays.join(', ')})`
+      : `No matching illustrations found after checking ${checkedDays.length} day(s): ${checkedDays.join(', ')}`;
+    // A bounded, exhausted scan IS the success path for a no-op day: nothing
+    // was eligible and nothing was submitted. Recorded as an explicit verdict.
     this.database.logExecution(displayTag, 'illustration', 'success', message);
-    logger.warn(`Illustration topic ${displayTag} produced no matching result`, { checkedDays });
-    this.outcomes.push({ kind: 'no_candidate', reason: message });
+    logger.warn(`Illustration topic ${displayTag} produced no matching result`, { checkedDays, message });
+    this.outcomes.push({
+      kind: 'no_candidate',
+      reason: message,
+      ...(scan ? { scan } : {}),
+    });
   }
 
   private resolveTopicDay(target: TargetConfig): string {
@@ -221,13 +338,17 @@ export class IllustrationTargetHandler {
         endDate: rankingDate,
         limit: Math.max(targetLimit * 20, 100),
       };
+      const fetchLimit = this.candidateFetchLimit(target);
       let illusts = await this.client.searchIllustrations(searchTarget);
       logger.info(`Found ${illusts.length} illustration(s) for ${rankingDate}`);
-      this.sortByPopularityAndLog(illusts, targetLimit, 'illustration');
+      this.sortByPopularityAndLog(illusts, fetchLimit, 'illustration');
 
-      if (illusts.length > targetLimit) {
-        illusts = illusts.slice(0, targetLimit);
-        logger.info(`Selected top ${illusts.length} illustration(s) by popularity`);
+      if (illusts.length > fetchLimit) {
+        illusts = illusts.slice(0, fetchLimit);
+        logger.info(
+          `Selected top ${illusts.length} illustration(s) by popularity ` +
+            `(to fill ${targetLimit}, candidate scan bound ${fetchLimit})`
+        );
       }
       return illusts;
     } else {
@@ -238,10 +359,12 @@ export class IllustrationTargetHandler {
       }
 
       logger.info(`Fetching ranking illustrations (mode: ${rankingMode}, date: ${rankingDate})`);
+      // Ask for the whole bounded scan window, not `limit`: the planner then
+      // narrows it to the candidates this run may attempt.
       const illusts = await this.rankingService.getRankingIllustrationsWithFallback(
         rankingMode,
         rankingDate,
-        target.limit
+        this.candidateFetchLimit(target)
       );
       logger.info(`Ranking API returned ${illusts.length} illustration(s)`);
       return illusts;
@@ -279,6 +402,7 @@ export class IllustrationTargetHandler {
       alreadyDownloaded: number;
       filteredOut: number;
       skipDetails?: { id: string; error: string }[];
+      scan: CandidateScanSummary;
     },
     target: TargetConfig,
     mode: string,
@@ -288,9 +412,23 @@ export class IllustrationTargetHandler {
     const targetLimit = target.limit || 10;
     const tagForLog = getTargetLabel(target);
 
-    if (downloaded === 0 && targetLimit > 0) {
+    // The bounded scan produced its own explicit verdict when it attempted
+    // candidates or pre-filtered some, so the legacy "zero downloads" reporter
+    // is only the fallback for a scan that had nothing at all to look at.
+    const scanOwnsVerdict = result.scan.attempted > 0 || result.scan.skipped.length > 0;
+    if (downloaded === 0 && targetLimit > 0 && !scanOwnsVerdict) {
       this.handleZeroDownloads(
         alreadyDownloaded, skipped, filteredOut, totalFound, targetLimit, tagForLog, mode, result.skipDetails
+      );
+    }
+
+    if (scanOwnsVerdict && downloaded > 0) {
+      // The explicit success sentence the operator needs: which work was
+      // submitted, and how many unusable candidates were skipped to reach it.
+      logger.info(
+        `Candidate scan verdict for ${tagForLog}: submitted after skipping ` +
+          `${result.scan.skipped.length} candidate(s) of ${result.scan.attempted} attempted ` +
+          `(bound ${result.scan.bound})`
       );
     }
 
@@ -372,12 +510,29 @@ export class IllustrationTargetHandler {
     try {
       if (this.database.hasDownloaded(String(illustId), 'illustration')) {
         logger.info(`Illustration ${illustId} already downloaded, skipping`);
+        // A pinned single-work target has no candidate list to advance to, but
+        // the reason is still recorded as a candidate skip so the terminal
+        // outcome names it instead of reporting an unexplained no-op.
+        this.scan = {
+          bound: 1,
+          attempted: 0,
+          skipped: [
+            { code: 'duplicate', workId: String(illustId), reason: 'already in download history' },
+          ],
+          outages: [],
+        };
         return;
       }
 
       const detail = await this.client.getIllustration(illustId);
       // Use the detail directly as it's already a PixivIllust
-      await this.downloadAndDeliver(detail, `illust-${illustId}`, target);
+      const attempt = await this.downloadAndDeliver(detail, `illust-${illustId}`, target);
+      this.scan = {
+        bound: 1,
+        attempted: 1,
+        skipped: attempt.kind === 'skipped' ? [attempt.skip] : [],
+        outages: [],
+      };
       logger.info(`Successfully downloaded illustration ${illustId}`);
     } catch (error) {
       this.logError(error, `Failed to download illustration ${illustId}`);
@@ -411,6 +566,7 @@ export class IllustrationTargetHandler {
         'illustration',
         (illust, tag) => this.downloadAndDeliver(illust, tag, target)
       );
+      this.scan = result.scan;
       this.handleDownloadResult(result, target, 'user', illusts.length);
     } catch (error) {
       this.logError(error, `Failed to download illustrations for user ${userId}`);
@@ -505,7 +661,18 @@ export class IllustrationTargetHandler {
 
     try {
       const detail = await this.client.getIllustration(illustId);
-      await this.downloadAndDeliver(detail, displayTag, target);
+      const attempt = await this.downloadAndDeliver(detail, displayTag, target);
+      if (attempt.kind === 'skipped') {
+        // A cell that already owns a work cannot advance to another candidate —
+        // its identity is fixed. An already-delivered locked work is therefore a
+        // terminal business duplicate for THIS cell (it published nothing new),
+        // not a candidate skip and not an empty candidate list.
+        this.outcomes.push(
+          attempt.skip.code === 'duplicate'
+            ? { kind: 'duplicate', workId: lockedWorkId, reason: attempt.skip.reason }
+            : { kind: 'failed', retryable: false, error: `LOCKED_WORK_UNAVAILABLE: ${attempt.skip.reason}` }
+        );
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const retryable = isRetryableNetworkError(error);
@@ -523,6 +690,11 @@ export class IllustrationTargetHandler {
   /**
    * Process ONE candidate work for this cell.
    *
+   * Returns what happened to THIS candidate, so the pipeline can advance to the
+   * next one when it was unusable. Throwing is reserved for JOB-level failures
+   * (dead database / dead token / dead delivery provider): a candidate-level
+   * failure is reported as a `skipped` attempt and never as a job verdict.
+   *
    * The cell is bound to `illust` BEFORE any side effect: it is the binding, not
    * the candidate list, that decides what a later recovery resumes. The binding
    * is only rolled back when the attempt produced no artifact at all, so in-run
@@ -532,7 +704,7 @@ export class IllustrationTargetHandler {
     illust: PixivIllust,
     tag: string,
     target: TargetConfig
-  ): Promise<void> {
+  ): Promise<CandidateAttempt> {
     const execution = this.execution;
     const workId = String(illust.id);
     // Recovery continues a work the cell already bound; it must never be released.
@@ -547,7 +719,14 @@ export class IllustrationTargetHandler {
           targetId: execution.targetId,
           boundWorkId: binding.workId,
         });
-        return;
+        return {
+          kind: 'skipped',
+          skip: {
+            code: 'duplicate',
+            workId,
+            reason: `cell already owns work ${binding.workId} (concurrent selection)`,
+          },
+        };
       }
     }
 
@@ -567,15 +746,37 @@ export class IllustrationTargetHandler {
     } catch (error) {
       // Nothing was persisted, so the cell may still pick another candidate.
       if (execution && !recovering) execution.release(workId);
-      throw error;
+      const failure = classifyCandidateFailure(error, workId);
+      if (failure.scope === 'job' || !skipCandidateWithoutRetry(failure.skip)) {
+        // Job-level outage, or a transient candidate failure: re-thrown so the
+        // queue's existing retry/backoff owns it and the scheduler records a JOB
+        // failure — never an exhausted candidate list.
+        throw error;
+      }
+      this.logError(error, `Candidate illustration ${workId} skipped (${failure.skip.code})`);
+      return { kind: 'skipped', skip: failure.skip };
     }
     if (!artifact) {
+      // Nothing was persisted: the downloader deliberately declined this
+      // candidate (over maxPageCount, AI metadata check, already on disk). That
+      // is a fact about the work, so the scan moves on instead of retrying it.
       if (execution && !recovering) execution.release(workId);
-      return;
+      return {
+        kind: 'skipped',
+        skip: { code: 'filtered', workId, reason: 'downloader declined this candidate (no artifact)' },
+      };
     }
-    // Committed: the artifact is durable and this work now defines the cell. Even
-    // if enqueue throws below, recovery must resume THIS work — never release.
-    this.recordArtifactOutcome(artifact, target);
+    // The artifact is durable, but this cell has NOT committed to it until the
+    // delivery below actually claims it. A candidate that turns out to be a
+    // duplicate must give the binding BACK, or `bind()` would refuse the next
+    // candidate and the scan could never advance — the whole point of this
+    // change. `releaseCellWork` itself refuses once the cell moved on
+    // (delivery_pending/submitted), so a committed identity stays stable.
+    const attempt = this.recordArtifactOutcome(artifact, target);
+    if (attempt.kind === 'skipped' && execution && !recovering) {
+      execution.release(workId);
+    }
+    return attempt;
   }
 
   /**
@@ -583,22 +784,33 @@ export class IllustrationTargetHandler {
    * delivery mode the DeliveryService creates the durable intent atomically and
    * the result is 'delivery_pending' (NOT submitted — the OutboxWorker confirms
    * the ACK). Persistent/download-only runs are 'stored'.
+   *
+   * An ALREADY-DELIVERED work is returned as a candidate SKIP, never as a
+   * target outcome: the run must try the next candidate instead of ending the
+   * slot as a `duplicate`. The delivery idempotency ledger is what makes the
+   * second concurrent worker lose this race instead of double-submitting.
    */
   private recordArtifactOutcome(
     artifact: import('../../delivery/types').DownloadedArtifact,
     target: TargetConfig
-  ): void {
+  ): CandidateAttempt {
     const isDelivery = target.storageMode === 'cache' && target.delivery?.target?.trim();
     if (!isDelivery || !this.deliveryService) {
       this.outcomes.push({ kind: 'stored', workId: artifact.pixivId, workType: artifact.type });
-      return;
+      return { kind: 'selected', workId: artifact.pixivId, workType: artifact.type };
     }
     // Pre-lock delivery dedupe (after selection): if the ledger already knows it,
     // that is a confirmed fact, not a new submission.
     const slotId = (target.delivery as { executionContext?: { slotId?: string } } | undefined)?.executionContext?.slotId;
     if (this.deliveryService.isAlreadyDelivered(target.delivery!.target!, artifact.type, artifact.pixivId)) {
-      this.outcomes.push({ kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered to target (ledger)' });
-      return;
+      return {
+        kind: 'skipped',
+        skip: {
+          code: 'duplicate',
+          workId: artifact.pixivId,
+          reason: 'already delivered to target (delivery ledger)',
+        },
+      };
     }
     const res = this.deliveryService.enqueue(artifact, target, {
       slotId,
@@ -606,10 +818,22 @@ export class IllustrationTargetHandler {
       extraContext: this.executionContextFields(target),
     });
     if (res.duplicate) {
-      this.outcomes.push({ kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered to target (ledger)' });
-    } else {
-      this.outcomes.push({ kind: 'delivery_pending', workId: artifact.pixivId, workType: artifact.type, deliveryId: res.deliveryId });
+      return {
+        kind: 'skipped',
+        skip: {
+          code: 'duplicate',
+          workId: artifact.pixivId,
+          reason: 'already delivered to target (idempotency ledger)',
+        },
+      };
     }
+    this.outcomes.push({
+      kind: 'delivery_pending',
+      workId: artifact.pixivId,
+      workType: artifact.type,
+      deliveryId: res.deliveryId,
+    });
+    return { kind: 'selected', workId: artifact.pixivId, workType: artifact.type };
   }
 
   private executionContextFields(target: TargetConfig): Record<string, unknown> {

--- a/src/download/handlers/NovelTargetHandler.ts
+++ b/src/download/handlers/NovelTargetHandler.ts
@@ -10,14 +10,57 @@ import { getTodayDate, getYesterdayDate } from '../../utils/pixiv-date-utils';
 import { calculatePopularityScore } from '../../utils/pixiv-utils';
 import { PixivNovel } from '@redtidev/pixiv-client';
 import { DeliveryService } from '../../delivery/DeliveryService';
-import { TargetOutcome } from '../../scheduler/TargetOutcome';
+import {
+  CandidateAttempt,
+  CandidateScanSummary,
+  TargetOutcome,
+  classifyCandidateFailure,
+  classifyJobLevelOutage,
+  hasTransientFailure,
+  mergeScanSummaries,
+  noEligibleCandidateText,
+  skipCandidateWithoutRetry,
+} from '../../scheduler/TargetOutcome';
 import { TargetExecutionContext, isSingleWorkCell } from '../../scheduler/WorkIdentity';
 import type { DownloadedArtifact } from '../../delivery/types';
 import type { TopicPipelineFactory } from '../../topic/createTopicPipeline';
 import { getTargetLabel } from '../../utils/target-label';
+import { resolveCandidateScanLimit } from '../plan/DownloadPlanner';
 
 export class NovelTargetHandler {
   private outcomes: TargetOutcome[] = [];
+
+  /**
+   * Candidate scan of the last pipeline.run() of this handle() call: how many
+   * candidates were attempted, which were skipped and why, and whether any
+   * job-level outage appeared. This is what turns an empty result into an
+   * explicit verdict instead of an ambiguous "completed".
+   */
+  private scan: CandidateScanSummary | null = null;
+
+  /**
+   * Global candidate-scan bound (`download.candidateScanLimit`), supplied by
+   * DownloadManager. This is what lets the FETCH stage ask for more than one
+   * candidate: a scheduled one-post-per-slot target has `limit: 1`, and asking
+   * the ranking API for exactly one work is the reason a single duplicate used
+   * to be unfixable downstream.
+   */
+  private defaultCandidateScanLimit?: number;
+
+  /** Publish the global candidate-scan bound for the fetch stage. */
+  public setDefaultCandidateScanLimit(limit: number | undefined): void {
+    this.defaultCandidateScanLimit = limit;
+  }
+
+  /**
+   * How many candidates to FETCH so the bounded scan has something to choose
+   * from. Same rule the planner applies to the attempt window, so fetch and
+   * scan agree on one bound.
+   */
+  private candidateFetchLimit(target: TargetConfig): number {
+    const targetLimit = target.limit && target.limit > 0 ? target.limit : 10;
+    return Math.max(targetLimit, resolveCandidateScanLimit(target, this.defaultCandidateScanLimit));
+  }
 
   /**
    * Cell identity for this handle() call. Set only for a single-work cell of a
@@ -38,6 +81,7 @@ export class NovelTargetHandler {
 
   async handle(target: TargetConfig, execution?: TargetExecutionContext): Promise<TargetOutcome> {
     this.outcomes = [];
+    this.scan = null;
     this.execution = execution && isSingleWorkCell(target) ? execution : null;
 
     // A cell that already owns a work is in RECOVERY, not in a new selection.
@@ -88,6 +132,7 @@ export class NovelTargetHandler {
         'novel',
         (novel, tag) => this.downloadAndDeliver(novel, tag, target)
       );
+      this.scan = result.scan;
       await this.handleDownloadResult(result, target, mode, novels.length);
       return this.summarize();
     } catch (error) {
@@ -95,30 +140,82 @@ export class NovelTargetHandler {
     }
   }
 
+  /**
+   * Reduce the outcomes collected while processing one target to one verdict,
+   * including the bounded-scan bookkeeping.
+   *
+   * A `duplicate` is deliberately NOT a target verdict for a scan: a duplicate
+   * is a CANDIDATE problem (skip it and try the next), which is what the scan
+   * already did. Returning it here is the bug that made a scheduled slot report
+   * success after submitting nothing. It remains a verdict only for the
+   * single-work RECOVERY path, whose cell identity is fixed.
+   */
   private summarize(): TargetOutcome {
-    return (
-      this.outcomes.find((o) => o.kind === 'submitted') ??
-      this.outcomes.find((o) => o.kind === 'stored') ??
-      this.outcomes.find((o) => o.kind === 'delivery_pending') ??
-      this.outcomes.find((o) => o.kind === 'duplicate') ??
-      this.outcomes.find((o) => o.kind === 'failed') ?? {
-        kind: 'no_candidate',
-        reason: 'no matching novel after filtering/dedupe',
-      }
-    );
+    const scan = this.scan ?? undefined;
+    const submitted = this.outcomes.find((o) => o.kind === 'submitted');
+    if (submitted) return scan ? { ...submitted, scan } : submitted;
+    const stored = this.outcomes.find((o) => o.kind === 'stored');
+    if (stored) return scan ? { ...stored, scan } : stored;
+    const pending = this.outcomes.find((o) => o.kind === 'delivery_pending');
+    if (pending) return scan ? { ...pending, scan } : pending;
+    const duplicate = this.outcomes.find((o) => o.kind === 'duplicate');
+    if (duplicate) return scan ? { ...duplicate, scan } : duplicate;
+    const failed = this.outcomes.find((o) => o.kind === 'failed');
+    if (failed) return scan ? { ...failed, scan } : failed;
+    if (scan && scan.outages.length > 0) {
+      return {
+        kind: 'failed',
+        retryable: true,
+        error: `job-level outage while scanning candidates: ${scan.outages.join(', ')}`,
+        scan,
+      };
+    }
+    if (scan && hasTransientFailure(scan)) {
+      return {
+        kind: 'failed',
+        retryable: true,
+        error:
+          `candidate scan hit transient infrastructure failures ` +
+          `(${scan.skipped.filter((s) => s.retryable).length} of ${scan.attempted} attempted)`,
+        scan,
+      };
+    }
+    if (scan && (scan.attempted > 0 || scan.skipped.length > 0)) {
+      return { kind: 'no_candidate', reason: noEligibleCandidateText(scan), scan };
+    }
+    return {
+      kind: 'no_candidate',
+      reason: 'no matching novel after filtering/dedupe',
+      ...(scan ? { scan } : {}),
+    };
   }
 
   private classifyError(error: unknown, displayTag: string, mode: string): TargetOutcome {
     const message = error instanceof Error ? error.message : String(error);
+    const scan = this.scan ?? undefined;
+    // A hard job-level outage is named as such and is never recorded as a
+    // no-candidate business outcome, whatever its message happens to look like.
+    const outage = classifyJobLevelOutage(error);
     this.database.logExecution(displayTag, 'novel', 'failed', message);
-    logger.error(`Novel ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, { error: message });
+    logger.error(`Novel ${mode === 'ranking' ? 'ranking' : 'tag'} ${displayTag} failed`, {
+      error: message,
+      ...(outage ? { jobLevelOutage: outage } : {}),
+    });
+    if (outage) {
+      return {
+        kind: 'failed',
+        retryable: true,
+        error: `job-level outage (${outage}): ${message}`,
+        ...(scan ? { scan } : {}),
+      };
+    }
     if (/no matching|all .*filtered|no_candidate|language filter/i.test(message)) {
-      return { kind: 'no_candidate', reason: message };
+      return { kind: 'no_candidate', reason: message, ...(scan ? { scan } : {}) };
     }
     const retryable =
         isRetryableNetworkError(error) ||
         (error instanceof Error && /timeout|econn|enotfound|etimed|429|5\d\d/i.test(error.message));
-    return { kind: 'failed', retryable, error: message };
+    return { kind: 'failed', retryable, error: message, ...(scan ? { scan } : {}) };
   }
 
   private async fetchNovels(target: TargetConfig, mode: string): Promise<PixivNovel[]> {
@@ -167,6 +264,7 @@ export class NovelTargetHandler {
       skipped: 0,
       alreadyDownloaded: 0,
       filteredOut: 0,
+      scan: { bound: 0, attempted: 0, skipped: [], outages: [] },
     };
     let totalFound = 0;
 
@@ -193,11 +291,21 @@ export class NovelTargetHandler {
         'novel',
         (novel, tag) => this.downloadAndDeliver(novel, tag, attemptTarget)
       );
+      // The lookback loop is ONE bounded scan: accumulate every day's
+      // skips/outages so the verdict covers all candidates attempted.
+      aggregate.scan = mergeScanSummaries(aggregate.scan, result.scan);
       aggregate.downloaded += result.downloaded;
       aggregate.skipped += result.skipped;
       aggregate.alreadyDownloaded += result.alreadyDownloaded;
       aggregate.filteredOut += result.filteredOut;
+      if (aggregate.scan.outages.length > 0) {
+        // A dead token / dead database / dead network is not "no matching
+        // novel": stop looking back and let the job fail/retry.
+        break;
+      }
     }
+
+    this.scan = aggregate.scan;
 
     await this.handleDownloadResult(
       aggregate,
@@ -237,13 +345,17 @@ export class NovelTargetHandler {
         endDate: rankingDate,
         limit: Math.max(targetLimit * 20, 100),
       };
+      const fetchLimit = this.candidateFetchLimit(target);
       let novels = await this.client.searchNovels(searchTarget);
       logger.info(`Found ${novels.length} novel(s) for ${rankingDate}`);
-      this.sortByPopularityAndLog(novels, targetLimit);
+      this.sortByPopularityAndLog(novels, fetchLimit);
 
-      if (novels.length > targetLimit) {
-        novels = novels.slice(0, targetLimit);
-        logger.info(`Selected top ${novels.length} novel(s) by popularity`);
+      if (novels.length > fetchLimit) {
+        novels = novels.slice(0, fetchLimit);
+        logger.info(
+          `Selected top ${novels.length} novel(s) by popularity ` +
+            `(to fill ${targetLimit}, candidate scan bound ${fetchLimit})`
+        );
       }
       return novels;
     } else {
@@ -254,7 +366,13 @@ export class NovelTargetHandler {
       }
 
       logger.info(`Fetching ranking novels (mode: ${rankingMode}, date: ${rankingDate})`);
-      const novels = await this.rankingService.getRankingNovelsWithFallback(rankingMode, rankingDate, target.limit);
+      // Ask for the whole bounded scan window, not `limit`: the planner then
+      // narrows it to the candidates this run may attempt.
+      const novels = await this.rankingService.getRankingNovelsWithFallback(
+        rankingMode,
+        rankingDate,
+        this.candidateFetchLimit(target)
+      );
       logger.info(`Ranking API returned ${novels.length} novel(s)`);
       return novels;
     }
@@ -291,6 +409,7 @@ export class NovelTargetHandler {
       alreadyDownloaded: number;
       filteredOut: number;
       skipDetails?: { id: string; error: string }[];
+      scan: CandidateScanSummary;
     },
     target: TargetConfig,
     mode: string,
@@ -301,7 +420,11 @@ export class NovelTargetHandler {
     const targetLimit = target.limit || 10;
     const tagForLog = getTargetLabel(target);
 
-    if (downloaded === 0 && targetLimit > 0) {
+    // The bounded scan produced its own explicit verdict when it attempted
+    // candidates or pre-filtered some, so the legacy "zero downloads" reporter
+    // is only the fallback for a scan that had nothing at all to look at.
+    const scanOwnsVerdict = result.scan.attempted > 0 || result.scan.skipped.length > 0;
+    if (downloaded === 0 && targetLimit > 0 && !scanOwnsVerdict) {
       await this.handleZeroDownloads(
         alreadyDownloaded,
         skipped,
@@ -315,6 +438,14 @@ export class NovelTargetHandler {
         result.skipDetails
       );
       return;
+    }
+
+    if (scanOwnsVerdict && downloaded > 0) {
+      logger.info(
+        `Candidate scan verdict for ${tagForLog}: submitted after skipping ` +
+          `${result.scan.skipped.length} candidate(s) of ${result.scan.attempted} attempted ` +
+          `(bound ${result.scan.bound})`
+      );
     }
 
     if (downloaded > 0 && downloaded < targetLimit * 0.5 && skipped > 0) {
@@ -496,6 +627,7 @@ export class NovelTargetHandler {
         'novel',
         (novel, tag) => this.downloadAndDeliver(novel, tag, target)
       );
+      this.scan = result.scan;
       this.handleDownloadResult(result, target, 'user', novels.length);
     } catch (error) {
       this.logError(error, `Failed to download novels for user ${userId}`);
@@ -591,7 +723,17 @@ export class NovelTargetHandler {
         user: detail.user,
         create_date: detail.create_date,
       };
-      await this.downloadAndDeliver(novel, `novel-${novelId}`, target);
+      const attempt = await this.downloadAndDeliver(novel, `novel-${novelId}`, target);
+      if (attempt.kind === 'skipped') {
+        // A cell that already owns a work cannot advance to another candidate —
+        // its identity is fixed. An already-delivered locked work is therefore a
+        // terminal business duplicate for THIS cell (it published nothing new).
+        this.outcomes.push(
+          attempt.skip.code === 'duplicate'
+            ? { kind: 'duplicate', workId: lockedWorkId, reason: attempt.skip.reason }
+            : { kind: 'failed', retryable: false, error: `LOCKED_WORK_UNAVAILABLE: ${attempt.skip.reason}` }
+        );
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const retryable = isRetryableNetworkError(error);
@@ -609,6 +751,11 @@ export class NovelTargetHandler {
   /**
    * Process ONE candidate work for this cell.
    *
+   * Returns what happened to THIS candidate, so the pipeline can advance to the
+   * next one when it was unusable. Throwing is reserved for JOB-level failures
+   * (dead database / dead token / dead delivery provider): a candidate-level
+   * failure is reported as a `skipped` attempt and never as a job verdict.
+   *
    * The cell is bound to `novel` BEFORE any side effect: it is the binding, not
    * the candidate list, that decides what a later recovery resumes. The binding
    * is only rolled back when the attempt produced no artifact at all, so in-run
@@ -618,7 +765,7 @@ export class NovelTargetHandler {
     novel: PixivNovel,
     tag: string,
     target: TargetConfig
-  ): Promise<void> {
+  ): Promise<CandidateAttempt> {
     const execution = this.execution;
     const workId = String(novel.id);
     // Recovery continues a work the cell already bound; it must never be released.
@@ -633,7 +780,14 @@ export class NovelTargetHandler {
           targetId: execution.targetId,
           boundWorkId: binding.workId,
         });
-        return;
+        return {
+          kind: 'skipped',
+          skip: {
+            code: 'duplicate',
+            workId,
+            reason: `cell already owns work ${binding.workId} (concurrent selection)`,
+          },
+        };
       }
     }
 
@@ -643,33 +797,85 @@ export class NovelTargetHandler {
     } catch (error) {
       // Nothing was persisted, so the cell may still pick another candidate.
       if (execution && !recovering) execution.release(workId);
-      throw error;
+      const failure = classifyCandidateFailure(error, workId);
+      if (failure.scope === 'job' || !skipCandidateWithoutRetry(failure.skip)) {
+        // Job-level outage, or a transient candidate failure: re-thrown so the
+        // queue's existing retry/backoff owns it and the scheduler records a JOB
+        // failure — never an exhausted candidate list.
+        throw error;
+      }
+      this.logError(error, `Candidate novel ${workId} skipped (${failure.skip.code})`);
+      return { kind: 'skipped', skip: failure.skip };
     }
     if (!artifact) {
       if (execution && !recovering) execution.release(workId);
-      return;
+      return {
+        kind: 'skipped',
+        skip: { code: 'filtered', workId, reason: 'downloader declined this candidate (no artifact)' },
+      };
     }
-    // Committed: the artifact is durable and this work now defines the cell. Even
-    // if the delivery below throws, recovery must resume THIS work — never release.
+    // The artifact is durable, but this cell has NOT committed to it until the
+    // delivery below actually claims it. A candidate that turns out to be a
+    // duplicate must give the binding BACK, or `bind()` would refuse the next
+    // candidate and the scan could never advance — the whole point of this
+    // change. `releaseCellWork` itself refuses once the cell moved on
+    // (delivery_pending/submitted), so a committed identity stays stable.
+    const attempt = this.recordArtifactOutcome(artifact, target);
+    if (attempt.kind === 'skipped' && execution && !recovering) {
+      execution.release(workId);
+    }
+    return attempt;
+  }
+
+  /**
+   * Turn a downloaded novel artifact into the target's business outcome.
+   *
+   * An ALREADY-DELIVERED work is returned as a candidate SKIP, never as a
+   * target outcome: the run must try the next candidate instead of ending the
+   * slot as a `duplicate`. The delivery idempotency ledger is what makes the
+   * second concurrent worker lose this race instead of double-submitting.
+   */
+  private recordArtifactOutcome(
+    artifact: DownloadedArtifact,
+    target: TargetConfig
+  ): CandidateAttempt {
     const isDelivery = target.storageMode === 'cache' && target.delivery?.target?.trim();
     if (!isDelivery || !this.deliveryService) {
       this.outcomes.push({ kind: 'stored', workId: artifact.pixivId, workType: artifact.type });
-      return;
+      return { kind: 'selected', workId: artifact.pixivId, workType: artifact.type };
     }
     const ec = target.delivery as { executionContext?: { slotId?: string } } | undefined;
     const slotId = ec?.executionContext?.slotId;
     if (this.deliveryService.isAlreadyDelivered(target.delivery!.target!, artifact.type, artifact.pixivId)) {
-      this.outcomes.push({ kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered to target (ledger)' });
-      return;
+      return {
+        kind: 'skipped',
+        skip: {
+          code: 'duplicate',
+          workId: artifact.pixivId,
+          reason: 'already delivered to target (delivery ledger)',
+        },
+      };
     }
     const res = this.deliveryService.enqueue(artifact, target, {
       slotId,
       fields: target.delivery?.fields as Record<string, unknown> | undefined,
     });
-    this.outcomes.push(
-      res.duplicate
-        ? { kind: 'duplicate', workId: artifact.pixivId, reason: 'already delivered (ledger)' }
-        : { kind: 'delivery_pending', workId: artifact.pixivId, workType: artifact.type, deliveryId: res.deliveryId }
-    );
+    if (res.duplicate) {
+      return {
+        kind: 'skipped',
+        skip: {
+          code: 'duplicate',
+          workId: artifact.pixivId,
+          reason: 'already delivered (idempotency ledger)',
+        },
+      };
+    }
+    this.outcomes.push({
+      kind: 'delivery_pending',
+      workId: artifact.pixivId,
+      workType: artifact.type,
+      deliveryId: res.deliveryId,
+    });
+    return { kind: 'selected', workId: artifact.pixivId, workType: artifact.type };
   }
 }

--- a/src/download/pipeline/DownloadPipeline.ts
+++ b/src/download/pipeline/DownloadPipeline.ts
@@ -7,17 +7,36 @@ import { DownloadPlanner } from '../plan/DownloadPlanner';
 import { DownloadExecutor } from '../exec/DownloadExecutor';
 import { ProgressReporter } from '../report/ProgressReporter';
 import { ErrorRecoveryStrategy, RecoveryDecision } from '../recovery/ErrorRecovery';
+import {
+  CandidateAttempt,
+  CandidateScanSummary,
+  CandidateSkip,
+  classifyCandidateFailure,
+  isSelectedAttempt,
+} from '../../scheduler/TargetOutcome';
 
 type DownloadItem = PixivIllust | PixivNovel;
 type ItemType = 'illustration' | 'novel';
 
 export interface DownloadPipelineResult {
+  /**
+   * Candidates that PRODUCED a business result for this target. A candidate
+   * that was skipped (duplicate, deleted, private, ...) does not count: that is
+   * precisely the accounting error that let a duplicate end a scheduled slot as
+   * a completed run.
+   */
   downloaded: number;
+  /** Candidates the executor skipped after an error (legacy error counter). */
   skipped: number;
   alreadyDownloaded: number;
   filteredOut: number;
   /** Per-candidate skip reasons (first few), so callers can report the real cause. */
   skipDetails?: { id: string; error: string }[];
+  /**
+   * Bounded candidate-scan bookkeeping. Always present, so the caller can state
+   * an explicit terminal outcome instead of "completed".
+   */
+  scan: CandidateScanSummary;
 }
 
 export interface DownloadPipelineDependencies {
@@ -32,6 +51,18 @@ export interface DownloadPipelineDependencies {
    */
   isCancelled?: () => boolean;
 }
+
+/**
+ * What a candidate hook must report back: did this candidate produce the
+ * target's business result, or was it unusable?
+ *
+ * `void` is accepted and treated as `selected`, so a hook with no
+ * candidate-level information keeps the historical meaning of "it resolved".
+ */
+export type CandidateDownloadFn<T extends DownloadItem> = (
+  item: T,
+  tag: string
+) => Promise<CandidateAttempt | void>;
 
 export class DownloadPipeline {
   private readonly config: StandaloneConfig;
@@ -54,7 +85,7 @@ export class DownloadPipeline {
     items: T[],
     target: TargetConfig,
     itemType: ItemType,
-    downloadFn: (item: T, tag: string) => Promise<void>
+    downloadFn: CandidateDownloadFn<T>
   ): Promise<DownloadPipelineResult> {
     const tagForLog = getTargetLabel(target);
     const plan = this.planner.planDownloads(items, target, itemType);
@@ -71,17 +102,148 @@ export class DownloadPipeline {
       skippedCount: 0,
       skipDetails: [] as { id: string; error: string }[],
     };
-    const concurrency = plan.mode === 'sequential' && plan.queue.length > targetLimit
-      ? 1
-      : itemType === 'novel' && target.languageFilter
-      ? 1
-      : (this.config.download?.concurrency || 3);
+
+    /**
+     * Bounded candidate scan bookkeeping. `bound` is the plan's window (the
+     * planner already clamped it to the configured limit) AND the item list
+     * length, so the scan is structurally unable to exceed it: a page full of
+     * duplicates terminates after at most `bound` attempts instead of looping.
+     */
+    const scan: CandidateScanSummary = {
+      bound: plan.scanBound ?? plan.queue.length,
+      attempted: 0,
+      skipped: [...(plan.prefiltered ?? [])],
+      outages: [],
+    };
+    /**
+     * Candidate INDEXES this run has attempted. Retries of the same candidate
+     * (the executor's backoff path) must not count as new candidates, and must
+     * not be blocked by the bound: that would silently convert a retried failure
+     * into a success.
+     */
+    const attemptedIndices = new Set<number>();
+    if (scan.skipped.length > 0) {
+      logger.info(
+        `Candidate scan pre-filtered ${scan.skipped.length} candidate(s) before download ` +
+          `(${[...new Set(scan.skipped.map((s) => s.code))].join(', ')})`,
+        { target: tagForLog }
+      );
+    }
+
+    /** Record a candidate-level skip: the scan advances to the next candidate. */
+    const recordCandidateSkip = (skip: CandidateSkip): void => {
+      scan.skipped.push(skip);
+      if (scan.skipped.length <= 5) {
+        logger.info(
+          `Candidate ${skip.workId} skipped (${skip.code}${skip.retryable ? ', transient' : ''}): ${skip.reason}`,
+          { target: tagForLog }
+        );
+      }
+      if (state.skipDetails.length < 3 && !state.skipDetails.some((d) => d.id === skip.workId)) {
+        state.skipDetails.push({ id: skip.workId, error: skip.reason });
+      }
+    };
+
+    /**
+     * Classify a candidate FAILURE. A dead database / dead token / dead
+     * delivery provider / dead network is a JOB problem and is recorded as an
+     * outage, so the target can fail instead of reporting "no eligible
+     * candidate". Anything else is a candidate problem: skip, try the next.
+     */
+    const recordCandidateFailure = (error: unknown, workId: string): void => {
+      const failure = classifyCandidateFailure(error, workId);
+      if (failure.scope === 'job') {
+        if (!scan.outages.includes(failure.outage)) {
+          scan.outages.push(failure.outage);
+        }
+        logger.error(`Job-level outage while scanning (${failure.outage}): ${failure.error}`, {
+          target: tagForLog,
+          candidate: workId,
+        });
+        return;
+      }
+      recordCandidateSkip(failure.skip);
+      state.skippedCount++;
+    };
+
+    const runOptions = {
+      concurrency:
+        plan.mode === 'sequential' && plan.queue.length > targetLimit
+          ? 1
+          : itemType === 'novel' && target.languageFilter
+          ? 1
+          : this.config.download?.concurrency || 3,
+      maxAttempts: retryAttempts,
+      recovery: this.recovery,
+      contextProvider: () => ({ itemType }),
+      task: async (item: T, index: number) => {
+        if (state.downloaded >= targetLimit || this.isRunCancelled()) {
+          return;
+        }
+        // Strict bound, measured in CANDIDATES — not in task invocations. A
+        // retry of the same candidate (the executor's backoff path) must not
+        // consume a new slot, or the guard would silently turn a retried failure
+        // into a success and swallow it.
+        if (!attemptedIndices.has(index)) {
+          if (attemptedIndices.size >= scan.bound) {
+            return;
+          }
+          attemptedIndices.add(index);
+          scan.attempted = attemptedIndices.size;
+        }
+        const attempt = await downloadFn(item, tagForLog);
+        if (isSelectedAttempt(attempt)) {
+          state.downloaded++;
+        } else if (attempt?.kind === 'skipped') {
+          recordCandidateSkip(attempt.skip);
+        } else {
+          state.downloaded++;
+        }
+        this.updateProgress(
+          state.downloaded,
+          targetLimit,
+          `已下载 ${itemType === 'illustration' ? '插画' : '小说'} ${item.id} (${state.downloaded}/${targetLimit})`
+        );
+        if (itemType === 'novel' && state.downloaded > 0) {
+          logger.info(`Successfully downloaded novel ${item.id} (${state.downloaded}/${targetLimit})`);
+        }
+      },
+      onProgress: (done: number, total: number) => {
+        const msgBase = itemType === 'illustration' ? '插画' : '小说';
+        this.updateProgress(
+          Math.min(state.downloaded, targetLimit),
+          targetLimit,
+          `进行中(${done}/${total}) - 已下载 ${msgBase}: ${state.downloaded}`
+        );
+      },
+      onDecision: (decision: RecoveryDecision, info: { item: T; error: unknown }) => {
+        const typedItem = info.item as DownloadItem;
+        this.logRecoveryDecision(decision, info.error, typedItem.id, itemType, typedItem.title);
+        if (decision.action === 'skip') {
+          const message = getErrorMessage(info.error) || decision.reason || 'download failed';
+          recordCandidateFailure(
+            info.error === undefined || info.error === null ? new Error(message) : info.error,
+            String(typedItem.id)
+          );
+        }
+      },
+    };
 
     if (plan.mode === 'random') {
-      await this.executeRandomMode(plan, targetLimit, planAvailableCount, itemType, tagForLog, downloadFn, retryAttempts, concurrency, state);
-    } else {
-      await this.executeSequentialMode(plan, targetLimit, itemType, tagForLog, downloadFn, retryAttempts, concurrency, state);
+      if (planAvailableCount === 0) {
+        logger.info('All search results have already been downloaded');
+      } else if (plan.queue.length > 0) {
+        await this.executor.run<T, void>({ ...runOptions, items: plan.queue });
+      }
+    } else if (plan.queue.length > 0) {
+      await this.executor.run<T, void>({ ...runOptions, items: plan.queue });
     }
+
+    logger.info(
+      `Candidate scan ${tagForLog}: attempted ${scan.attempted}/${scan.bound}, produced ${state.downloaded} ` +
+        `${itemType}(s), skipped ${scan.skipped.length}` +
+        `${scan.outages.length > 0 ? `, job-level outage(s): ${scan.outages.join(', ')}` : ''}`
+    );
 
     this.updateProgress(
       state.downloaded,
@@ -95,149 +257,8 @@ export class DownloadPipeline {
       alreadyDownloaded: alreadyDownloadedCount,
       filteredOut: filteredOutCount,
       skipDetails: state.skipDetails,
+      scan,
     };
-  }
-
-  private async executeRandomMode<T extends DownloadItem>(
-    plan: { queue: T[]; random?: { maxAttempts: number } },
-    targetLimit: number,
-    planAvailableCount: number,
-    itemType: ItemType,
-    tagForLog: string,
-    downloadFn: (item: T, tag: string) => Promise<void>,
-    retryAttempts: number,
-    concurrency: number,
-    state: { downloaded: number; skippedCount: number; skipDetails: { id: string; error: string }[] }
-  ): Promise<void> {
-    const candidates = plan.queue;
-    if (planAvailableCount === 0) {
-      logger.info('All search results have already been downloaded');
-      return;
-    }
-
-    if (candidates.length === 0) {
-      return;
-    }
-
-    const selectionLimit = plan.random?.maxAttempts ?? candidates.length;
-    let attemptCounter = 0;
-    let completedForProgress = 0;
-    const totalPlanned = Math.min(candidates.length, targetLimit);
-
-    await this.executor.run<T, void>({
-      items: candidates,
-      concurrency,
-      maxAttempts: retryAttempts,
-      recovery: this.recovery,
-      contextProvider: () => ({ itemType }),
-      task: async (item) => {
-        if (state.downloaded >= targetLimit || this.isRunCancelled()) {
-          return;
-        }
-
-        const attempt = ++attemptCounter;
-        const remaining = Math.max(0, candidates.length - attempt + 1);
-        const typeLabel = itemType === 'illustration' ? 'Illustration' : 'Novel';
-        logger.info(
-          `Randomly selected ${typeLabel.toLowerCase()} ${item.id} from ${remaining} remaining result(s) (attempt ${attempt}/${selectionLimit})`
-        );
-
-        await downloadFn(item, tagForLog);
-        state.downloaded++;
-        this.updateProgress(
-          state.downloaded,
-          targetLimit,
-          `已下载 ${itemType === 'illustration' ? '插画' : '小说'} ${item.id} (${state.downloaded}/${targetLimit})`
-        );
-        if (itemType === 'novel') {
-          logger.info(`Successfully downloaded novel ${item.id} (${state.downloaded}/${targetLimit})`);
-        }
-      },
-      onProgress: (done, total) => {
-        completedForProgress = done;
-        const msgBase = itemType === 'illustration' ? '插画' : '小说';
-        this.updateProgress(
-          Math.min(state.downloaded, targetLimit),
-          targetLimit,
-          `随机模式进行中(${completedForProgress}/${total}) - 已下载 ${msgBase}: ${state.downloaded}`
-        );
-      },
-      onDecision: (decision, { item, error }) => {
-        const typedItem = item as DownloadItem;
-        this.logRecoveryDecision(decision, error, typedItem.id, itemType, typedItem.title);
-        if (decision.action === 'skip') {
-          state.skippedCount++;
-          const detail = getErrorMessage(error) || decision.reason || 'download failed';
-          if (state.skipDetails.length < 3 && !state.skipDetails.some((d) => d.id === String(typedItem.id))) {
-            state.skipDetails.push({ id: String(typedItem.id), error: detail });
-          }
-        }
-      },
-    });
-
-    if (totalPlanned < targetLimit && state.downloaded < targetLimit) {
-      logger.info(
-        `Random mode ended after ${totalPlanned} attempt(s); downloaded ${state.downloaded}/${targetLimit} ${itemType}(s)`
-      );
-    }
-  }
-
-  private async executeSequentialMode<T extends DownloadItem>(
-    plan: { queue: T[] },
-    targetLimit: number,
-    itemType: ItemType,
-    tagForLog: string,
-    downloadFn: (item: T, tag: string) => Promise<void>,
-    retryAttempts: number,
-    concurrency: number,
-    state: { downloaded: number; skippedCount: number; skipDetails: { id: string; error: string }[] }
-  ): Promise<void> {
-    const toProcess = plan.queue;
-    const totalPlanned = toProcess.length;
-    let completedForProgress = 0;
-
-    await this.executor.run<T, void>({
-      items: toProcess,
-      concurrency,
-      maxAttempts: retryAttempts,
-      recovery: this.recovery,
-      contextProvider: () => ({ itemType }),
-      task: async (item) => {
-        if (state.downloaded >= targetLimit || this.isRunCancelled()) {
-          return;
-        }
-        await downloadFn(item, tagForLog);
-        state.downloaded++;
-        this.updateProgress(
-          state.downloaded,
-          targetLimit,
-          `已下载 ${itemType === 'illustration' ? '插画' : '小说'} ${item.id} (${state.downloaded}/${targetLimit})`
-        );
-        if (itemType === 'novel') {
-          logger.info(`Successfully downloaded novel ${item.id} (${state.downloaded}/${targetLimit})`);
-        }
-      },
-      onProgress: (done, total) => {
-        completedForProgress = done;
-        const msgBase = itemType === 'illustration' ? '插画' : '小说';
-        this.updateProgress(
-          Math.min(state.downloaded, targetLimit),
-          targetLimit,
-          `进行中(${completedForProgress}/${totalPlanned}) - 已下载 ${msgBase}: ${state.downloaded}`
-        );
-      },
-      onDecision: (decision, { item, error }) => {
-        const typedItem = item as DownloadItem;
-        this.logRecoveryDecision(decision, error, typedItem.id, itemType, typedItem.title);
-        if (decision.action === 'skip') {
-          state.skippedCount++;
-          const detail = getErrorMessage(error) || decision.reason || 'download failed';
-          if (state.skipDetails.length < 3 && !state.skipDetails.some((d) => d.id === String(typedItem.id))) {
-            state.skipDetails.push({ id: String(typedItem.id), error: detail });
-          }
-        }
-      },
-    });
   }
 
   private updateProgress(current: number, total: number, message?: string) {

--- a/src/download/plan/DownloadPlanner.ts
+++ b/src/download/plan/DownloadPlanner.ts
@@ -4,6 +4,7 @@ import { parseDateRange, isDateInRange } from '../../utils/date-utils';
 import { isAIIllustration } from '../../utils/ai-detection';
 import { logger } from '../../logger';
 import type { IDatabase } from '../../interfaces/IDatabase';
+import type { CandidateSkip } from '../../scheduler/TargetOutcome';
 
 export type DownloadItem = PixivIllust | PixivNovel;
 
@@ -17,14 +18,52 @@ export interface PlannedDownload<T extends DownloadItem> {
   queue: T[];
   mode: 'sequential' | 'random';
   limit: number;
+  /**
+   * Maximum candidates this plan may ATTEMPT. Always `queue.length`, so the
+   * bound is enforced structurally: the pipeline cannot scan further than the
+   * window it was handed. Reported in the terminal outcome as "scanning N".
+   */
+  scanBound: number;
   filteredOut: number;
   deduplicated: number;
   alreadyDownloaded: number;
   availableCount: number;
   originalCount: number;
+  /**
+   * Candidates the planner itself dropped BEFORE the download attempt —
+   * already in download history, already CONFIRMED delivered to this target, or
+   * already handled per durable history. They are skips, not failures, and are
+   * reported in the terminal outcome so "skipping Y candidates" includes the
+   * ones that never had to be downloaded.
+   */
+  prefiltered: CandidateSkip[];
   random?: {
     maxAttempts: number;
   };
+}
+
+/**
+ * Default candidate-scan window. Five candidates is enough to survive a few
+ * already-delivered works on a ranking page without turning one slot into a
+ * long crawl; the operator can raise it per target or globally.
+ */
+export const DEFAULT_CANDIDATE_SCAN_LIMIT = 5;
+
+/** Hard ceiling on the scan so a misconfigured value cannot become a crawl. */
+export const MAX_CANDIDATE_SCAN_LIMIT = 100;
+
+/**
+ * Resolve the candidate-scan bound for one target: per-target override, then
+ * the global `download.candidateScanLimit`, then the default. Clamped so a bad
+ * value degrades to a working bound instead of disabling the bound.
+ */
+export function resolveCandidateScanLimit(
+  target: TargetConfig,
+  fallback?: number
+): number {
+  const configured = target.candidateScanLimit ?? fallback ?? DEFAULT_CANDIDATE_SCAN_LIMIT;
+  if (!Number.isFinite(configured)) return DEFAULT_CANDIDATE_SCAN_LIMIT;
+  return Math.min(Math.max(Math.trunc(configured), 1), MAX_CANDIDATE_SCAN_LIMIT);
 }
 
 /**
@@ -33,6 +72,13 @@ export interface PlannedDownload<T extends DownloadItem> {
 export interface DeliveryDedupeSource {
   /** Returns the subset of ids already CONFIRMED delivered to this target. */
   deliveredIds?(deliveryTarget: string, workType: 'illustration' | 'novel', ids: string[]): Set<string>;
+  /**
+   * Returns the subset of ids already SUBMITTED for this target — delivered OR
+   * still awaiting a review answer. Candidate selection prefers this over
+   * `deliveredIds`: a work whose review submission is pending is already in the
+   * human queue, so selecting it again would submit it twice.
+   */
+  submittedIds?(deliveryTarget: string, workType: 'illustration' | 'novel', ids: string[]): Set<string>;
   /**
    * Works this bot has already handled ANYWHERE — durable history owned by a
    * control plane, supplied by the caller.
@@ -48,7 +94,12 @@ export interface DeliveryDedupeSource {
 export class DownloadPlanner {
   constructor(
     private readonly database: IDatabase,
-    private readonly deliveryDedupe?: DeliveryDedupeSource
+    private readonly deliveryDedupe?: DeliveryDedupeSource,
+    /**
+     * Global candidate-scan bound (`download.candidateScanLimit`). A per-target
+     * `candidateScanLimit` overrides it.
+     */
+    private readonly defaultCandidateScanLimit?: number
   ) {}
 
   planDownloads<T extends DownloadItem>(
@@ -58,35 +109,71 @@ export class DownloadPlanner {
   ): PlannedDownload<T> {
     const filtered = this.filterItems(items, target, itemType);
     const { items: deduplicatedItems, removed } = this.deduplicate(filtered.items);
+    /**
+     * Candidates dropped before any download attempt. Reported as explicit
+     * skips so the terminal outcome can say "skipping Y candidates" instead of
+     * claiming a run produced nothing for no stated reason.
+     */
+    const prefiltered: CandidateSkip[] = [];
+    const ruleFiltered = new Set(deduplicatedItems.map((item) => String(item.id)));
+    for (const item of items) {
+      const id = String(item.id);
+      if (!ruleFiltered.has(id)) {
+        // Excluded by the target's own rules (bookmarks/date/AI) — or a
+        // repeated id inside the page. Both are candidate-level skips.
+        prefiltered.push({ code: 'filtered', workId: id, reason: 'excluded by target filters (bookmarks/date/AI)' });
+      }
+    }
 
     const itemIds = deduplicatedItems.map((item) => String(item.id));
     const downloadedIds =
       itemIds.length > 0 ? this.database.getDownloadedIds(itemIds, itemType) : new Set<string>();
     let available = deduplicatedItems.filter((item) => !downloadedIds.has(String(item.id)));
     const alreadyDownloadedCount = deduplicatedItems.length - available.length;
+    for (const item of deduplicatedItems) {
+      const id = String(item.id);
+      if (downloadedIds.has(id)) {
+        prefiltered.push({ code: 'duplicate', workId: id, reason: 'already in download history' });
+      }
+    }
 
     // DELIVERY dedupe (pre-lock, distinct from download dedupe): skip works
-    // already CONFIRMED delivered to THIS target so ranking falls through to
-    // the next valid candidate instead of selecting a historical duplicate.
+    // already SUBMITTED for THIS target — confirmed delivered, or still awaiting
+    // a review answer — so ranking falls through to the next valid candidate
+    // instead of selecting a historical duplicate. `submittedIds` is preferred
+    // because a pending review submission is already in the human queue.
     // Best-effort only: downstream reconciliation remains the final safety net.
     const deliveryTarget = target.delivery?.target?.trim();
+    const submittedQuery =
+      this.deliveryDedupe?.submittedIds ?? this.deliveryDedupe?.deliveredIds;
     let deliveryDuplicateCount = 0;
     if (
       deliveryTarget &&
-      this.deliveryDedupe?.deliveredIds &&
+      submittedQuery &&
       typeof (this.database as { deliveries?: unknown }).deliveries === 'object'
     ) {
       try {
-        const delivered = this.deliveryDedupe.deliveredIds(
+        const taken = submittedQuery.call(
+          this.deliveryDedupe,
           deliveryTarget,
           itemType,
           available.map((item) => String(item.id))
         );
         const before = available.length;
-        available = available.filter((item) => !delivered.has(String(item.id)));
+        for (const item of available) {
+          const id = String(item.id);
+          if (taken.has(id)) {
+            prefiltered.push({
+              code: 'duplicate',
+              workId: id,
+              reason: `already submitted to ${deliveryTarget} (delivery ledger)`,
+            });
+          }
+        }
+        available = available.filter((item) => !taken.has(String(item.id)));
         deliveryDuplicateCount = before - available.length;
         if (deliveryDuplicateCount > 0) {
-          logger.info(`Delivery dedupe skipped ${deliveryDuplicateCount} already-delivered ${itemType}(s) for ${deliveryTarget}`);
+          logger.info(`Delivery dedupe skipped ${deliveryDuplicateCount} already-submitted ${itemType}(s) for ${deliveryTarget}`);
         }
       } catch (error) {
         logger.warn('Delivery dedupe preflight failed; continuing (downstream net remains)', {
@@ -102,6 +189,12 @@ export class DownloadPlanner {
       try {
         const processed = processedSource(itemType, available.map((item) => String(item.id)));
         const before = available.length;
+        for (const item of available) {
+          const id = String(item.id);
+          if (processed.has(id)) {
+            prefiltered.push({ code: 'duplicate', workId: id, reason: 'already handled (durable history)' });
+          }
+        }
         available = available.filter((item) => !processed.has(String(item.id)));
         const skipped = before - available.length;
         if (skipped > 0) {
@@ -115,43 +208,68 @@ export class DownloadPlanner {
     }
 
     const limit = target.limit && target.limit > 0 ? target.limit : 10;
+    // How many candidates this run may ATTEMPT. Distinct from `limit`, which is
+    // how many it may PRODUCE. A scheduled one-post-per-slot target has
+    // `limit: 1`, so keying the candidate window off `limit` alone handed the
+    // pipeline exactly one candidate: the first duplicate ended the slot with
+    // nothing submitted. Never below `limit`, so a multi-work target can still
+    // fill its own limit.
+    const scanBound = Math.max(limit, resolveCandidateScanLimit(target, this.defaultCandidateScanLimit));
 
     if (target.random) {
       const shuffled = this.shuffle(available);
-      const maxAttempts = Math.min(shuffled.length, 50);
+      // Historical 50-attempt random pool, unless the operator set an explicit
+      // bound — in which case that bound is the contract.
+      const attemptPool = target.candidateScanLimit !== undefined ? scanBound : 50;
+      const maxAttempts = Math.min(shuffled.length, Math.max(limit, attemptPool));
       const queue = shuffled.slice(0, maxAttempts);
       return {
         queue,
         mode: 'random',
         limit,
+        scanBound: queue.length,
         filteredOut: filtered.filteredOut,
         deduplicated: removed,
         alreadyDownloaded: alreadyDownloadedCount,
         availableCount: available.length,
         originalCount: filtered.originalCount,
+        prefiltered,
         random: { maxAttempts },
       };
     }
 
-    // Language is detected from the full novel body during download. Keep a
-    // bounded popularity-ordered retry pool so a non-matching Top-1 candidate
-    // can be skipped and replaced by the next matching novel.
-    const backfillLimit = itemType === 'novel' && target.languageFilter
+    // How many candidates the run may ATTEMPT:
+    //   window = clamp(candidateScanLimit, lower = limit, upper = pool)
+    // where `pool` is what the operator asked to consider — the whole page for a
+    // plain search/ranking target, and a deliberately deeper pool for full-text
+    // novel language filtering or topic discovery. `candidateScanLimit` is the
+    // hard cap; it is never exceeded, and it is never allowed below `limit`
+    // because a multi-work target must still be able to fill its own limit.
+    const pool = itemType === 'novel' && target.languageFilter
       ? Math.max(limit, Math.min(target.languageCandidateLimit ?? 20, 100))
       : target.mode === 'topic'
         ? Math.max(limit, 20)
-        : limit;
-    const queue = available.slice(0, Math.min(available.length, backfillLimit));
+        : available.length;
+    const windowSize = Math.max(limit, Math.min(pool, scanBound));
+    const queue = available.slice(0, Math.min(available.length, windowSize));
+    if (queue.length > limit) {
+      logger.info(
+        `Candidate scan window: up to ${queue.length} candidate(s) to fill ${limit} slot(s) ` +
+          `(bound ${scanBound}, pool ${pool}, ${available.length} available)`
+      );
+    }
 
     return {
       queue,
       mode: 'sequential',
       limit,
+      scanBound: queue.length,
       filteredOut: filtered.filteredOut,
       deduplicated: removed,
       alreadyDownloaded: alreadyDownloadedCount,
       availableCount: available.length,
       originalCount: filtered.originalCount,
+      prefiltered,
     };
   }
 

--- a/src/scheduler/TargetOutcome.ts
+++ b/src/scheduler/TargetOutcome.ts
@@ -5,8 +5,123 @@
  * submitted". Undefined / a 2xx HTTP response / a caught-and-swallowed error
  * must NEVER be inferred as a successful submission. Every target produces one
  * of these explicit outcomes; the Slot ledger maps it to a cell transition.
+ *
+ * The vocabulary has TWO levels, and conflating them is what let a duplicate
+ * candidate end a scheduled slot as "successful":
+ *
+ *  - CANDIDATE level (`CandidateSkip`): this ONE candidate work was unusable —
+ *    already delivered, deleted, private, wrong media, wrong language. A
+ *    candidate problem is never a job verdict: the scan advances to the next
+ *    candidate.
+ *  - TARGET level (`TargetOutcome`, below): the verdict for the whole logical
+ *    item after its bounded candidate scan, including the scan bookkeeping so
+ *    "completed with nothing done" is impossible to report silently.
  */
 export type WorkType = 'illustration' | 'novel';
+
+/**
+ * Why ONE candidate work was skipped without producing a business result.
+ *
+ * Codes are deliberately outcome-shaped, not error-shaped: they say what the
+ * run should DO (try the next candidate), not which exception was raised.
+ */
+export type CandidateSkipCode =
+  /** Already delivered / already pending review for this target, or a lost
+   *  idempotency race against a concurrent worker. Try the next candidate. */
+  | 'duplicate'
+  /** Gone: 404, deleted work, removed account. Permanent for this candidate. */
+  | 'deleted'
+  /** Private / R-18 without permission / 403 on THIS work. */
+  | 'access_denied'
+  /** Ugoira or novel form this build cannot process. */
+  | 'unsupported_media'
+  /** Missing or malformed metadata: no id, no pages, no image urls. */
+  | 'invalid_metadata'
+  /**
+   * The attempt failed for a reason that is NOT a fact about the work: timeout,
+   * connection reset, rate limit, 5xx, or an unclassifiable error. `retryable`
+   * is set, which means the candidate is handed back to the existing
+   * retry/backoff instead of being silently skipped — and a scan in which EVERY
+   * attempted candidate was transient is a JOB failure, not an empty candidate
+   * list.
+   */
+  | 'unavailable'
+  /**
+   * Not usable for THIS run by the run's own rules: full-text language filter,
+   * over maxPageCount, AI-metadata check, or a candidate the downloader
+   * deliberately declined. Move on to the next candidate.
+   */
+  | 'filtered';
+
+export interface CandidateSkip {
+  code: CandidateSkipCode;
+  workId: string;
+  reason: string;
+  /**
+   * True when the cause is transient infrastructure rather than this work.
+   * One such candidate still means "try the next"; EVERY attempted candidate
+   * being retryable means the infrastructure — not the candidate list — is the
+   * problem, and the target must fail/retry instead of reporting "no eligible
+   * candidate".
+   */
+  retryable?: boolean;
+}
+
+/**
+ * Infrastructure failure scoped to the WHOLE job, never to one candidate. These
+ * must abort/fail/retry the job; they must never be swallowed as "skip and try
+ * the next candidate" (that is the failure mode that burned scheduled slots).
+ */
+export type JobLevelOutage =
+  | 'database_unavailable'
+  | 'pixiv_auth_failure'
+  | 'delivery_unavailable'
+  | 'network_outage';
+
+/**
+ * What one failed candidate ATTEMPT means. `candidate` => the scan advances.
+ * `job` => the scan must not be allowed to degrade the run into an empty
+ * candidate list.
+ */
+export type CandidateFailure =
+  | { scope: 'candidate'; skip: CandidateSkip }
+  | { scope: 'job'; outage: JobLevelOutage; error: string };
+
+/** What happened to ONE candidate work during a target's bounded scan. */
+export type CandidateAttempt =
+  /** The candidate produced the target's business result (or a delivery intent). */
+  | { kind: 'selected'; workId: string; workType: WorkType }
+  /** The candidate was unusable; the scan continues with the next one. */
+  | { kind: 'skipped'; skip: CandidateSkip };
+
+/**
+ * Bookkeeping for a target's bounded candidate scan. Attached to the terminal
+ * target outcome so the run can state exactly one of:
+ *
+ *   "submitted candidate X after skipping Y candidate(s)"
+ *   "no eligible candidate found after scanning N"
+ *
+ * `bound` is the configured cap (never exceeded), `attempted` the real count.
+ */
+export interface CandidateScanSummary {
+  /** Configured cap on candidates this scan was allowed to attempt. */
+  bound: number;
+  /** Candidates actually attempted. Always <= bound. */
+  attempted: number;
+  /** Candidates skipped before the scan ended, in scan order. */
+  skipped: CandidateSkip[];
+  /** Job-level outages observed while scanning (never a candidate verdict). */
+  outages: JobLevelOutage[];
+}
+
+/**
+ * A scan that attempted nothing. The real pipeline always reports its own scan;
+ * this is for callers/tests that have no candidate-level information, so they
+ * cannot fabricate a verdict they did not observe.
+ */
+export function emptyCandidateScan(): CandidateScanSummary {
+  return { bound: 0, attempted: 0, skipped: [], outages: [] };
+}
 
 export type TargetOutcome =
   | {
@@ -15,6 +130,8 @@ export type TargetOutcome =
       workType: WorkType;
       /** Durable delivery row that recorded the downstream ACK. */
       deliveryId?: string;
+      /** Which candidates were skipped to reach this one. */
+      scan?: CandidateScanSummary;
     }
   /**
    * The work was processed locally but there is no downstream delivery target
@@ -22,23 +139,35 @@ export type TargetOutcome =
    * is a business success for that target, but it is NEVER confused with a
    * confirmed remote submission.
    */
-  | { kind: 'stored'; workId: string; workType: WorkType }
+  | { kind: 'stored'; workId: string; workType: WorkType; scan?: CandidateScanSummary }
   /**
    * A delivery intent + outbox item were created durably, but the downstream
    * ACK has not been confirmed yet. The OutboxWorker drives this to
    * 'submitted'; a crash/restart resumes it. delivery_pending != submitted.
    */
-  | { kind: 'delivery_pending'; workId: string; workType: WorkType; deliveryId: string }
-  /** No work matched after the full candidate pipeline (filter/topic/lookback). */
-  | { kind: 'no_candidate'; reason: string }
+  | {
+      kind: 'delivery_pending';
+      workId: string;
+      workType: WorkType;
+      deliveryId: string;
+      scan?: CandidateScanSummary;
+    }
+  /**
+   * The bounded scan found no ELIGIBLE candidate: every attempted candidate was
+   * skipped for a candidate-level reason (duplicate / deleted / denied / ...).
+   * A clean no-op, not a failure and not a retry loop.
+   */
+  | { kind: 'no_candidate'; reason: string; scan?: CandidateScanSummary }
   /**
    * Downstream proved this work was already delivered by a DIFFERENT intent
    * (historical drift). This is a terminal business duplicate, not a new
-   * submission. Produced only by the explicit reconciliation path.
+   * submission. Produced only by the explicit reconciliation path
+   * (`settleDeliveryTerminal`) or by a single-work cell RESUME whose locked work
+   * turns out to be already delivered — NEVER as the verdict of a candidate scan.
    */
-  | { kind: 'duplicate'; workId: string; reason: string }
+  | { kind: 'duplicate'; workId: string; reason: string; scan?: CandidateScanSummary }
   /** The target failed. retryable=true => a later trigger/outbox may resume. */
-  | { kind: 'failed'; retryable: boolean; error: string };
+  | { kind: 'failed'; retryable: boolean; error: string; scan?: CandidateScanSummary };
 
 /** Terminal outcomes settle the cell; others leave it recoverable. */
 export function isTerminalOutcome(outcome: TargetOutcome): boolean {
@@ -51,18 +180,222 @@ export function isTerminalOutcome(outcome: TargetOutcome): boolean {
   );
 }
 
+/** True when the scan ended on a candidate it may actually submit. */
+export function isSelectedAttempt(attempt: CandidateAttempt | void): attempt is {
+  kind: 'selected';
+  workId: string;
+  workType: WorkType;
+} {
+  return attempt?.kind === 'selected';
+}
+
+/**
+ * True when this candidate failure means "move on to the next candidate"
+ * WITHOUT retrying this one — the cause is a fact about the work (deleted,
+ * private, wrong media/format, filtered by rules, already submitted).
+ *
+ * Transient infrastructure failures return FALSE on purpose: the existing
+ * retry/backoff semantics own those, because retrying the same work is what
+ * this repo does, and churning through a whole ranking page while the network
+ * is down would be worse than failing the target once.
+ */
+export function skipCandidateWithoutRetry(skip: CandidateSkip): boolean {
+  return skip.retryable !== true;
+}
+
+/**
+ * The explicit, human-readable verdict of a target. Requirement: a run must
+ * report one of "submitted candidate X after skipping Y candidates" or "no
+ * eligible candidate found after scanning N" — never a bare "completed".
+ */
 export function outcomeSummary(outcome: TargetOutcome): string {
   switch (outcome.kind) {
     case 'submitted':
     case 'stored':
-      return outcome.kind;
+      return outcome.scan
+        ? `submitted candidate ${outcome.workId} (${outcome.workType}) after skipping ` +
+            `${outcome.scan.skipped.length} candidate(s)${skipDetail(outcome.scan)}`
+        : `${outcome.kind} ${outcome.workId}`;
     case 'delivery_pending':
-      return 'delivery_pending';
+      return outcome.scan
+        ? `submitted candidate ${outcome.workId} (${outcome.workType}) for review after skipping ` +
+            `${outcome.scan.skipped.length} candidate(s)${skipDetail(outcome.scan)}`
+        : `delivery_pending ${outcome.workId}`;
     case 'no_candidate':
-      return `no_candidate: ${outcome.reason}`;
+      return outcome.scan
+        ? noEligibleCandidateText(outcome.scan)
+        : `no_candidate: ${outcome.reason}`;
     case 'duplicate':
       return `duplicate: ${outcome.reason}`;
     case 'failed':
       return `failed(${outcome.retryable ? 'retryable' : 'permanent'}): ${outcome.error}`;
   }
+}
+
+/**
+ * `no eligible candidate found after scanning N` (+ what was skipped).
+ *
+ * Candidates dropped before any download attempt (already submitted / already
+ * in history) are counted separately from the ones actually attempted, because
+ * "scanned 0" with three duplicates is a very different statement from
+ * "scanned 3, all unusable" — and the operator needs to be able to tell them
+ * apart.
+ */
+export function noEligibleCandidateText(scan: CandidateScanSummary): string {
+  const scanned = scan.attempted;
+  if (scan.skipped.length === 0) {
+    return `no eligible candidate found after scanning ${scanned}`;
+  }
+  const codes = [...new Set(scan.skipped.map((s) => s.code))].join(', ');
+  const prefiltered = Math.max(0, scan.skipped.length - scanned);
+  const detail =
+    prefiltered > 0
+      ? ` (bound ${scan.bound}); all ${scan.skipped.length} candidate(s) unusable ` +
+        `[${prefiltered} filtered before download, ${scanned} attempted]: ${codes}`
+      : ` (bound ${scan.bound}); all ${scan.skipped.length} attempted candidate(s) skipped: ${codes}`;
+  return `no eligible candidate found after scanning ${scanned}${detail}${skipDetail(scan)}`;
+}
+
+function skipDetail(scan: CandidateScanSummary): string {
+  if (scan.skipped.length === 0) return '';
+  const sample = scan.skipped
+    .slice(0, 3)
+    .map((s) => `${s.code}(${s.workId})`)
+    .join(', ');
+  return ` [${sample}${scan.skipped.length > 3 ? `, +${scan.skipped.length - 3} more` : ''}]`;
+}
+
+/**
+ * True when the scan saw a transient infrastructure failure, or ANY attempted
+ * candidate failed transiently. Such a scan says "the network/API is flaky",
+ * NOT "no eligible candidate", so the caller must fail/retry the target instead
+ * of reporting a clean empty scan.
+ */
+export function hasTransientFailure(scan: CandidateScanSummary): boolean {
+  if (scan.outages.length > 0) return true;
+  return scan.skipped.some((skip) => skip.retryable === true);
+}
+
+/**
+ * Fold two scans of the same logical target into one, so a multi-page or
+ * lookback scan reports the whole picture rather than only its last page.
+ * `bound` is the sum of the windows actually offered (each page is bounded
+ * independently), which keeps `attempted <= bound` true.
+ */
+export function mergeScanSummaries(
+  first: CandidateScanSummary | null,
+  second: CandidateScanSummary
+): CandidateScanSummary {
+  if (!first) return second;
+  return {
+    bound: first.bound + second.bound,
+    attempted: first.attempted + second.attempted,
+    skipped: [...first.skipped, ...second.skipped],
+    outages: [...new Set([...first.outages, ...second.outages])],
+  };
+}
+
+const SQLITE_OUTAGE = /sqlite|database (?:is )?locked|unable to open database|no such table|disk i\/o error/i;
+/** A delivery-provider OUTAGE — not a per-message rejection such as a too-long caption. */
+const DELIVERY_OUTAGE =
+  /(?:telegram|delivery (?:target|provider))[^.]{0,80}\b(?:unavailable|unreachable|down|not configured|timed? ?out|econn\w*|etimedout|enotfound|401|403|50[234])\b|api\.telegram\.org[^.]*\b(?:econn\w*|etimedout|enotfound|50[234])\b/i;
+const AUTH_OUTAGE = /\b(401|unauthorized|invalid_grant|invalid refresh token|authentication failed)\b/i;
+const NETWORK_OUTAGE =
+  /econnrefused|econnreset|enotfound|etimedout|ehostunreach|enetunreach|socket hang up|network is unreachable|getaddrinfo/i;
+const RATE_LIMIT = /\b429\b|rate limit/i;
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function statusOf(error: unknown): number | undefined {
+  const status = (error as { status?: unknown; statusCode?: unknown })?.status ??
+    (error as { statusCode?: unknown })?.statusCode;
+  return typeof status === 'number' ? status : undefined;
+}
+
+/**
+ * Decide what a failed candidate ATTEMPT means.
+ *
+ * This is the boundary the previous design got wrong: a duplicate was treated
+ * as a completed job. The order below is what makes the distinction real —
+ * a dead database, a dead token, a dead delivery provider or a dead network is
+ * a JOB problem and is classified as such before any candidate-level pattern
+ * can claim it.
+ */
+export function classifyCandidateFailure(error: unknown, workId: string): CandidateFailure {
+  const message = messageOf(error);
+  const status = statusOf(error);
+  const name = error instanceof Error ? error.name : '';
+  const code = (error as { code?: unknown })?.code;
+  const codeText = typeof code === 'string' ? code : '';
+
+  // --- Job-level first: these must never shrink to "empty candidate list" ---
+  if (name === 'DatabaseError' || codeText.startsWith('SQLITE_') || SQLITE_OUTAGE.test(message)) {
+    return { scope: 'job', outage: 'database_unavailable', error: message };
+  }
+  if (name === 'AuthenticationError' || status === 401 || AUTH_OUTAGE.test(message)) {
+    return { scope: 'job', outage: 'pixiv_auth_failure', error: message };
+  }
+  // The delivery provider being unreachable says nothing about the candidate:
+  // every candidate would "fail" identically, so this must never be counted as
+  // an empty candidate list.
+  if (DELIVERY_OUTAGE.test(message) && !/already delivered|already published|duplicate/i.test(message)) {
+    return { scope: 'job', outage: 'delivery_unavailable', error: message };
+  }
+  if (status === 502 || status === 503 || status === 504) {
+    // The remote provider itself is down, not this work.
+    return { scope: 'job', outage: 'network_outage', error: message };
+  }
+  if (NETWORK_OUTAGE.test(message)) {
+    return {
+      scope: 'candidate',
+      skip: { code: 'unavailable', workId, reason: message, retryable: true },
+    };
+  }
+
+  // --- Candidate-level: this ONE work is unusable, try the next one ---------
+  if (/already delivered|already processed|already published|idempotent_replay/i.test(message)) {
+    return {
+      scope: 'candidate',
+      skip: { code: 'duplicate', workId, reason: message },
+    };
+  }
+  if (name === 'PixivNotFoundError' || status === 404 || /\b404\b|not found|deleted/i.test(message)) {
+    return { scope: 'candidate', skip: { code: 'deleted', workId, reason: message } };
+  }
+  if (name === 'PixivRateLimitError' || RATE_LIMIT.test(message)) {
+    return {
+      scope: 'candidate',
+      skip: { code: 'unavailable', workId, reason: message, retryable: true },
+    };
+  }
+  if (status === 403 || /forbidden|private|access denied|permission/i.test(message)) {
+    return { scope: 'candidate', skip: { code: 'access_denied', workId, reason: message } };
+  }
+  if (/ugoira|unsupported (?:media|type|format)|cannot (?:process|handle)/i.test(message)) {
+    return { scope: 'candidate', skip: { code: 'unsupported_media', workId, reason: message } };
+  }
+  if (/language filter|filtered out|excluded (?:by|from)/i.test(message)) {
+    return { scope: 'candidate', skip: { code: 'filtered', workId, reason: message } };
+  }
+  if (/invalid (?:metadata|id|illustId|novelId)|missing (?:metadata|page|image)|no files produced/i.test(message)) {
+    return { scope: 'candidate', skip: { code: 'invalid_metadata', workId, reason: message } };
+  }
+
+  // Unclassifiable: treat as a transient candidate problem (retryable) so an
+  // all-unknown scan fails the job rather than silently reporting an empty scan.
+  return {
+    scope: 'candidate',
+    skip: { code: 'unavailable', workId, reason: message, retryable: true },
+  };
+}
+
+/** Hard job-level outage for a directly-thrown error, or null. */
+export function classifyJobLevelOutage(error: unknown): JobLevelOutage | null {
+  const failure = classifyCandidateFailure(error, '');
+  return failure.scope === 'job' ? failure.outage : null;
 }

--- a/src/scheduler/TargetOutcome.ts
+++ b/src/scheduler/TargetOutcome.ts
@@ -104,11 +104,19 @@ export type CandidateAttempt =
  * `bound` is the configured cap (never exceeded), `attempted` the real count.
  */
 export interface CandidateScanSummary {
-  /** Configured cap on candidates this scan was allowed to attempt. */
+  /**
+   * Cap on candidates this scan was allowed to attempt: the effective window,
+   * never above the configured `candidateScanLimit` unless the target's own
+   * `limit` is larger (a multi-work target must be able to fill its limit).
+   */
   bound: number;
   /** Candidates actually attempted. Always <= bound. */
   attempted: number;
-  /** Candidates skipped before the scan ended, in scan order. */
+  /**
+   * Candidates skipped before the scan ended, in the order they were skipped —
+   * strictly candidate order whenever the scan is serial, which is always the
+   * case for a single-work cell.
+   */
   skipped: CandidateSkip[];
   /** Job-level outages observed while scanning (never a candidate verdict). */
   outages: JobLevelOutage[];

--- a/src/storage/repositories/DeliveryRepository.ts
+++ b/src/storage/repositories/DeliveryRepository.ts
@@ -111,8 +111,32 @@ export class DeliveryRepository extends BaseRepository {
 
   /** Batch form for candidate-pipeline pre-lock dedupe. */
   deliveredIds(deliveryTarget: string, workType: string, pixivIds: string[]): Set<string> {
+    return this.idsByStatus(deliveryTarget, workType, pixivIds, ['delivered', 'duplicate']);
+  }
+
+  /**
+   * Batch pre-lock dedupe for CANDIDATE SELECTION: works already delivered, or
+   * whose review submission is still PENDING.
+   *
+   * Deliberately broader than `deliveredIds`: a pending intent is a work already
+   * submitted for human review that has not been answered yet. Re-selecting it
+   * would submit the same work a second time, which is the user-visible defect
+   * this scan exists to prevent. Within-slot RESUME keeps using `isDelivered`:
+   * a cell resuming its OWN pending work is continuing it, not duplicating it.
+   */
+  submittedIds(deliveryTarget: string, workType: string, pixivIds: string[]): Set<string> {
+    return this.idsByStatus(deliveryTarget, workType, pixivIds, ['pending', 'delivered', 'duplicate']);
+  }
+
+  private idsByStatus(
+    deliveryTarget: string,
+    workType: string,
+    pixivIds: string[],
+    statuses: DeliveryStatus[]
+  ): Set<string> {
     const out = new Set<string>();
     if (pixivIds.length === 0) return out;
+    const statusList = statuses.map((status) => `'${status}'`).join(',');
     const CHUNK = 400;
     for (let i = 0; i < pixivIds.length; i += CHUNK) {
       const slice = pixivIds.slice(i, i + CHUNK);
@@ -120,7 +144,7 @@ export class DeliveryRepository extends BaseRepository {
       const rows = this.db
         .prepare(
           `SELECT DISTINCT pixiv_id FROM deliveries
-           WHERE delivery_target = ? AND work_type = ? AND status IN ('delivered','duplicate')
+           WHERE delivery_target = ? AND work_type = ? AND status IN (${statusList})
              AND pixiv_id IN (${placeholders})`
         )
         .all(deliveryTarget, workType, ...slice) as Array<{ pixiv_id: string }>;


### PR DESCRIPTION
## 症状

计划槽位触发后，抓到第 1 个候选作品 → 发现是重复投稿 → **整个 job 以 success 结束**，
本时段什么都没投出去。用户看到槽位被消耗、审核群却没有任何新投稿。

## 根因：「只取一个候选」被写死在三处

1. **抓取阶段就只要 1 个**：`IllustrationTargetHandler` / `NovelTargetHandler` 调
   `getRankingIllustrationsWithFallback(mode, date, target.limit)` —— 一个
   "每槽位 1 篇" 的 target，`limit` 就是 1，所以 ranking+filterTag 分支也把当日集合
   切到 1 个。**候选列表根本不存在**。
2. **队列被截断成 1 个**：`DownloadPlanner` 里 `available.slice(0, backfillLimit)`，
   而 `backfillLimit === limit`。
3. **没有产生投稿的候选也被计为成功**：`DownloadPipeline` 的
   `await downloadFn(item); state.downloaded++` —— 重复投稿会正常 resolve，
   `downloaded` 照样 +1，扫描于是停止；加上 `TargetOutcome.isTerminalOutcome` 把
   `duplicate` 算作终态、`summarize()` 返回它 → cell/slot/job 全部上报 success。

模型错了：**duplicate 是 candidate rejected，不是 job completed**。

## 新流程

```text
取候选列表（受 candidateScanLimit 约束）
  ↓ 逐个候选：
  duplicate / 已发布 / 已 pending / 已 rejected 且策略禁止 → skip，下一个
  已删除 / 无权限 / 不支持的媒体 / 元数据非法 / 永久不可下载 / 被过滤规则排除 → skip，下一个
  否则 → 校验 → 投稿 → 结束
  ↓
没有合格候选 → 干净的 no-op，并明确上报
```

- **有界扫描**：新增 `download.candidateScanLimit`（默认 5），支持 per-target
  `candidateScanLimit` 与环境变量 `PIXIV_CANDIDATE_SCAN_LIMIT`，clamp 1..100。
  同一个 bound 同时驱动**抓取阶段**（向 ranking API 要多少个），否则候选列表本身
  就只有 1 个，扫描无从谈起。
- **candidate-level 与 job-level 严格区分**：DB 整体不可用、Telegram 整体不可用、
  Pixiv 认证整体失败、网络整体故障 → 记为 `outages`（job 失败/重试），**绝不**伪装成
  「没有合格候选」；其余才是 candidate skip。
- **明确终态**：`CandidateScanSummary { bound, attempted, skipped[], outages }`，
  结果只有两种可读结论：`submitted candidate X after skipping Y` 或
  `no eligible candidate found after scanning N`。
- **并发安全（复用既有机制，不另起炉灶）**：`SlotCoordinator.claimRunLease` +
  `(slotId,targetId)->workId` 的 CAS（`WorkIdentity.release/bind`）+ 投稿幂等键
  （`deliveries.idempotency_key` UNIQUE）。被跳过的候选会释放它的临时 cell 占位，
  让 `bind()` 能赢得下一个候选；已提交的 identity 仍然绝不被换掉。

## 测试

| 命令 | 结果 |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npm run build` | clean |
| `npx jest` | **74/74 suites, 721/721 tests**（原 616；新增 33 个） |

新增 `src/__tests__/scheduler/candidateScan.test.ts`（934 行）覆盖：
候选 1 重复 → 选候选 2；候选 1+2 重复 → 选候选 3；全重复 → 干净 no-op 且有界；
候选不可用/已删除/无权限/不支持/元数据非法 → 下一个；job 级故障（Telegram/DB/Pixiv
认证/网络）→ job 失败而非「无合格候选」；并发两次 → 同一作品只投一次；
扫描遵守 bound N。其中两个核心回归用例被**单独还原每处修改**验证过确实会失败。
